### PR TITLE
Add support for rewrite-target annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ template file at `/etc/haproxy/template/haproxy.tmpl`.
 The following annotations are supported:
 
 * `[0]` only in `canary` tag
+* `[1]` only in `shanpshot` tag
 
 ||Name|Data|Usage|
 |---|---|---|:---:|
@@ -60,6 +61,7 @@ The following annotations are supported:
 ||`ingress.kubernetes.io/ssl-redirect`|[true\|false]|[doc](https://github.com/kubernetes/ingress/tree/master/examples/rewrite/haproxy)|
 ||`ingress.kubernetes.io/app-root`|/url|[doc](https://github.com/kubernetes/ingress/tree/master/examples/rewrite/haproxy)|
 ||`ingress.kubernetes.io/whitelist-source-range`|CIDR|-|
+|`[1]`|[`ingress.kubernetes.io/rewrite-target`](#rewrite-target)|path string|-|
 |`[0]`|[`ingress.kubernetes.io/server-alias`](#server-alias)|domain name or regex|-|
 
 ### Affinity
@@ -87,6 +89,16 @@ Alias rules will be checked at the very end of list or rules.
 It is allowed to be a regex.
 
 Note: `^` and `$` cannot be used because they are already included in ACL.
+
+### Rewrite Target
+
+Supported rewrite annotations:
+
+* `/`
+* `/path1`
+* `/path1/path2`
+
+Trailing slashes on rewrite target annotations are not supported.
 
 ## ConfigMap
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -208,12 +208,12 @@ func (cfg *haConfig) newHAProxyLocations(server *ingress.Server) ([]*types.HAPro
 			haRootLocation = &haLocation
 		} else {
 			otherPaths = otherPaths + " " + location.Path
-			haLocation.HAMatchPath = " { path_beg " + haLocation.Path + " }"
+			haLocation.HAMatchPath = " { var(req.path) -m beg " + haLocation.Path + " }"
 		}
 		haLocations[i] = &haLocation
 	}
 	if haRootLocation != nil && otherPaths != "" {
-		haRootLocation.HAMatchPath = " !{ path_beg" + otherPaths + " }"
+		haRootLocation.HAMatchPath = " !{ var(req.path) -m beg " + otherPaths + " }"
 	}
 	return haLocations, haRootLocation
 }

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -105,6 +105,8 @@ frontend httpfront
     acl ishost-{{ $server.HostnameLabel }}-alias {{ if isRegexHostname $server.Alias }}hdr_reg(host) '{{ aliasRegex $server.Alias }}'{{ else }}hdr(host) {{ $server.Alias }} {{ $server.Alias }}:80{{ end }}
 {{ end }}
 {{ end }}
+
+    http-request set-var(req.path) path
 {{ range $server := $ing.HAServers }}
 {{ if $server.UseHTTP }}
 {{ range $location := $server.Locations }}
@@ -119,6 +121,19 @@ frontend httpfront
 {{ end }}
 {{ end }}
 {{ end }}
+
+{{ range $server := $ing.HAServers }}
+{{ if $server.UseHTTP }}
+{{ range $location := $server.Locations }}
+{{ $rewriteTarget := $location.Rewrite.Target }}
+{{ if ne $rewriteTarget "" }}
+    reqrep ^([^\ :]*)\ {{ $location.Path }}/(.*$) \1\ {{ if eq $rewriteTarget "/" }}/{{ else }}{{ $rewriteTarget }}/{{ end }}\2 if { var(req.path) -m beg {{ $location.Path }} } {{ if ne $server.Alias "" }} ishost-{{ $server.HostnameLabel }} or ishost-{{ $server.HostnameLabel }}-alias {{ else }} ishost-{{ $server.HostnameLabel }} {{ end }}
+    reqrep ^([^\ :]*)\ {{ $location.Path }}(.*$) \1\ {{ $rewriteTarget }}\2 if { var(req.path) -m beg {{ $location.Path }} } {{ if ne $server.Alias "" }} ishost-{{ $server.HostnameLabel }} or ishost-{{ $server.HostnameLabel }}-alias {{ else }} ishost-{{ $server.HostnameLabel }} {{ end }}
+{{ end }}
+{{ end }}
+{{ end }}
+{{ end }}
+
 {{ if eq $cfg.Forwardfor "add" }}
     reqidel ^X-Forwarded-For:.*
     option forwardfor
@@ -129,7 +144,7 @@ frontend httpfront
 {{ if $server.UseHTTP }}
 {{ $appRoot := $server.RootLocation.Rewrite.AppRoot }}
 {{ if ne $appRoot "" }}
-    redirect location {{ $appRoot }} if ishost-{{ $server.HostnameLabel }} { path / }
+    redirect location {{ $appRoot }} if ishost-{{ $server.HostnameLabel }} { var(req.path) -m str / }
 {{ end }}
 {{ end }}
 {{ end }}
@@ -169,11 +184,11 @@ frontend httpfront
 {{ if or $server.UseHTTP $hasHTTPStoHTTP }}
 {{ range $location := $server.Locations }}
 {{ if ne $location.Proxy.BodySize "" }}
-    use_backend error413 if ishost-{{ $server.HostnameLabel }} { path_beg {{ $location.Path }} } { req.body_size gt {{ sizeSuffix $location.Proxy.BodySize }} }
+    use_backend error413 if ishost-{{ $server.HostnameLabel }} { var(req.path) -m beg {{ $location.Path }} } { req.body_size gt {{ sizeSuffix $location.Proxy.BodySize }} }
 {{ end }}
 {{ end }}
 {{ range $location := $server.Locations }}
-    use_backend {{ $location.Backend }} if ishost-{{ $server.HostnameLabel }} { path_beg {{ $location.Path }} }
+    use_backend {{ $location.Backend }} if ishost-{{ $server.HostnameLabel }} { var(req.path) -m beg {{ $location.Path }} }
 {{ end }}
 {{ end }}
 {{ end }}
@@ -182,7 +197,7 @@ frontend httpfront
 {{ if or $server.UseHTTP $hasHTTPStoHTTP }}
 {{ range $location := $server.Locations }}
 {{ if ne $server.Alias "" }}
-    use_backend {{ $location.Backend }} if ishost-{{ $server.HostnameLabel }}-alias { path_beg {{ $location.Path }} }
+    use_backend {{ $location.Backend }} if ishost-{{ $server.HostnameLabel }}-alias { var(req.path) -m beg {{ $location.Path }} }
 {{ end }}
 {{ end }}
 {{ end }}
@@ -263,13 +278,14 @@ frontend httpsfront-{{ $host }}
     http-request set-header X-SSL-Client-DN    %{+Q}[ssl_c_s_dn]
     http-request set-header X-SSL-Client-CN    %{+Q}[ssl_c_s_dn(cn)]
 {{ end }}
+    http-request set-header X-Forwarded-Proto https
+    http-request set-var(req.path) path
 {{ if eq $cfg.Forwardfor "add" }}
     reqidel ^X-Forwarded-For:.*
     option forwardfor
 {{ else if eq $cfg.Forwardfor "ifmissing" }}
     option forwardfor if-none
 {{ end }}
-    http-request set-header X-Forwarded-Proto https
 {{ if ne $authSSLCert.CAFileName "" }}
 {{ if eq $server.CertificateAuth.ErrorPage "" }}
     use_backend error495 if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
@@ -281,18 +297,29 @@ frontend httpsfront-{{ $host }}
 {{ if $cfg.HSTS }}
     rspadd "Strict-Transport-Security: max-age={{ $cfg.HSTSMaxAge }}{{ if $cfg.HSTSIncludeSubdomains }}; includeSubDomains{{ end }}{{ if $cfg.HSTSPreload }}; preload{{ end }}"
 {{ end }}
+
 {{ $appRoot := $server.RootLocation.Rewrite.AppRoot }}
 {{ if ne $appRoot "" }}
-    redirect location {{ $appRoot }} if { path / }
+    redirect location {{ $appRoot }} if { var(req.path) -m str / }
 {{ end }}
+
+{{ range $location := $server.Locations }}
+{{ $rewriteTarget := $location.Rewrite.Target }}
+{{ if ne $rewriteTarget "" }}
+    reqrep ^([^\ :]*)\ {{ $location.Path }}/(.*$) \1\ {{ if eq $rewriteTarget "/" }}/{{ else }}{{ $rewriteTarget }}/{{ end }}\2 if { var(req.path) -m beg {{ $location.Path }} }
+    reqrep ^([^\ :]*)\ {{ $location.Path }}(.*$) \1\ {{ $rewriteTarget }}\2 if { var(req.path) -m beg {{ $location.Path }} }
+{{ end }}
+{{ end }}
+
 {{ range $location := $server.Locations }}
 {{ if ne $location.Proxy.BodySize "" }}
-    use_backend error413 if { path_beg {{ $location.Path }} } { req.body_size gt {{ sizeSuffix $location.Proxy.BodySize }} }
+    use_backend error413 if { var(req.path) -m beg {{ $location.Path }} } { req.body_size gt {{ sizeSuffix $location.Proxy.BodySize }} }
 {{ end }}
 {{ end }}
+
 {{ range $location := $server.Locations }}
 {{ if not $location.IsRootLocation }}
-    use_backend {{ $location.Backend }} if { path_beg {{ $location.Path }} }
+    use_backend {{ $location.Backend }} if { var(req.path) -m beg {{ $location.Path }} }
 {{ else }}
     default_backend {{ $location.Backend }}
 {{ end }}


### PR DESCRIPTION
#55 

Adds support for ingress annotation: `ingress.kubernetes.io/rewrite-target`.

Our test case for this work was `ingress.kubernetes.io/rewrite-target: /` as that has been the most common use case for us internally. This implementation SEEMS to be feature similar to the current implementation in the [kubernetes/ingress](https://github.com/kubernetes/ingress) nginx ingress controller, but our test cases were rather limited so unsure.

Used https://gist.github.com/kushmansingh/47644ef4db96f11b1ea450ae19072552 to do our testing but could have used most any other container that echoes the headers.