### PR TITLE
Add maxconn to defaults as well as global

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -26,6 +26,7 @@ defaults
 {{- if $cfg.LoadServerState }}
     load-server-state-from-file global
 {{- end }}
+    maxconn {{ $cfg.MaxConn }}
 {{- if $cfg.DrainSupport }}
     option persist
 {{- else }}


### PR DESCRIPTION
This applies the same `maxconn` settings to each proxy in addition to
the global `maxconn` setting.

Could fix https://github.com/jcmoraisjr/haproxy-ingress/issues/114
