### PR TITLE
add support for wildcard hostnames

### DIFF
--- a/pkg/controller/template.go
+++ b/pkg/controller/template.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
 	"os/exec"
 	gotemplate "text/template"
+	"regexp"
 )
 
 type template struct {
@@ -38,6 +39,15 @@ var funcMap = gotemplate.FuncMap{
 		}
 		glog.Error("invalid type conversion on backendHash template function")
 		return ""
+	},
+	"hostnameRegex": func(hostname string) string {
+		rtn := regexp.MustCompile(`\.`).ReplaceAllLiteralString(hostname, "\\.")
+		rtn = regexp.MustCompile(`\*`).ReplaceAllLiteralString(rtn, "([^\\.]+)")
+		return "^" + rtn
+	},
+	"labelize": func (identifier string) string {
+		re := regexp.MustCompile(`[^a-zA-Z0-9:_\-.]`)
+		return re.ReplaceAllLiteralString(identifier, "_")
 	},
 }
 

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -79,24 +79,24 @@ frontend httpfront
     mode http
 {{ if ne $cfg.Syslog "" }}
     option httplog
-    {{ if ne $cfg.HTTPLogFormat "" }}
+{{ if ne $cfg.HTTPLogFormat "" }}
     log-format {{ $cfg.HTTPLogFormat }}
-    {{ end }}
+{{ end }}
 {{ end }}
 {{ range $server := $ing.Servers }}
 {{ if ne $server.Hostname "_" }}
-    acl ishost-{{ $server.Hostname }} hdr(host) {{ $server.Hostname }} {{ $server.Hostname }}:80
+    acl ishost-{{ labelize $server.Hostname }} hdr_reg(host) {{ hostnameRegex $server.Hostname }} {{ hostnameRegex $server.Hostname }}:80
 {{ end }}
 {{ end }}
 {{ range $server := $ing.HTTPServers }}
 {{ range $location := $server.Locations }}
 {{ if ne $location.HAWhitelist "" }}
-    http-request deny if ishost-{{ $server.Hostname }}{{ $location.HAMatchPath }} !{ src{{ $location.HAWhitelist }} }
+    http-request deny if ishost-{{ labelize $server.Hostname }}{{ $location.HAMatchPath }} !{ src{{ $location.HAWhitelist }} }
 {{ end }}
 {{ $listName := $location.Userlist.ListName }}
 {{ if ne $listName "" }}
     {{ $realm := $location.Userlist.Realm }}
-    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if ishost-{{ $server.Hostname }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
+    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if ishost-{{ labelize $server.Hostname }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
 {{ end }}
 {{ end }}
 {{ end }}
@@ -109,16 +109,16 @@ frontend httpfront
 {{ range $server := $ing.HTTPServers }}
 {{ $appRoot := $server.RootLocation.Redirect.AppRoot }}
 {{ if ne $appRoot "" }}
-    redirect location {{ $appRoot }} if ishost-{{ $server.Hostname }} { path / }
+    redirect location {{ $appRoot }} if ishost-{{ labelize $server.Hostname }} { path / }
 {{ end }}
 {{ end }}
 {{ range $server := $ing.HTTPSServers }}
 {{ if $server.SSLRedirect }}
-    redirect scheme https if ishost-{{ $server.Hostname }}
+    redirect scheme https if ishost-{{ labelize $server.Hostname }}
 {{ else }}
 {{ range $location := $server.Locations }}
 {{ if $location.Redirect.SSLRedirect }}
-    redirect scheme https if ishost-{{ $server.Hostname }}{{ $location.HAMatchPath }}
+    redirect scheme https if ishost-{{ labelize $server.Hostname }}{{ $location.HAMatchPath }}
 {{ end }}
 {{ end }}
 {{ end }}
@@ -126,11 +126,11 @@ frontend httpfront
 {{ range $server := $ing.HTTPServers }}
 {{ range $location := $server.Locations }}
 {{ if ne $location.Proxy.BodySize "" }}
-    use_backend error413 if ishost-{{ $server.Hostname }} { path_beg {{ $location.Path }} } { req.body_size gt {{ $location.Proxy.BodySize }} }
+    use_backend error413 if ishost-{{ labelize $server.Hostname }} { path_beg {{ $location.Path }} } { req.body_size gt {{ $location.Proxy.BodySize }} }
 {{ end }}
 {{ end }}
 {{ range $location := $server.Locations }}
-    use_backend {{ $location.Backend }} if ishost-{{ $server.Hostname }} { path_beg {{ $location.Path }} }
+    use_backend {{ $location.Backend }} if ishost-{{ labelize $server.Hostname }} { path_beg {{ $location.Path }} }
 {{ end }}
 {{ end }}
     default_backend {{ $ing.DefaultServer.RootLocation.Backend }}
@@ -144,10 +144,10 @@ frontend httpsfront
     tcp-request inspect-delay 5s
     tcp-request content accept if { req.ssl_hello_type 1 }
 {{ range $server := $ing.PassthroughBackends }}
-    use_backend {{ $server.Backend }} if { req.ssl_sni -i {{ $server.Hostname }} }
+    use_backend {{ $server.Backend }} if { req.ssl_sni -m reg -i {{ hostnameRegex $server.Hostname }} }
 {{ end }}
 {{ range $server := $ing.HTTPSServers }}
-    use_backend httpsback-{{ $server.Hostname }} if { req.ssl_sni -i {{ $server.Hostname }} }
+    use_backend httpsback-{{ labelize $server.Hostname }} if { req.ssl_sni -m reg -i {{ hostnameRegex $server.Hostname }} }
 {{ end }}
     default_backend httpsback-default-backend
 {{ if ne $cfg.TCPLogFormat "" }}
@@ -155,7 +155,7 @@ frontend httpsfront
 {{ end }}
 
 {{ range $server := $ing.HTTPSServers }}
-{{ $host := $server.Hostname }}
+{{ $host := labelize $server.Hostname }}
 ##
 ## {{ $host }}
 backend httpsback-{{ $host }}
@@ -172,9 +172,9 @@ frontend httpsfront-{{ $host }}
     mode http
 {{ if ne $cfg.Syslog "" }}
     option httplog
-    {{ if ne $cfg.HTTPLogFormat "" }}
+{{ if ne $cfg.HTTPLogFormat "" }}
     log-format {{ $cfg.HTTPLogFormat }}
-    {{ end }}
+{{ end }}
 {{ end }}
 {{ range $location := $server.Locations }}
 {{ if ne $location.HAWhitelist "" }}


### PR DESCRIPTION
I added support for using a regex to allow *. wildcard hostnames.  This also escapes characters that are not allowed in ACL rules to an `_`. 

An example ishost rule will look like this: `ishost-_.example.com hdr_reg(host) ^([^\.]+)\.example.com`