### PR TITLE
Correctly copy Endpoints to FullSlots

### DIFF
--- a/pkg/controller/stats_socket.go
+++ b/pkg/controller/stats_socket.go
@@ -181,9 +181,10 @@ func fillBackendServerSlots(updatedConfig *types.ControllerConfig) {
 		newBackend.FullSlots = map[string]types.HAProxyBackendSlot{}
 		if updatedConfig.Cfg.DynamicScaling {
 			for i, endpoint := range updBackendsMap[backendName].Endpoints {
+				curEndpoint := endpoint
 				newBackend.FullSlots[fmt.Sprintf("%s:%s", endpoint.Address, endpoint.Port)] = types.HAProxyBackendSlot{
 					BackendServerName: fmt.Sprintf("server%04d", i),
-					BackendEndpoint:   &endpoint,
+					BackendEndpoint:   &curEndpoint,
 				}
 			}
 			// add up to BackendServerSlotsIncrement empty slots

--- a/pkg/controller/stats_socket.go
+++ b/pkg/controller/stats_socket.go
@@ -195,10 +195,11 @@ func fillBackendServerSlots(updatedConfig *types.ControllerConfig) {
 		} else {
 			// use addr:port as BackendServerName, don't generate empty slots
 			for _, endpoint := range updBackendsMap[backendName].Endpoints {
+				curEndpoint := endpoint
 				target := fmt.Sprintf("%s:%s", endpoint.Address, endpoint.Port)
 				newBackend.FullSlots[target] = types.HAProxyBackendSlot{
 					BackendServerName: target,
-					BackendEndpoint:   &endpoint,
+					BackendEndpoint:   &curEndpoint,
 				}
 			}
 		}


### PR DESCRIPTION
The Endpoint address copied to FullSlots was a local variable re-used by a loop. This was resulting in all of the endpoints pointing to the last one copied.

Issue: #84 