### PR TITLE
Fix making ingress-class overridable

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -103,9 +103,10 @@ func (haproxy *HAProxyController) UpdateIngressStatus(*extensions.Ingress) []api
 func (haproxy *HAProxyController) ConfigureFlags(flags *pflag.FlagSet) {
 	haproxy.reloadStrategy = flags.String("reload-strategy", "native",
 		`Name of the reload strategy. Options are: native (default) or multibinder`)
-	ingressClass, _ := flags.GetString("ingress-class")
-	if ingressClass == "" {
-		flags.Set("ingress-class", "haproxy")
+	ingressClass := flags.Lookup("ingress-class")
+	if ingressClass != nil {
+		ingressClass.Value.Set("haproxy")
+		ingressClass.DefValue = "haproxy"
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -103,10 +103,9 @@ func (haproxy *HAProxyController) UpdateIngressStatus(*extensions.Ingress) []api
 func (haproxy *HAProxyController) ConfigureFlags(flags *pflag.FlagSet) {
 	haproxy.reloadStrategy = flags.String("reload-strategy", "native",
 		`Name of the reload strategy. Options are: native (default) or multibinder`)
-	ingressClass := flags.Lookup("ingress-class")
-	if ingressClass != nil {
-		ingressClass.Value.Set("haproxy")
-		ingressClass.DefValue = "haproxy"
+	ingressClass, _ := flags.GetString("ingress-class")
+	if ingressClass == "" {
+		flags.Set("ingress-class", "haproxy")
 	}
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -122,6 +122,11 @@ func (haproxy *HAProxyController) OverrideFlags(flags *pflag.FlagSet) {
 		glog.Fatalf("Unsupported reload strategy: %v", *haproxy.reloadStrategy)
 	}
 	haproxy.command = "/haproxy-reload.sh"
+
+	ingressClass, _ := flags.GetString("ingress-class")
+	if ingressClass == "" {
+		flags.Set("ingress-class", "haproxy")
+	}
 }
 
 // SetConfig receives the ConfigMap the user has configured


### PR DESCRIPTION
See #49 

Before this fix the ingress-class flag could not be overridden and was always set to haproxy.
