### PR TITLE
Change equality of drain-support and dynamic-scaling

### DIFF
--- a/pkg/common/ingress/types_equals.go
+++ b/pkg/common/ingress/types_equals.go
@@ -259,19 +259,6 @@ func (e1 *Endpoint) Equal(e2 *Endpoint) bool {
 	if e1.Draining != e2.Draining {
 		return false
 	}
-
-	if e1.Target != e2.Target {
-		if e1.Target == nil || e2.Target == nil {
-			return false
-		}
-		if e1.Target.UID != e2.Target.UID {
-			return false
-		}
-		if e1.Target.ResourceVersion != e2.Target.ResourceVersion {
-			return false
-		}
-	}
-
 	return true
 }
 

--- a/pkg/common/utils/utils.go
+++ b/pkg/common/utils/utils.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"reflect"
+)
+
+// DeepEqualUnsorted check equality of unsorted arrays.
+// Panic if p1 or p2 isn't array
+func DeepEqualUnsorted(p1, p2 interface{}, equal func(i1, i2 int) bool) bool {
+	v1 := reflect.ValueOf(p1)
+	v2 := reflect.ValueOf(p2)
+	if v1.Len() != v2.Len() {
+		return false
+	}
+	for i1 := 0; i1 < v1.Len(); i1++ {
+		found := false
+		for i2 := 0; i2 < v2.Len(); i2++ {
+			if equal(i1, i2) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/common/utils/utils_test.go
+++ b/pkg/common/utils/utils_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"testing"
+)
+
+func TestDeepEqualUnsortedMatch(t *testing.T) {
+	a1 := []string{"a", "b", "c"}
+	a2 := []string{"c", "a", "b"}
+	if !DeepEqualUnsorted(a1, a2, func(i1, i2 int) bool {
+		return a1[i1] == a2[i2]
+	}) {
+		t.Errorf("expected a1 and a2 equals")
+	}
+
+	a3 := []string{"1", "2", "3"}
+	a4 := []string{"1", "2", "3"}
+	if !DeepEqualUnsorted(a3, a4, func(i1, i2 int) bool {
+		return a4[i1] == a4[i2]
+	}) {
+		t.Errorf("expected a3 and a4 equals")
+	}
+}
+
+func TestDeepEqualUnsortedUnmatch(t *testing.T) {
+	a1 := []string{"a", "b", "c"}
+	a2 := []string{"a", "b", "d"}
+	if DeepEqualUnsorted(a1, a2, func(i1, i2 int) bool {
+		return a1[i1] == a2[i2]
+	}) {
+		t.Errorf("expected a1 and a2 not equals")
+	}
+
+	a3 := []string{"1", "2", "3"}
+	a4 := []string{"1", "2", "2", "3"}
+	if DeepEqualUnsorted(a3, a4, func(i1, i2 int) bool {
+		return a4[i1] == a4[i2]
+	}) {
+		t.Errorf("expected a3 and a4 not equals")
+	}
+}

--- a/pkg/types/equal.go
+++ b/pkg/types/equal.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/utils"
+	"reflect"
+)
+
+// Equal return the equality between two ControllerConfig
+func (c1 *ControllerConfig) Equal(c2 *ControllerConfig) bool {
+	if c1 == nil || c2 == nil {
+		return c1 == c2
+	}
+	// diffing only source of data: Backends, Servers, TCPEndpoints and PassthroughBackends
+	// TODO: move them to a single IngressConfig field
+	if !utils.DeepEqualUnsorted(c1.Backends, c2.Backends, func(i1, i2 int) bool {
+		return c1.Backends[i1].Equal(c2.Backends[i2])
+	}) {
+		return false
+	}
+	if !utils.DeepEqualUnsorted(c1.Servers, c2.Servers, func(i1, i2 int) bool {
+		return c1.Servers[i1].Equal(c2.Servers[i2])
+	}) {
+		return false
+	}
+	if !utils.DeepEqualUnsorted(c1.TCPEndpoints, c2.TCPEndpoints, func(i1, i2 int) bool {
+		return c1.TCPEndpoints[i1].Equal(&c2.TCPEndpoints[i2])
+	}) {
+		return false
+	}
+	if !utils.DeepEqualUnsorted(c1.PassthroughBackends, c2.PassthroughBackends, func(i1, i2 int) bool {
+		return c1.PassthroughBackends[i1].Equal(c2.PassthroughBackends[i2])
+	}) {
+		return false
+	}
+	if !reflect.DeepEqual(c1.Cfg, c2.Cfg) {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
Changing the implementation of equality and partial equality of ingress config structs

* Changes are related with `dynamic-scaling` and `drain-support`
* Remove changing comparison of `Endpoint.Target` field
* Move from `DeepEqual` to `.Equal` func on ingress config struct, removing issues with internal states of k8s objects and unsorted arrays
* Usage of a cloned object `configCopy` for partial equality on behalf of visibility of what isn't being compared
* A new func `DeepEqualUnsorted` used to compare unsorted arrays
