### PR TITLE
fix reloadRequired potentially not set correctly

### DIFF
--- a/pkg/controller/stats_socket.go
+++ b/pkg/controller/stats_socket.go
@@ -136,7 +136,7 @@ func reconfigureBackends(currentConfig, updatedConfig *types.ControllerConfig) b
 						backendSlots := updatedConfig.BackendSlots[backendName]
 						// remove endpoints
 						for k := range toRemoveEndpoints {
-							reloadRequired = !removeEndpoint(currentConfig.Cfg.StatsSocket, backendName, backendSlots.FullSlots[k].BackendServerName)
+							reloadRequired = reloadRequired || !removeEndpoint(currentConfig.Cfg.StatsSocket, backendName, backendSlots.FullSlots[k].BackendServerName)
 							backendSlots.EmptySlots = append(backendSlots.EmptySlots, backendSlots.FullSlots[k].BackendServerName)
 							delete(backendSlots.FullSlots, k)
 						}
@@ -149,7 +149,7 @@ func reconfigureBackends(currentConfig, updatedConfig *types.ControllerConfig) b
 								BackendEndpoint:   endpoint,
 							}
 							backendSlots.EmptySlots = backendSlots.EmptySlots[1:]
-							reloadRequired = !addEndpoint(currentConfig.Cfg.StatsSocket, backendName, backendSlots.FullSlots[k].BackendServerName, endpoint.Address, endpoint.Port)
+							reloadRequired = reloadRequired || !addEndpoint(currentConfig.Cfg.StatsSocket, backendName, backendSlots.FullSlots[k].BackendServerName, endpoint.Address, endpoint.Port)
 						}
 						updatedConfig.BackendSlots[backendName] = backendSlots
 					}


### PR DESCRIPTION
This fixes a corner-case when if only some but not all socket commands fail, the successful ones would overwrite the previous value of `reloadRequired`. 