### PR TITLE
Add use-proxy-protocol option

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -97,6 +97,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		DynamicScaling:              false,
 		BackendServerSlotsIncrement: 32,
 		StatsSocket:                 "/var/run/haproxy-stats.sock",
+		UseProxyProtocol:            false,
 	}
 	if haproxyController.configMap != nil {
 		utils.MergeMap(haproxyController.configMap.Data, &conf)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -67,6 +67,7 @@ type (
 		DynamicScaling              bool   `json:"dynamic-scaling"`
 		BackendServerSlotsIncrement int    `json:"backend-server-slots-increment"`
 		StatsSocket                 string
+		UseProxyProtocol						bool    `json:"use-proxy-protocol"`
 	}
 	// Userlist list of users for basic authentication
 	Userlist struct {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -71,7 +71,7 @@ backend {{ $backend.Name }}
 ###### HTTP frontend
 ######
 frontend httpfront
-    bind *:80
+    bind *:80{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
     mode http
 {{ if ne $cfg.Syslog "" }}
     option httplog
@@ -127,7 +127,7 @@ frontend httpfront
 ###### HTTPS frontend (tcp mode)
 ######
 frontend httpsfront
-    bind *:443
+    bind *:443{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
     mode tcp
     tcp-request inspect-delay 5s
     tcp-request content accept if { req.ssl_hello_type 1 }

--- a/rootfs/start.sh
+++ b/rootfs/start.sh
@@ -59,7 +59,9 @@ listen main
 EOF
 
     # Add erb code to a new template file
-    sed "/^    bind \+\*\?:/s/\*\?:\(.*\)/<%= bind_tcp('0.0.0.0', \1) %>/" \
+    # - [0-9]* will match actual ports, for example 443 in bind *:443
+    # - {{[^}]*}} will match when the port is templatized, for example {{ $cfg.StatsPort }} in bind *:{{ $cfg.StatsPort }}
+    sed "/^    bind \+\*\?:/s/\*\?:\(\([0-9]*\)\|\({{[^}]*}}\)\)/<%= bind_tcp('0.0.0.0', \1) %>/" \
         "$TEMPLATE" > "${CONFIG}.tmpl"
 }
 


### PR DESCRIPTION
This enables external load balancers, e.g. AWS ELBs, to use the proxy protocol on requests to haproxy-ingress.