### PR TITLE
Use pidof to ensure all previous haproxy processes are shutdown

### DIFF
--- a/rootfs/haproxy-reload.sh
+++ b/rootfs/haproxy-reload.sh
@@ -49,12 +49,12 @@ case "$1" in
     native)
         CONFIG="$2"
         HAPROXY_PID=/var/run/haproxy.pid
-        haproxy -f "$CONFIG" -p "$HAPROXY_PID" -D -sf $(cat "$HAPROXY_PID" 2>/dev/null || :)
+        haproxy -f "$CONFIG" -p "$HAPROXY_PID" -D -sf $(pidof haproxy 2>/dev/null || :)
         ;;
     reusesocket)
         CONFIG="$2"
         HAPROXY_PID=/var/run/haproxy.pid
-        OLD_PID=$(cat "$HAPROXY_PID" 2>/dev/null || :)
+        OLD_PID=$(pidof haproxy 2>/dev/null || :)
         if [ -S "$HAPROXY_SOCKET" ]; then
             haproxy -f "$CONFIG" -p "$HAPROXY_PID" -sf $OLD_PID -x "$HAPROXY_SOCKET"
         else


### PR DESCRIPTION
This more closely matches [haproxy's documentation of the -sf option](https://cbonte.github.io/haproxy-dconv/1.8/management.html#3), as well as potentially being more safe because each new haproxy process ensures all previous processes sockets are transferred.