### PR TITLE
Support a "drain" mode for terminating pods and servers failing readiness checks

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/jcmoraisjr/haproxy-ingress",
 	"GoVersion": "go1.9",
-	"GodepVersion": "v79",
+	"GodepVersion": "v80",
 	"Packages": [
 		"./..."
 	],
@@ -1061,6 +1061,16 @@
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api",
+			"Comment": "v1.8.3",
+			"Rev": "f0efb3cb883751c5ffdbe6d515f3cb4fbe7b7acd"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/apis",
+			"Comment": "v1.8.3",
+			"Rev": "f0efb3cb883751c5ffdbe6d515f3cb4fbe7b7acd"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/util/node",
 			"Comment": "v1.8.3",
 			"Rev": "f0efb3cb883751c5ffdbe6d515f3cb4fbe7b7acd"
 		}

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ A ConfigMap can be created with `kubectl create configmap`.
 The following parameters are supported:
 
 * `[0]` only in `canary` tag
+* `[1]` only in `snapshot` tag
 
 ||Name|Type|Default|
 |---|---|---|---|
@@ -191,6 +192,7 @@ The following parameters are supported:
 ||[`timeout-tunnel`](#timeout)|time with suffix|`1h`|
 |`[0]`|[`use-host-on-https`](#use-host-on-https)|[true\|false]|`false`|
 ||[`use-proxy-protocol`](#use-proxy-protocol)|[true\|false]|`false`|
+|`[1]`|[`drain-support`](#drain-support)|[true\|false]|`false`|
 
 ### balance-algorithm
 
@@ -413,6 +415,13 @@ configuration.
 
 * http://cbonte.github.io/haproxy-dconv/1.7/configuration.html#5.1-accept-proxy
 * http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+
+### drain-support
+
+Set to true if you wish to use HAProxy's drain support for pods that are NotReady (e.g., failing a
+k8s readiness check) or are in the process of terminating. This option only makes sense with
+cookie affinity configured as it allows persistent traffic to be directed to pods that are in a
+not ready or terminating state.
 
 ## Command-line
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -603,7 +603,7 @@ func (ic *GenericController) getBackendServers(ingresses []*extensions.Ingress) 
 	aUpstreams := make([]*ingress.Backend, 0, len(upstreams))
 
 	for _, upstream := range upstreams {
-		isHTTPSfrom := []*ingress.Server{}
+		var isHTTPSfrom []*ingress.Server
 		for _, server := range servers {
 			for _, location := range server.Locations {
 				if upstream.Name == location.Backend {
@@ -821,7 +821,7 @@ func (ic *GenericController) getServiceClusterEndpoint(svcKey string, backend *e
 
 	svc := svcObj.(*apiv1.Service)
 	if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == "None" {
-		return endpoint, fmt.Errorf("No ClusterIP found for service %s", svcKey)
+		return endpoint, fmt.Errorf("no ClusterIP found for service %s", svcKey)
 	}
 
 	endpoint.Address = svc.Spec.ClusterIP
@@ -1142,7 +1142,7 @@ func (ic *GenericController) getEndpoints(
 	proto apiv1.Protocol,
 	hz *healthcheck.Upstream) []ingress.Endpoint {
 
-	upsServers := []ingress.Endpoint{}
+	var upsServers []ingress.Endpoint
 
 	// avoid duplicated upstream servers when the service
 	// contains multiple port definitions sharing the same
@@ -1171,6 +1171,7 @@ func (ic *GenericController) getEndpoints(
 		return append(upsServers, ingress.Endpoint{
 			Address:     s.Spec.ExternalName,
 			Port:        fmt.Sprintf("%v", targetPort),
+			Draining:    false,
 			MaxFails:    hz.MaxFails,
 			FailTimeout: hz.FailTimeout,
 		})
@@ -1204,25 +1205,68 @@ func (ic *GenericController) getEndpoints(
 				continue
 			}
 
-			for _, epAddress := range ss.Addresses {
-				ep := fmt.Sprintf("%v:%v", epAddress.IP, targetPort)
-				if _, exists := adus[ep]; exists {
-					continue
-				}
-				ups := ingress.Endpoint{
-					Address:     epAddress.IP,
-					Port:        fmt.Sprintf("%v", targetPort),
-					MaxFails:    hz.MaxFails,
-					FailTimeout: hz.FailTimeout,
-					Target:      epAddress.TargetRef,
-				}
-				upsServers = append(upsServers, ups)
-				adus[ep] = true
-			}
+			upsServers = addIngressEndpoint(ss.Addresses, false, targetPort, adus, hz, upsServers)
+			upsServers = addIngressEndpoint(ss.NotReadyAddresses, true, targetPort, adus, hz, upsServers)
 		}
 	}
 
+	terminatingPods, err := ic.listers.Pod.GetTerminatingServicePods(s)
+	if err != nil {
+		glog.Warningf("unexpected error obtaining terminating pods for service: %v", err)
+		return upsServers
+	}
+
+	// For each pod associated with this service that is in the terminating state, add it to the output in the draining state
+	// This will allow persistent traffic to be sent to the server during the termination grace period.
+	for _, tp := range terminatingPods {
+		ep := fmt.Sprintf("%v:%v", tp.Status.PodIP, servicePort.TargetPort.IntValue())
+		if _, exists := adus[ep]; exists {
+			continue
+		}
+		ups := ingress.Endpoint{
+			Address:     tp.Status.PodIP,
+			Port:        fmt.Sprintf("%v", servicePort.TargetPort.IntValue()),
+			Draining:    true,
+			MaxFails:    hz.MaxFails,
+			FailTimeout: hz.FailTimeout,
+			Target:      &apiv1.ObjectReference{
+				Kind:            tp.Kind,
+				Namespace:       tp.Namespace,
+				Name:            tp.Name,
+				UID:             tp.UID,
+				ResourceVersion: tp.ResourceVersion,
+			},
+		}
+		upsServers = append(upsServers, ups)
+		adus[ep] = true
+	}
+
 	glog.V(3).Infof("endpoints found: %v", upsServers)
+	return upsServers
+}
+
+func addIngressEndpoint(addresses []apiv1.EndpointAddress,
+	draining bool,
+	targetPort int32,
+	adus map[string]bool,
+	hz *healthcheck.Upstream,
+	upsServers []ingress.Endpoint) []ingress.Endpoint {
+	for _, epAddress := range addresses {
+		ep := fmt.Sprintf("%v:%v", epAddress.IP, targetPort)
+		if _, exists := adus[ep]; exists {
+			continue
+		}
+		ups := ingress.Endpoint{
+			Address:     epAddress.IP,
+			Port:        fmt.Sprintf("%v", targetPort),
+			Draining:    draining,
+			MaxFails:    hz.MaxFails,
+			FailTimeout: hz.FailTimeout,
+			Target:      epAddress.TargetRef,
+		}
+		upsServers = append(upsServers, ups)
+		adus[ep] = true
+	}
 	return upsServers
 }
 

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -158,7 +158,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		glog.Fatalf("invalid format for service %v: %v", *defaultSvc, err)
 	}
 
-	_, err = kubeClient.Core().Services(ns).Get(name, metav1.GetOptions{})
+	_, err = kubeClient.CoreV1().Services(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		if strings.Contains(err.Error(), "cannot get services in the namespace") {
 			glog.Fatalf("✖ It seems the cluster it is running with Authorization enabled (like RBAC) and there is no permissions for the ingress controller. Please check the configuration")

--- a/pkg/common/ingress/store/main.go
+++ b/pkg/common/ingress/store/main.go
@@ -123,6 +123,9 @@ func (s *PodLister) GetTerminatingServicePods(svc *apiv1.Service) (pl []apiv1.Po
 // Indicates whether or not pod belongs to svc, and is in the process of terminating
 func isTerminatingServicePod(svc *apiv1.Service, pod *apiv1.Pod) (termSvcPod bool) {
 	termSvcPod = false
+	if svc.GetNamespace() != pod.GetNamespace() {
+		return
+	}
 	for selectorLabel, selectorValue := range svc.Spec.Selector {
 		if labelValue, present := pod.Labels[selectorLabel]; !present || selectorValue != labelValue {
 			return

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -105,6 +105,10 @@ type Controller interface {
 	// referenced service does not exists. This should return the content
 	// of to the default backend
 	DefaultEndpoint() Endpoint
+	// Indicates whether or not this controller supports a "drain" mode where unavailable
+	// and terminating pods are included in the list of returned pods and used to direct
+	// certain traffic (e.g., traffic using persistence) to terminating/unavailable pods.
+	DrainSupport() bool
 }
 
 // StoreLister returns the configured stores for ingresses, services,

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -116,6 +116,7 @@ type StoreLister struct {
 	Endpoint  store.EndpointLister
 	Secret    store.SecretLister
 	ConfigMap store.ConfigMapLister
+	Pod       store.PodLister
 }
 
 // BackendInfo returns information about the backend.
@@ -180,7 +181,7 @@ type Backend struct {
 	SSLPassthrough bool `json:"sslPassthrough"`
 	// Endpoints contains the list of endpoints currently running
 	Endpoints []Endpoint `json:"endpoints,omitempty"`
-	// StickySessionAffinitySession contains the StickyConfig object with stickness configuration
+	// StickySessionAffinitySession contains the StickyConfig object with stickiness configuration
 	SessionAffinity SessionAffinityConfig `json:"sessionAffinityConfig"`
 	// Consistent hashing by NGINX variable
 	UpstreamHashBy string `json:"upstream-hash-by,omitempty"`
@@ -215,13 +216,15 @@ type Endpoint struct {
 	// Port number of the TCP port
 	Port string `json:"port"`
 	// MaxFails returns the number of unsuccessful attempts to communicate
-	// allowed before this should be considered dow.
+	// allowed before this should be considered down.
 	// Setting 0 indicates that the check is performed by a Kubernetes probe
 	MaxFails int `json:"maxFails"`
 	// FailTimeout returns the time in seconds during which the specified number
 	// of unsuccessful attempts to communicate with the server should happen
 	// to consider the endpoint unavailable
 	FailTimeout int `json:"failTimeout"`
+	// Indicates whether or not this endpoint is currently draining (not available or terminating)
+	Draining bool `json:"draining"`
 	// Target returns a reference to the object providing the endpoint
 	Target *apiv1.ObjectReference `json:"target,omitempty"`
 }

--- a/pkg/common/ingress/types_equals.go
+++ b/pkg/common/ingress/types_equals.go
@@ -256,6 +256,9 @@ func (e1 *Endpoint) Equal(e2 *Endpoint) bool {
 	if e1.FailTimeout != e2.FailTimeout {
 		return false
 	}
+	if e1.Draining != e2.Draining {
+		return false
+	}
 
 	if e1.Target != e2.Target {
 		if e1.Target == nil || e2.Target == nil {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -111,6 +111,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		HTTPLogFormat:               "",
 		HTTPSLogFormat:              "",
 		TCPLogFormat:                "",
+		DrainSupport:                false,
 	}
 	if haproxyController.configMap != nil {
 		utils.MergeMap(haproxyController.configMap.Data, &conf)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -140,6 +140,7 @@ func (haproxy *HAProxyController) DefaultEndpoint() ingress.Endpoint {
 	return ingress.Endpoint{
 		Address: "127.0.0.1",
 		Port:    "8181",
+		Draining:false,
 		Target:  &api.ObjectReference{},
 	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -156,6 +156,13 @@ func (haproxy *HAProxyController) DefaultEndpoint() ingress.Endpoint {
 	}
 }
 
+// Indicates whether or not this controller supports a "drain" mode where unavailable
+// and terminating pods are included in the list of returned pods and used to direct
+// certain traffic (e.g., traffic using persistence) to terminating/unavailable pods.
+func (haproxy *HAProxyController) DrainSupport() bool {
+	return haproxy.currentConfig.Cfg.DrainSupport
+}
+
 // OnUpdate regenerate the configuration file of the backend
 func (haproxy *HAProxyController) OnUpdate(cfg ingress.Configuration) error {
 	updatedConfig := newControllerConfig(&cfg, haproxy)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -159,8 +159,11 @@ func (haproxy *HAProxyController) DefaultEndpoint() ingress.Endpoint {
 // Indicates whether or not this controller supports a "drain" mode where unavailable
 // and terminating pods are included in the list of returned pods and used to direct
 // certain traffic (e.g., traffic using persistence) to terminating/unavailable pods.
-func (haproxy *HAProxyController) DrainSupport() bool {
-	return haproxy.currentConfig.Cfg.DrainSupport
+func (haproxy *HAProxyController) DrainSupport() (drainSupport bool) {
+	if haproxy.currentConfig != nil {
+		drainSupport = haproxy.currentConfig.Cfg.DrainSupport
+	}
+	return
 }
 
 // OnUpdate regenerate the configuration file of the backend

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -77,6 +77,7 @@ type (
 		HTTPLogFormat               string `json:"http-log-format"`
 		HTTPSLogFormat              string `json:"https-log-format"`
 		TCPLogFormat                string `json:"tcp-log-format"`
+		DrainSupport				bool   `json:"drain-support"`
 	}
 	// Userlist list of users for basic authentication
 	Userlist struct {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -26,7 +26,11 @@ defaults
 {{- if $cfg.LoadServerState }}
     load-server-state-from-file global
 {{- end }}
+{{- if $cfg.DrainSupport }}
+    option persist
+{{- else }}
     option redispatch
+{{- end }}
     option dontlognull
     option http-server-close
     option http-keep-alive
@@ -93,7 +97,7 @@ backend {{ $backend.Name }}
 {{- end }}
 {{- $BackendSlots := index $ing.BackendSlots $backend.Name }}
 {{- range $target, $slot := $BackendSlots.FullSlots }}
-    server {{ $slot.BackendServerName }} {{ $target }} {{ if $backend.Secure }}ssl {{ if ne $cacert.CAFileName "" }}verify required ca-file {{ $cacert.CAFileName }} {{ else }}verify none {{ end }}{{ end }}check port {{ $slot.BackendEndpoint.Port }} inter {{ $cfg.BackendCheckInterval }}{{ if eq $sticky.AffinityType "cookie" }} cookie {{ backendHash $slot.BackendServerName }}{{ end }}
+    server {{ $slot.BackendServerName }} {{ $target }} {{ if $backend.Secure }}ssl {{ if ne $cacert.CAFileName "" }}verify required ca-file {{ $cacert.CAFileName }} {{ else }}verify none {{ end }}{{ end }}{{ if $cfg.DrainSupport }}weight {{ if $slot.BackendEndpoint.Draining }}0 {{ else }}100 {{ end }}{{ end }}check port {{ $slot.BackendEndpoint.Port }} inter {{ $cfg.BackendCheckInterval }}{{ if eq $sticky.AffinityType "cookie" }} cookie {{ backendHash $slot.BackendServerName }}{{ end }}
 {{- end }}
 {{- range $empty := $BackendSlots.EmptySlots }}
     server {{ $empty }} 127.0.0.1:81 {{ if $backend.Secure }}ssl {{ if ne $cacert.CAFileName "" }}verify required ca-file {{ $cacert.CAFileName }} {{ else }}verify none {{ end }}{{ end }}check disabled inter {{ $cfg.BackendCheckInterval }}{{ if eq $sticky.AffinityType "cookie" }} cookie {{ backendHash $empty }}{{ end }}

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/BUILD
@@ -1,0 +1,33 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "well_known_annotations.go",
+        "well_known_labels.go",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//pkg/kubelet/apis/cri:all-srcs",
+        "//pkg/kubelet/apis/deviceplugin/v1alpha1:all-srcs",
+        "//pkg/kubelet/apis/kubeletconfig:all-srcs",
+        "//pkg/kubelet/apis/stats/v1alpha1:all-srcs",
+    ],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/well_known_annotations.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/well_known_annotations.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+const (
+	// When kubelet is started with the "external" cloud provider, then
+	// it sets this annotation on the node to denote an ip address set from the
+	// cmd line flag. This ip is verified with the cloudprovider as valid by
+	// the cloud-controller-manager
+	AnnotationProvidedIPAddr = "alpha.kubernetes.io/provided-node-ip"
+)

--- a/vendor/k8s.io/kubernetes/pkg/kubelet/apis/well_known_labels.go
+++ b/vendor/k8s.io/kubernetes/pkg/kubelet/apis/well_known_labels.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apis
+
+const (
+	LabelHostname           = "kubernetes.io/hostname"
+	LabelZoneFailureDomain  = "failure-domain.beta.kubernetes.io/zone"
+	LabelMultiZoneDelimiter = "__"
+	LabelZoneRegion         = "failure-domain.beta.kubernetes.io/region"
+
+	LabelInstanceType = "beta.kubernetes.io/instance-type"
+
+	LabelOS   = "beta.kubernetes.io/os"
+	LabelArch = "beta.kubernetes.io/arch"
+)
+
+// When the --failure-domains scheduler flag is not specified,
+// DefaultFailureDomains defines the set of label keys used when TopologyKey is empty in PreferredDuringScheduling anti-affinity.
+var DefaultFailureDomains string = LabelHostname + "," + LabelZoneFailureDomain + "," + LabelZoneRegion

--- a/vendor/k8s.io/kubernetes/pkg/util/node/BUILD
+++ b/vendor/k8s.io/kubernetes/pkg/util/node/BUILD
@@ -1,0 +1,47 @@
+package(default_visibility = ["//visibility:public"])
+
+load(
+    "@io_bazel_rules_go//go:def.bzl",
+    "go_library",
+    "go_test",
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["node.go"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/kubelet/apis:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/strategicpatch:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["node_test.go"],
+    library = ":go_default_library",
+    deps = [
+        "//pkg/kubelet/apis:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+)

--- a/vendor/k8s.io/kubernetes/pkg/util/node/node.go
+++ b/vendor/k8s.io/kubernetes/pkg/util/node/node.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
+	clientset "k8s.io/client-go/kubernetes"
+	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/kubernetes/pkg/api"
+	kubeletapis "k8s.io/kubernetes/pkg/kubelet/apis"
+)
+
+const (
+	// The reason and message set on a pod when its state cannot be confirmed as kubelet is unresponsive
+	// on the node it is (was) running.
+	NodeUnreachablePodReason  = "NodeLost"
+	NodeUnreachablePodMessage = "Node %v which was running pod %v is unresponsive"
+)
+
+// GetHostname returns OS's hostname if 'hostnameOverride' is empty; otherwise, return 'hostnameOverride'.
+func GetHostname(hostnameOverride string) string {
+	hostname := hostnameOverride
+	if hostname == "" {
+		nodename, err := os.Hostname()
+		if err != nil {
+			glog.Fatalf("Couldn't determine hostname: %v", err)
+		}
+		hostname = nodename
+	}
+	return strings.ToLower(strings.TrimSpace(hostname))
+}
+
+// GetPreferredNodeAddress returns the address of the provided node, using the provided preference order.
+// If none of the preferred address types are found, an error is returned.
+func GetPreferredNodeAddress(node *v1.Node, preferredAddressTypes []v1.NodeAddressType) (string, error) {
+	for _, addressType := range preferredAddressTypes {
+		for _, address := range node.Status.Addresses {
+			if address.Type == addressType {
+				return address.Address, nil
+			}
+		}
+		// If hostname was requested and no Hostname address was registered...
+		if addressType == v1.NodeHostName {
+			// ...fall back to the kubernetes.io/hostname label for compatibility with kubelets before 1.5
+			if hostname, ok := node.Labels[kubeletapis.LabelHostname]; ok && len(hostname) > 0 {
+				return hostname, nil
+			}
+		}
+	}
+	return "", fmt.Errorf("no preferred addresses found; known addresses: %v", node.Status.Addresses)
+}
+
+// GetNodeHostIP returns the provided node's IP, based on the priority:
+// 1. NodeInternalIP
+// 2. NodeExternalIP
+func GetNodeHostIP(node *v1.Node) (net.IP, error) {
+	addresses := node.Status.Addresses
+	addressMap := make(map[v1.NodeAddressType][]v1.NodeAddress)
+	for i := range addresses {
+		addressMap[addresses[i].Type] = append(addressMap[addresses[i].Type], addresses[i])
+	}
+	if addresses, ok := addressMap[v1.NodeInternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	if addresses, ok := addressMap[v1.NodeExternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	return nil, fmt.Errorf("host IP unknown; known addresses: %v", addresses)
+}
+
+// InternalGetNodeHostIP returns the provided node's IP, based on the priority:
+// 1. NodeInternalIP
+// 2. NodeExternalIP
+func InternalGetNodeHostIP(node *api.Node) (net.IP, error) {
+	addresses := node.Status.Addresses
+	addressMap := make(map[api.NodeAddressType][]api.NodeAddress)
+	for i := range addresses {
+		addressMap[addresses[i].Type] = append(addressMap[addresses[i].Type], addresses[i])
+	}
+	if addresses, ok := addressMap[api.NodeInternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	if addresses, ok := addressMap[api.NodeExternalIP]; ok {
+		return net.ParseIP(addresses[0].Address), nil
+	}
+	return nil, fmt.Errorf("host IP unknown; known addresses: %v", addresses)
+}
+
+// GetZoneKey is a helper function that builds a string identifier that is unique per failure-zone;
+// it returns empty-string for no zone.
+func GetZoneKey(node *v1.Node) string {
+	labels := node.Labels
+	if labels == nil {
+		return ""
+	}
+
+	region, _ := labels[kubeletapis.LabelZoneRegion]
+	failureDomain, _ := labels[kubeletapis.LabelZoneFailureDomain]
+
+	if region == "" && failureDomain == "" {
+		return ""
+	}
+
+	// We include the null character just in case region or failureDomain has a colon
+	// (We do assume there's no null characters in a region or failureDomain)
+	// As a nice side-benefit, the null character is not printed by fmt.Print or glog
+	return region + ":\x00:" + failureDomain
+}
+
+// SetNodeCondition updates specific node condition with patch operation.
+func SetNodeCondition(c clientset.Interface, node types.NodeName, condition v1.NodeCondition) error {
+	generatePatch := func(condition v1.NodeCondition) ([]byte, error) {
+		raw, err := json.Marshal(&[]v1.NodeCondition{condition})
+		if err != nil {
+			return nil, err
+		}
+		return []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, raw)), nil
+	}
+	condition.LastHeartbeatTime = metav1.NewTime(time.Now())
+	patch, err := generatePatch(condition)
+	if err != nil {
+		return nil
+	}
+	_, err = c.Core().Nodes().PatchStatus(string(node), patch)
+	return err
+}
+
+// PatchNodeStatus patches node status.
+func PatchNodeStatus(c v1core.CoreV1Interface, nodeName types.NodeName, oldNode *v1.Node, newNode *v1.Node) (*v1.Node, error) {
+	oldData, err := json.Marshal(oldNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal old node %#v for node %q: %v", oldNode, nodeName, err)
+	}
+
+	// Reset spec to make sure only patch for Status or ObjectMeta is generated.
+	// Note that we don't reset ObjectMeta here, because:
+	// 1. This aligns with Nodes().UpdateStatus().
+	// 2. Some component does use this to update node annotations.
+	newNode.Spec = oldNode.Spec
+	newData, err := json.Marshal(newNode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal new node %#v for node %q: %v", newNode, nodeName, err)
+	}
+
+	patchBytes, err := strategicpatch.CreateTwoWayMergePatch(oldData, newData, v1.Node{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create patch for node %q: %v", nodeName, err)
+	}
+
+	updatedNode, err := c.Nodes().Patch(string(nodeName), types.StrategicMergePatchType, patchBytes, "status")
+	if err != nil {
+		return nil, fmt.Errorf("failed to patch status %q for node %q: %v", patchBytes, nodeName, err)
+	}
+	return updatedNode, nil
+}


### PR DESCRIPTION
When a pod starts terminating or the readiness check fails, leave the pod as a service
in the load balancer, but set its weight to 0 so that HAProxy does not send ordinary
traffic to the pod. Traffic using persistence, however, will be directed to the terminating
pods. This allows persistent requests to continue to flow to a terminating pod. Updates to
only the draining state are made using the stats socket rather than forcing a full reload
of HAProxy.

This PR includes the described change, as well as a few fixes for typos I found along the way, and clearing up some warnings IntelliJ was showing (e.g., initializing slices with empty literal instead of nil, error messages starting with a capital letter).

I have a use case for pods having a long termination period and new requests with a cookie need to be directed to terminating servers during this period. I was thinking this could potentially be useful for other people too, but can always keep in a fork if you don't think it fits.