### PR TITLE
Set graceful docker stopsignal

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 FROM haproxy:1.7-alpine
+STOPSIGNAL SIGUSR1
 RUN apk --no-cache add openssl ruby ruby-json\
  && gem install --no-ri --no-rdoc multibinder:0.0.4
 


### PR DESCRIPTION
Kubernetes respects the STOPSIGNAL from the dockerfile when terminating pods. Setting the stopsignal to the gracefulstop instead of hard stop, allows for rolling updates to the HAProxy pods themselves with zero downtime (when not using Daemonsets or Hostports).
