### PR TITLE
Avoid reload when shrinking backend slots

### DIFF
--- a/pkg/controller/stats_socket.go
+++ b/pkg/controller/stats_socket.go
@@ -152,7 +152,7 @@ func reconfigureBackends(currentConfig, updatedConfig *types.ControllerConfig) b
 				for _, backendName := range curKeys {
 					updLen := len(updBackendsMap[backendName].Endpoints)
 					totalSlots := len(currentConfig.BackendSlots[backendName].EmptySlots) + len(currentConfig.BackendSlots[backendName].FullSlots)
-					if updLen > totalSlots || updLen < (totalSlots-updatedConfig.Cfg.BackendServerSlotsIncrement) {
+					if updLen > totalSlots {
 						// need to resize number of empty slots by BackendServerSlotsIncrement amount
 						reconfigureEmptySlots = true
 					} else {


### PR DESCRIPTION
This changes the condition used to reload the server because of resizing of the backend slots. If the slots need to be shrinked the reload is skipped. They will be shrinked anyway if the server need to be reloaded for any other reason.