### PR TITLE
Remove multibinder, change it to an alias of reusesocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ The following command-line arguments are supported:
 ||[`ingress-class`](#ingress-class)|name|`haproxy`|
 ||[`kubeconfig`](#kubeconfig)|/path/to/kubeconfig|in cluster config|
 |`[0]`|[`rate-limit-update`](#rate-limit-update)|uploads per second (float)|`0.5`|
-||[`reload-strategy`](#reload-strategy)|[native\|multibinder]|`native`|
+||[`reload-strategy`](#reload-strategy)|[native\|reusesocket\|multibinder]|`native`|
 ||[`sort-backends`](#sort-backends)|[true\|false]|`false`|
 |`[0]`|[`tcp-services-configmap`](#tcp-services-configmap)|namespace/configmapname|no tcp svc|
 |`[0]`|[`verify-hostname`](#verify-hostname)|[true\|false]|`true`|
@@ -518,7 +518,7 @@ HAProxy should use. The following options are available:
 
 * `native`: Uses native HAProxy reload option `-sf`. This is the default option.
 * `reusesocket`: (starting on v0.6) Uses HAProxy `-x` command-line option to pass the listening sockets between old and new HAProxy process, allowing hitless reloads.
-* `multibinder`: Uses GitHub's [multibinder](https://github.com/github/multibinder). This [link](https://githubengineering.com/glb-part-2-haproxy-zero-downtime-zero-delay-reloads-with-multibinder/)
+* `multibinder`: (deprecated on v0.6) Uses GitHub's [multibinder](https://github.com/github/multibinder). This [link](https://githubengineering.com/glb-part-2-haproxy-zero-downtime-zero-delay-reloads-with-multibinder/)
 describes how it works.
 
 ### sort-backends

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,8 +13,7 @@
 # limitations under the License.
 
 FROM haproxy:1.8-alpine
-RUN apk --no-cache add socat openssl ruby ruby-json\
- && gem install --no-ri --no-rdoc multibinder:0.0.5
+RUN apk --no-cache add socat openssl
 
 # dumb-init kindly manages SIGCHLD from forked HAProxy processes
 ARG DUMB_INIT_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363

--- a/rootfs/haproxy-reload.sh
+++ b/rootfs/haproxy-reload.sh
@@ -23,9 +23,6 @@
 #  reusesocket <.cfg>
 #    Pass the listening sockets to the new HAProxy process instead of
 #    rebinding them, allowing hitless reloads.
-#  multibinder <.cfg.erb>
-#    Used on multibinder deployment. Send USR2 to the
-#    multibinder-haproxy-wrapper process.
 #
 # HAProxy options:
 #  -f config file
@@ -51,7 +48,8 @@ case "$1" in
         HAPROXY_PID=/var/run/haproxy.pid
         haproxy -f "$CONFIG" -p "$HAPROXY_PID" -D -sf $(cat "$HAPROXY_PID" 2>/dev/null || :)
         ;;
-    reusesocket)
+    reusesocket|multibinder)
+        # multibinder is now deprecated and, if used, is an alias to reusesocket
         CONFIG="$2"
         HAPROXY_PID=/var/run/haproxy.pid
         OLD_PID=$(cat "$HAPROXY_PID" 2>/dev/null || :)
@@ -60,12 +58,6 @@ case "$1" in
         else
             haproxy -f "$CONFIG" -p "$HAPROXY_PID" -sf $OLD_PID
         fi
-        ;;
-    multibinder)
-        HAPROXY=/usr/local/sbin/haproxy
-        CONFIG="$2"
-        WRAPPER_PID=/var/run/wrapper.pid
-        kill -USR2 $(cat "$WRAPPER_PID")
         ;;
     *)
         echo "Unsupported reload strategy: $1"

--- a/rootfs/start.sh
+++ b/rootfs/start.sh
@@ -16,73 +16,9 @@
 
 set -e
 
-init() {
-    if [ $# -gt 0 ] && [ "$(echo $1 | cut -b1-2)" != "--" ]; then
-        exec "$@"
-        exit 0
-    fi
-    reloadStrategy=$(
-        echo "$*" | sed -nr 's/.*--reload-strategy[ =]([^ ]+).*/\1/p'
-    )
-    reloadStrategy="${reloadStrategy:-native}"
-    case "$reloadStrategy" in
-        native|reusesocket)
-            ;;
-        multibinder)
-            HAPROXY=/usr/local/sbin/haproxy
-            TEMPLATE=/etc/haproxy/template/haproxy.tmpl
-            CONFIG=/etc/haproxy/haproxy.cfg.erb
-            WRAPPER_PID=/var/run/wrapper.pid
-            HAPROXY_PID=/var/run/haproxy.pid
-            create_erb
-            start_multibinder
-            ;;
-        *)
-            echo "Unsupported reload strategy: $reloadStrategy"
-            exit 1
-            ;;
-    esac
-    echo "Reload strategy: $reloadStrategy"
+if [ $# -gt 0 ] && [ "$(echo $1 | cut -b1-2)" != "--" ]; then
+    # Probably a `docker run -ti`, so exec and exit
+    exec "$@"
+else
     exec /haproxy-ingress-controller "$@"
-}
-
-create_erb() {
-    # Create a minimal valid starting configuration file
-    cat > "$CONFIG" <<EOF
-global
-    daemon
-listen main
-    bind unix@/var/run/haproxy-tmp.sock
-    timeout client 1s
-    timeout connect 1s
-    timeout server 1s
-EOF
-
-    # Add erb code to a new template file
-    # - [0-9]* will match actual ports, for example 443 in bind *:443
-    # - {{[^}]*}} will match when the port is templatized, for example {{ $cfg.StatsPort }} in bind *:{{ $cfg.StatsPort }}
-    sed "/^    bind \+\*\?:/s/\*\?:\(\([0-9]*\)\|\({{[^}]*}}\)\)/<%= bind_tcp('0.0.0.0', \1) %>/" \
-        "$TEMPLATE" > "${CONFIG}.tmpl"
-}
-
-start_multibinder() {
-    # Start multibinder
-    export MULTIBINDER_SOCK=/run/multibinder.sock
-    multibinder "$MULTIBINDER_SOCK" &
-    multibinder_pid=$!
-
-    # Wait for socket
-    while [ ! -S "$MULTIBINDER_SOCK" ]; do
-        sleep 1
-    done
-
-    # Create initial config
-    multibinder-haproxy-erb "$HAPROXY" -f "$CONFIG" -c -q
-
-    # Start HAProxy
-    multibinder-haproxy-wrapper "$HAPROXY" -Ds -f "$CONFIG" -p "$HAPROXY_PID" &
-    wrapper_pid=$!
-    echo $wrapper_pid > "$WRAPPER_PID"
-}
-
-init "$@"
+fi


### PR DESCRIPTION
GitHub's multibinder [isn't compatible with HAProxy 1.8](https://github.com/github/multibinder/issues/15). Since the new `-x` HAProxy command-line option uses the same strategy - reusing the same sockets between old and new HAProxy process, `multibinder` is being deprecated and removed on behalf of `reusesocket` reload-strategy. If the user points the reload-strategy to multibinder, he will be warned (logs) and reusesocket will be used instead.