### PR TITLE
Fix handling error496

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -264,7 +264,7 @@ frontend httpsfront-{{ $host }}
 {{ if ne $authSSLCert.CAFileName "" }}
 {{ if eq $server.CertificateAuth.ErrorPage "" }}
     use_backend error495 if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
-    use_backend error496 if !{ ssl_fc_has_crt }
+    use_backend error496 if !{ ssl_c_used }
 {{ else }}
     redirect location {{ $server.CertificateAuth.ErrorPage }} if !{ ssl_fc_has_crt } || { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
 {{ end }}


### PR DESCRIPTION
Fixes: #52
Replace variable that detects usage of client certificate from `ssl_fc_has_crt` to `ssl_c_used`.