### PR TITLE
Add support for Http 2 connections

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -264,7 +264,7 @@ frontend httpfront-{{ $host }}
 {{- if ne $authSSLCert.PemSHA "" }}
     # CA PEM checksum: {{ $authSSLCert.PemSHA }}
 {{- end }}
-    bind unix@/var/run/haproxy-https-{{ $sock }}.sock ssl crt {{ $server.SSLCertificate }}{{ if ne $authSSLCert.CAFileName "" }} ca-file {{ $authSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
+    bind unix@/var/run/haproxy-https-{{ $sock }}.sock ssl crt {{ $server.SSLCertificate }} alpn h2,http/1.1{{ if ne $authSSLCert.CAFileName "" }} ca-file {{ $authSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
 {{- end }}
     mode http
 


### PR DESCRIPTION
Update haproxy.tmpl to accept http2 and http 1.1 connections.

Allow H2 connections to be accepted in addition to HTTP 1.1 connections.
Information about HAProxy 1.8 HTTP 2 support is available [here](https://www.haproxy.com/blog/whats-new-haproxy-1-8/).

A very small change providing nice performance wins.