### PR TITLE
expose http and tcp log format

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following parameters are supported:
 ||[`hsts-include-subdomains`](#hsts)|[true\|false]|`false`|
 ||[`hsts-max-age`](#hsts)|number of seconds|`15768000`|
 ||[`hsts-preload`](#hsts)|[true\|false]|`false`|
+|`[1]`|[`http-log-format`](#http-log-format)|http log format|HAProxy default log format|
 ||[`max-connections`](#max-connections)|number|`2000`|
 ||[`proxy-body-size`](#proxy-body-size)|number of bytes|unlimited|
 ||[`ssl-ciphers`](#ssl-ciphers)|colon-separated list|[link to code](https://github.com/jcmoraisjr/haproxy-ingress/blob/master/pkg/controller/config.go#L33)|
@@ -89,6 +90,7 @@ The following parameters are supported:
 ||[`stats-port`](#stats)|port number|`1936`|
 |`[1]`|[`stats-proxy-protocol`](#stats)|[true\|false]|`false`|
 ||[`syslog-endpoint`](#syslog-endpoint)|IP:port (udp)|do not log|
+|`[1]`|[`tcp-log-format`](#tcp-log-format)|tcp log format|HAProxy default log format|
 ||[`timeout-client`](#timeout)|time with suffix|`50s`|
 ||[`timeout-client-fin`](#timeout)|time with suffix|`50s`|
 ||[`timeout-connect`](#timeout)|time with suffix|`5s`|
@@ -157,6 +159,18 @@ Configure HSTS - HTTP Strict Transport Security.
 * `hsts-preload`: `true` if the browser should include the domain to [HSTS preload list](https://hstspreload.org/)
 
 https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security
+
+### http-log-format
+
+Customize the http log format using log format variables. Default to the HAProxy default log format
+
+https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#8.2.4
+
+### tcp-log-format
+
+Customize the tcp log format using log format variables. Default to the HAProxy default log format
+
+https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#8.2.4
 
 ### max-connections
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -101,6 +101,8 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		StatsSocket:                 "/var/run/haproxy-stats.sock",
 		UseProxyProtocol:            false,
 		StatsProxyProtocol:          false,
+		HTTPLogFormat:               "",
+		TCPLogFormat:                "",
 	}
 	if haproxyController.configMap != nil {
 		utils.MergeMap(haproxyController.configMap.Data, &conf)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -71,6 +71,8 @@ type (
 		StatsSocket                 string
 		UseProxyProtocol            bool `json:"use-proxy-protocol"`
 		StatsProxyProtocol          bool `json:"stats-proxy-protocol"`
+		HTTPLogFormat               string `json:"http-log-format"`
+		TCPLogFormat                string `json:"tcp-log-format"`
 	}
 	// Userlist list of users for basic authentication
 	Userlist struct {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -75,6 +75,9 @@ frontend httpfront
     mode http
 {{ if ne $cfg.Syslog "" }}
     option httplog
+    {{ if ne $cfg.HTTPLogFormat "" }}
+    log-format {{ $cfg.HTTPLogFormat }}
+    {{ end }}
 {{ end }}
 {{ range $server := $ing.Servers }}
 {{ if ne $server.Hostname "_" }}
@@ -143,6 +146,9 @@ frontend httpsfront
     use_backend httpsback-{{ $server.Hostname }} if { req.ssl_sni -i {{ $server.Hostname }} }
 {{ end }}
     default_backend httpsback-default-backend
+{{ if ne $cfg.TCPLogFormat "" }}
+    log-format {{ $cfg.TCPLogFormat }}
+{{ end }}
 
 {{ range $server := $ing.HTTPSServers }}
 {{ $host := $server.Hostname }}
@@ -162,6 +168,9 @@ frontend httpsfront-{{ $host }}
     mode http
 {{ if ne $cfg.Syslog "" }}
     option httplog
+    {{ if ne $cfg.HTTPLogFormat "" }}
+    log-format {{ $cfg.HTTPLogFormat }}
+    {{ end }}
 {{ end }}
 {{ range $location := $server.Locations }}
 {{ if ne $location.HAWhitelist "" }}
@@ -215,6 +224,9 @@ frontend httpsfront-default-backend
     mode http
 {{ if ne $cfg.Syslog "" }}
     option httplog
+    {{ if ne $cfg.HTTPLogFormat "" }}
+    log-format {{ $cfg.HTTPLogFormat }}
+    {{ end }}
 {{ end }}
 {{ if eq $cfg.Forwardfor "add" }}
     reqidel ^X-Forwarded-For:.*


### PR DESCRIPTION
expose `http-log-format` and `tcp-log-format` to set the `log-format` on the respectively.