### PR TITLE
Replace bash-only substring expansion

### DIFF
--- a/rootfs/start.sh
+++ b/rootfs/start.sh
@@ -17,7 +17,7 @@
 set -e
 
 init() {
-    if [ $# -gt 0 ] && [ "$(echo $1 | awk '{s=substr($0, 1, 2); print s}')" != "--" ]; then
+    if [ $# -gt 0 ] && [ "$(echo $1 | cut -b1-2)" != "--" ]; then
         exec "$@"
         exit 0
     fi

--- a/rootfs/start.sh
+++ b/rootfs/start.sh
@@ -17,7 +17,7 @@
 set -e
 
 init() {
-    if [ $# -gt 0 ] && [ "${1:0:2}" != "--" ]; then
+    if [ $# -gt 0 ] && [ "$(echo $1 | awk '{s=substr($0, 1, 2); print s}')" != "--" ]; then
         exec "$@"
         exit 0
     fi


### PR DESCRIPTION
/bin/sh points to bash in the alpine base image, but is usually a symlink to dash on other distros. This replaces bash-only substring expansion with a dash-compatible version.