### PR TITLE
Add an X-Forwarded-Proto header in https frontends

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -269,6 +269,7 @@ frontend httpsfront-{{ $host }}
 {{ else if eq $cfg.Forwardfor "ifmissing" }}
     option forwardfor if-none
 {{ end }}
+    http-request set-header X-Forwarded-Proto https
 {{ if ne $authSSLCert.CAFileName "" }}
 {{ if eq $server.CertificateAuth.ErrorPage "" }}
     use_backend error495 if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }


### PR DESCRIPTION
Some applications requires a X-Forwarded-Proto header when the reverse
proxy offloads SSL.
By adding "http-request set-header X-Forwarded-Proto https", the header
will be added if none exist, or it will replace previous occurences if
it was already present.