### PR TITLE
Add a cookie strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ The following annotations are supported:
 ||`ingress.kubernetes.io/secure-backends`|[true\|false]|-|
 ||`ingress.kubernetes.io/secure-verify-ca-secret`|secret name|-|
 ||[`ingress.kubernetes.io/session-cookie-name`](#affinity)|cookie name|-|
+|`[0]`|[`ingress.kubernetes.io/session-cookie-strategy`](#affinity)|cookie strategy|-|
 ||`ingress.kubernetes.io/ssl-passthrough`|[true\|false]|-|
 ||`ingress.kubernetes.io/ssl-redirect`|[true\|false]|[doc](/examples/rewrite)|
 ||`ingress.kubernetes.io/app-root`|/url|[doc](/examples/rewrite)|
@@ -72,6 +73,7 @@ Configure if HAProxy should maintain client requests to the same backend server.
 
 * `ingress.kubernetes.io/affinity`: the only supported option is `cookie`. If declared, clients will receive a cookie with a hash of the server it should be fidelized to.
 * `ingress.kubernetes.io/session-cookie-name`: the name of the cookie. `INGRESSCOOKIE` is the default value if not declared.
+* `ingress.kubernetes.io/session-cookie-strategy`: the cookie strategy to use (insert, rewrite, prefix). `insert` is the default value if not declared.
 
 Note for `dynamic-scaling` users only: the hash of the server is built based on it's name.
 When the slots are scaled down, the remaining servers might change it's server name on

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ configmap with `haproxy.tmpl` key mounting into `/etc/haproxy/template` will wor
 The following annotations are supported:
 
 * `[0]` only in `canary` tag
+* `[1]` only in `snapshot` tag
 
 ||Name|Data|Usage|
 |---|---|---|:---:|
@@ -59,7 +60,7 @@ The following annotations are supported:
 ||`ingress.kubernetes.io/secure-backends`|[true\|false]|-|
 ||`ingress.kubernetes.io/secure-verify-ca-secret`|secret name|-|
 ||[`ingress.kubernetes.io/session-cookie-name`](#affinity)|cookie name|-|
-|`[0]`|[`ingress.kubernetes.io/session-cookie-strategy`](#affinity)|cookie strategy|-|
+|`[1]`|[`ingress.kubernetes.io/session-cookie-strategy`](#affinity)|[insert\|prefix\|rewrite]|-|
 ||`ingress.kubernetes.io/ssl-passthrough`|[true\|false]|-|
 ||`ingress.kubernetes.io/ssl-redirect`|[true\|false]|[doc](/examples/rewrite)|
 ||`ingress.kubernetes.io/app-root`|/url|[doc](/examples/rewrite)|

--- a/pkg/common/ingress/annotations/sessionaffinity/main.go
+++ b/pkg/common/ingress/annotations/sessionaffinity/main.go
@@ -77,7 +77,11 @@ func CookieAffinityParse(ing *extensions.Ingress) *CookieConfig {
 	ss, err := parser.GetStringAnnotation(annotationAffinityCookieStrategy, ing)
 
 	if err != nil || !affinityCookieStrategyRegex.MatchString(ss) {
-		glog.V(3).Infof("Invalid or no annotation value found in Ingress %v: %v. Setting it to default %v", ing.Name, annotationAffinityCookieStrategy, defaultAffinityCookieStrategy)
+		if ss != "" {
+			glog.Warningf("Invalid annotation value found in Ingress %v: %v. Setting it to default %v", ing.Name, annotationAffinityCookieStrategy, defaultAffinityCookieStrategy)
+		} else {
+			glog.V(3).Infof("No annotation value found in Ingress %v: %v. Setting it to default %v", ing.Name, annotationAffinityCookieStrategy, defaultAffinityCookieStrategy)
+		}
 		ss = defaultAffinityCookieStrategy
 	}
 

--- a/pkg/common/ingress/annotations/sessionaffinity/main.go
+++ b/pkg/common/ingress/annotations/sessionaffinity/main.go
@@ -43,7 +43,7 @@ const (
 
 var (
 	affinityCookieHashRegex = regexp.MustCompile(`^(index|md5|sha1)$`)
-	affinityCookieStrategyRegex = regexp.MustCompile(`^(insert|prefix|rewrite)`)
+	affinityCookieStrategyRegex = regexp.MustCompile(`^(insert|prefix|rewrite)$`)
 )
 
 // AffinityConfig describes the per ingress session affinity config

--- a/pkg/common/ingress/annotations/sessionaffinity/main_test.go
+++ b/pkg/common/ingress/annotations/sessionaffinity/main_test.go
@@ -85,10 +85,10 @@ func TestIngressAffinityCookieConfig(t *testing.T) {
 	}
 
 	if nginxAffinity.CookieConfig.Name != "INGRESSCOOKIE" {
-		t.Errorf("expected route as sticky-name but returned %v", nginxAffinity.CookieConfig.Name)
+		t.Errorf("expected INGRESSCOOKIE as sticky-name but returned %v", nginxAffinity.CookieConfig.Name)
 	}
 
 	if nginxAffinity.CookieConfig.Strategy != "insert" {
-		t.Errorf("expected route as sticky-strategy but returned %v", nginxAffinity.CookieConfig.Strategy)
+		t.Errorf("expected insert as sticky-strategy but returned %v", nginxAffinity.CookieConfig.Strategy)
 	}
 }

--- a/pkg/common/ingress/annotations/sessionaffinity/main_test.go
+++ b/pkg/common/ingress/annotations/sessionaffinity/main_test.go
@@ -67,6 +67,7 @@ func TestIngressAffinityCookieConfig(t *testing.T) {
 	data[annotationAffinityType] = "cookie"
 	data[annotationAffinityCookieHash] = "sha123"
 	data[annotationAffinityCookieName] = "INGRESSCOOKIE"
+	data[annotationAffinityCookieStrategy] = "insert"
 	ing.SetAnnotations(data)
 
 	affin, _ := NewParser().Parse(ing)
@@ -85,5 +86,9 @@ func TestIngressAffinityCookieConfig(t *testing.T) {
 
 	if nginxAffinity.CookieConfig.Name != "INGRESSCOOKIE" {
 		t.Errorf("expected route as sticky-name but returned %v", nginxAffinity.CookieConfig.Name)
+	}
+
+	if nginxAffinity.CookieConfig.Strategy != "insert" {
+		t.Errorf("expected route as sticky-strategy but returned %v", nginxAffinity.CookieConfig.Strategy)
 	}
 }

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -586,6 +586,7 @@ func (ic *GenericController) getBackendServers(ingresses []*extensions.Ingress) 
 
 				if affinity.AffinityType == "cookie" {
 					ups.SessionAffinity.CookieSessionAffinity.Name = affinity.CookieConfig.Name
+					ups.SessionAffinity.CookieSessionAffinity.Strategy = affinity.CookieConfig.Strategy
 					ups.SessionAffinity.CookieSessionAffinity.Hash = affinity.CookieConfig.Hash
 
 					locs := ups.SessionAffinity.CookieSessionAffinity.Locations

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -202,6 +202,7 @@ type SessionAffinityConfig struct {
 // +k8s:deepcopy-gen=true
 type CookieSessionAffinity struct {
 	Name      string              `json:"name"`
+	Strategy  string              `json:"strategy"`
 	Hash      string              `json:"hash"`
 	Locations map[string][]string `json:"locations,omitempty"`
 }
@@ -222,7 +223,7 @@ type Endpoint struct {
 	// to consider the endpoint unavailable
 	FailTimeout int `json:"failTimeout"`
 	// Target returns a reference to the object providing the endpoint
-	Target *apiv1.ObjectReference `json:"target,omipempty"`
+	Target *apiv1.ObjectReference `json:"target,omitempty"`
 }
 
 // Server describes a website

--- a/pkg/common/ingress/types_equals.go
+++ b/pkg/common/ingress/types_equals.go
@@ -226,6 +226,9 @@ func (csa1 *CookieSessionAffinity) Equal(csa2 *CookieSessionAffinity) bool {
 	if csa1.Name != csa2.Name {
 		return false
 	}
+	if csa1.Strategy != csa2.Strategy {
+		return false
+	}
 	if csa1.Hash != csa2.Hash {
 		return false
 	}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -85,7 +85,7 @@ backend {{ $backend.Name }}
     balance {{ $cfg.BalanceAlgorithm }}
 {{- $sticky := $backend.SessionAffinity }}
 {{- if eq $sticky.AffinityType "cookie" }}
-    cookie {{ $sticky.CookieSessionAffinity.Name }} insert indirect nocache
+    cookie {{ $sticky.CookieSessionAffinity.Name }} {{ $sticky.CookieSessionAffinity.Strategy }} {{ if eq $sticky.CookieSessionAffinity.Strategy "insert" }}indirect nocache{{ end }}
 {{- end }}
 {{- $cacert := $backend.SecureCACert }}
 {{- if ne $cacert.PemSHA "" }}

--- a/tests/manifests/configuration-c.json
+++ b/tests/manifests/configuration-c.json
@@ -27,6 +27,7 @@
 			"name": "",
 			"CookieSessionAffinity": {
 				"name": "",
+				"strategy": "",
 				"hash": ""
 			}
 		}
@@ -81,6 +82,7 @@
 			"name": "",
 			"CookieSessionAffinity": {
 				"name": "",
+				"strategy": "",
 				"hash": ""
 			}
 		}


### PR DESCRIPTION
This is an additional annotation that will allow the user to select a different HAProxy cookie strategy other than insert. Supported additions are prefix and rewrite.