### PR TITLE
HSTS and HTTPS redirect for case when SSL is terminated at the load balancer

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -104,6 +104,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		StatsProxyProtocol:          false,
 		HTTPLogFormat:               "",
 		TCPLogFormat:                "",
+		ForceSSLRedirect:            false,
 	}
 	if haproxyController.configMap != nil {
 		utils.MergeMap(haproxyController.configMap.Data, &conf)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -74,6 +74,7 @@ type (
 		StatsProxyProtocol          bool   `json:"stats-proxy-protocol"`
 		HTTPLogFormat               string `json:"http-log-format"`
 		TCPLogFormat                string `json:"tcp-log-format"`
+		ForceSSLRedirect            bool   `json:"force-ssl-redirect"`
 	}
 	// Userlist list of users for basic authentication
 	Userlist struct {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -83,6 +83,9 @@ frontend httpfront
     log-format {{ $cfg.HTTPLogFormat }}
 {{ end }}
 {{ end }}
+{{ if $cfg.ForceSSLRedirect }}
+redirect scheme https
+{{ else }}
 {{ range $server := $ing.Servers }}
 {{ if ne $server.Hostname "_" }}
 {{ if isWildcardHostname $server.Hostname }}
@@ -142,7 +145,7 @@ frontend httpfront
 {{ end }}
 {{ end }}
     default_backend {{ $ing.DefaultServer.RootLocation.Backend }}
-
+{{ end }}
 
 ######
 ###### HTTPS to HTTP frontend

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -134,6 +134,71 @@ frontend httpfront
 {{ end }}
 {{ end }}
 {{ range $location := $server.Locations }}
+{{ if $location.Rewrite.ForceSSLRedirect }}
+    redirect scheme https if ishost-{{ labelize $server.Hostname }}{{ $location.HAMatchPath }}
+{{ else }}
+    use_backend {{ $location.Backend }} if ishost-{{ labelize $server.Hostname }} { path_beg {{ $location.Path }} }
+{{ end }}
+{{ end }}
+{{ end }}
+    default_backend {{ $ing.DefaultServer.RootLocation.Backend }}
+
+
+######
+###### HTTPS to HTTP frontend
+######
+frontend https2httpfront
+    bind *:81{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
+    mode http
+{{ if ne $cfg.Syslog "" }}
+    option httplog
+{{ if ne $cfg.HTTPLogFormat "" }}
+    log-format {{ $cfg.HTTPLogFormat }}
+{{ end }}
+{{ end }}
+{{ range $server := $ing.Servers }}
+{{ if ne $server.Hostname "_" }}
+{{ if isWildcardHostname $server.Hostname }}
+    acl ishost-{{ labelize $server.Hostname }} hdr_reg(host) {{ hostnameRegex $server.Hostname }} {{ hostnameRegex $server.Hostname }}:80
+{{ else }}
+    acl ishost-{{ labelize $server.Hostname }} hdr(host) {{ $server.Hostname }} {{ $server.Hostname }}:80
+{{ end }}
+{{ end }}
+{{ end }}
+{{ range $server := $ing.HTTPServers }}
+{{ range $location := $server.Locations }}
+{{ if ne $location.HAWhitelist "" }}
+    http-request deny if ishost-{{ labelize $server.Hostname }}{{ $location.HAMatchPath }} !{ src{{ $location.HAWhitelist }} }
+{{ end }}
+{{ $listName := $location.Userlist.ListName }}
+{{ if ne $listName "" }}
+    {{ $realm := $location.Userlist.Realm }}
+    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if ishost-{{ labelize $server.Hostname }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
+{{ end }}
+{{ end }}
+{{ end }}
+{{ if eq $cfg.Forwardfor "add" }}
+    reqidel ^X-Forwarded-For:.*
+    option forwardfor
+{{ else if eq $cfg.Forwardfor "ifmissing" }}
+    option forwardfor if-none
+{{ end }}
+{{ range $server := $ing.HTTPServers }}
+{{ $appRoot := $server.RootLocation.Rewrite.AppRoot }}
+{{ if ne $appRoot "" }}
+    redirect location {{ $appRoot }} if ishost-{{ labelize $server.Hostname }} { path / }
+{{ end }}
+{{ end }}
+{{ if $cfg.HSTS }}
+    rspadd "Strict-Transport-Security: max-age={{ $cfg.HSTSMaxAge }}{{ if $cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }}{{ if $cfg.HSTSPreload }}; preload{{ end }}"
+{{ end }}
+{{ range $server := $ing.HTTPServers }}
+{{ range $location := $server.Locations }}
+{{ if ne $location.Proxy.BodySize "" }}
+    use_backend error413 if ishost-{{ labelize $server.Hostname }} { path_beg {{ $location.Path }} } { req.body_size gt {{ $location.Proxy.BodySize }} }
+{{ end }}
+{{ end }}
+{{ range $location := $server.Locations }}
     use_backend {{ $location.Backend }} if ishost-{{ labelize $server.Hostname }} { path_beg {{ $location.Path }} }
 {{ end }}
 {{ end }}


### PR DESCRIPTION
Follow-up pull request for #38 

I don't like that I had to copy the whole httpfront section.

Also, this new https2httpfront only loop over non-HTTPS servers -- not sure if this is correct (although in this mode HTTPS servers are sort of useless anyway as we terminate SSL before getting to HAProxy).

Any comments/suggestions? Makes sense/does not?