### PR TITLE
verify new configuration is valid before replacing

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,9 +19,9 @@ package controller
 import (
 	"github.com/golang/glog"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/types"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/version"
 	"github.com/spf13/pflag"
-	"io/ioutil"
 	api "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/ingress/core/pkg/ingress"
 	"k8s.io/ingress/core/pkg/ingress/controller"
@@ -137,15 +137,11 @@ func (haproxy *HAProxyController) OnUpdate(cfg ingress.Configuration) error {
 		return err
 	}
 
-	// TODO missing HAProxy validation on native reaload-strategy
-	// before overwrite and try to reload
-	err = ioutil.WriteFile(haproxy.configFile, data, 0644)
+	err = utils.RewriteConfigFiles(data, *haproxy.reloadStrategy, haproxy.configFile)
 	if err != nil {
 		return err
 	}
 
-	// TODO if reload is not required, only a haproxy.cfg.erb will be
-	// updated on mutibinder reload-strategy
 	if !reloadRequired {
 		glog.Infoln("HAProxy updated through socket, reload not required")
 		return nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,7 +19,11 @@ package utils
 import (
 	"github.com/golang/glog"
 	"github.com/mitchellh/mapstructure"
+	"io/ioutil"
 	"net"
+	"os"
+	"os/exec"
+	"strings"
 )
 
 // MergeMap copy keys from a `data` map to a `resultTo` tagged object
@@ -59,5 +63,61 @@ func SendToSocket(socket string, command string) error {
 	if rcvd > 2 {
 		glog.Infof("haproxy stat socket response: \"%s\"", string(readBuffer[:rcvd-2]))
 	}
+	return nil
+}
+
+// checkValidity runs a HAProxy configuration validity check on a file
+func checkValidity(configFile string) error {
+	out, err := exec.Command("haproxy", "-c", "-f", configFile).CombinedOutput()
+	if err != nil {
+		glog.Warningf("Error validating config file:\n%v", string(out))
+		return err
+	}
+	return nil
+}
+
+// multibinderERBOnly generates a config file from ERB template by invoking multibinder-haproxy-erb
+func multibinderERBOnly(configFile string) (string, error) {
+	_, err := exec.Command("multibinder-haproxy-erb", "/usr/local/sbin/haproxy", "-f", configFile, "--erb-write-only").CombinedOutput()
+	if err != nil {
+		return "", err
+	}
+	return configFile[:strings.LastIndex(configFile, ".erb")], nil
+}
+
+// RewriteConfigFiles safely replaces configuration files with new contents after validation
+func RewriteConfigFiles(data []byte, reloadStrategy, configFile string) error {
+	tmpf := "/etc/haproxy/new_cfg.erb"
+
+	err := ioutil.WriteFile(tmpf, data, 644)
+	if err != nil {
+		glog.Warningln("Error writing rendered template to file")
+		return err
+	}
+
+	if reloadStrategy == "multibinder" {
+		unverified, err := multibinderERBOnly(tmpf)
+		if err != nil {
+			glog.Warningln("Error generating file contents from ERB template")
+			return err
+		}
+		// multibinder haproxy configuration file will not pass validation due to file descriptors so it is skipped
+		err = os.Rename(unverified, "/etc/haproxy/haproxy.cfg")
+		if err != nil {
+			glog.Warningln("Error updating config file")
+			return err
+		}
+	} else {
+		err = checkValidity(tmpf)
+		if err != nil {
+			return err
+		}
+	}
+	err = os.Rename(tmpf, configFile)
+	if err != nil {
+		glog.Warningln("Error updating config file")
+		return err
+	}
+
 	return nil
 }

--- a/rootfs/haproxy-reload.sh
+++ b/rootfs/haproxy-reload.sh
@@ -43,7 +43,6 @@ case "$1" in
         HAPROXY=/usr/local/sbin/haproxy
         CONFIG="$2"
         WRAPPER_PID=/var/run/wrapper.pid
-        multibinder-haproxy-erb "$HAPROXY" -f "$CONFIG" -c -q
         kill -USR2 $(cat "$WRAPPER_PID")
         ;;
     *)


### PR DESCRIPTION
This works for native reload strategy. For multibinder reload strategy all configuration files are now kept in sync but validation is not performed as it cannot pass in a standalone haproxy process due to file-descriptor use.

As always, open for discussion.