### PR TITLE
Drain Endpoint on Removal

### DIFF
--- a/pkg/controller/stats_socket.go
+++ b/pkg/controller/stats_socket.go
@@ -62,7 +62,7 @@ func endpointsSubtract(s1, s2 map[string]*ingress.Endpoint) map[string]*ingress.
 // remove Ingress Endpoint from a backend by disabling a specific server slot
 func removeEndpoint(statsSocket, backendName, backendServerName string) bool {
 	err := utils.SendToSocket(statsSocket,
-		fmt.Sprintf("set server %s/%s state maint\n", backendName, backendServerName))
+		fmt.Sprintf("set server %s/%s state drain\n", backendName, backendServerName))
 	if err != nil {
 		glog.Warningln("failed socket command srv remove")
 		return false


### PR DESCRIPTION
HAProxy has both a maintenance state and a drain state that a backend can be put into through the socket. http://cbonte.github.io/haproxy-dconv/1.8/management.html#9.3-set%20server.

I think that the ingress controller should put the backend into the drain state to allow currently active connections to drain but remove this backend from load balancing. One consequence of this is checks will still be performed, as a result it may be necessary to put the backend into maintenance state after a specific interval.