### PR TITLE
Fix precedence on hosts/alias without regexp

### DIFF
--- a/pkg/controller/template.go
+++ b/pkg/controller/template.go
@@ -71,12 +71,6 @@ var funcMap = gotemplate.FuncMap{
 		rtn := regexp.MustCompile(`\.`).ReplaceAllLiteralString(hostname, "\\.")
 		return "^" + rtn + "(:[0-9]+)?$"
 	},
-	"isWildcardHostname": func(identifier string) bool {
-		return regexp.MustCompile(`^\*\.`).MatchString(identifier)
-	},
-	"isRegexHostname": func(identifier string) bool {
-		return !regexp.MustCompile(`^[a-zA-Z0-9\-.]+$`).MatchString(identifier)
-	},
 	"sizeSuffix": func(size string) string {
 		value, err := utils.SizeSuffixToInt64(size)
 		if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -100,23 +100,25 @@ type (
 	// HAProxyServer and HAProxyLocation build some missing pieces
 	// from ingress.Server used by HAProxy
 	HAProxyServer struct {
-		IsDefaultServer bool                  `json:"isDefaultServer"`
-		IsCACert        bool                  `json:"isCACert"`
-		UseHTTP         bool                  `json:"useHTTP"`
-		UseHTTPS        bool                  `json:"useHTTPS"`
-		Hostname        string                `json:"hostname"`
-		HostnameLabel   string                `json:"hostnameLabel"`
-		HostnameSocket  string                `json:"hostnameSocket"`
-		ACLLabel        string                `json:"aclLabel"`
-		SSLCertificate  string                `json:"sslCertificate"`
-		SSLPemChecksum  string                `json:"sslPemChecksum"`
-		RootLocation    *HAProxyLocation      `json:"defaultLocation"`
-		Locations       []*HAProxyLocation    `json:"locations,omitempty"`
-		SSLRedirect     bool                  `json:"sslRedirect"`
-		HSTS            *hsts.Config          `json:"hsts"`
-		HasRateLimit    bool                  `json:"hasRateLimit"`
-		CertificateAuth authtls.AuthSSLConfig `json:"certificateAuth,omitempty"`
-		Alias           string                `json:"alias,omitempty"`
+		IsDefaultServer    bool                  `json:"isDefaultServer"`
+		IsCACert           bool                  `json:"isCACert"`
+		UseHTTP            bool                  `json:"useHTTP"`
+		UseHTTPS           bool                  `json:"useHTTPS"`
+		Hostname           string                `json:"hostname"`
+		HostnameIsWildcard bool                  `json:"hostnameIsWildcard"`
+		HostnameLabel      string                `json:"hostnameLabel"`
+		HostnameSocket     string                `json:"hostnameSocket"`
+		ACLLabel           string                `json:"aclLabel"`
+		SSLCertificate     string                `json:"sslCertificate"`
+		SSLPemChecksum     string                `json:"sslPemChecksum"`
+		RootLocation       *HAProxyLocation      `json:"defaultLocation"`
+		Locations          []*HAProxyLocation    `json:"locations,omitempty"`
+		SSLRedirect        bool                  `json:"sslRedirect"`
+		HSTS               *hsts.Config          `json:"hsts"`
+		HasRateLimit       bool                  `json:"hasRateLimit"`
+		CertificateAuth    authtls.AuthSSLConfig `json:"certificateAuth,omitempty"`
+		Alias              string                `json:"alias,omitempty"`
+		AliasIsRegex       bool                  `json:"aliasIsRegex"`
 	}
 	// HAProxyLocation has location data as a HAProxy friendly syntax
 	HAProxyLocation struct {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -399,13 +399,13 @@ frontend httpfront-{{ if $isShared }}shared-frontend{{ else if $isDefault }}defa
 {{- $fetch := .p3 }}
 {{- $needport := .p4 }}
 {{- if ne $server.ACLLabel "" }}
-{{- if isWildcardHostname $server.Hostname }}
+{{- if $server.HostnameIsWildcard }}
     acl {{ $server.ACLLabel }} {{ $fetch }} -m reg -i {{ hostnameRegex $server.Hostname }}
 {{- else }}
     acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.Hostname }}{{ if $needport }} {{ $server.Hostname }}:80 {{ $server.Hostname }}:443{{ if and $cfg.HTTPStoHTTPPort (ne $cfg.HTTPStoHTTPPort 80) }} {{ $server.Hostname }}:{{ $cfg.HTTPStoHTTPPort }}{{ end }}{{ end }}
 {{- end }}
 {{- if ne $server.Alias "" }}
-{{- if isRegexHostname $server.Alias }}
+{{- if $server.AliasIsRegex }}
     acl {{ $server.ACLLabel }} {{ $fetch }} -m reg -i '{{ aliasRegex $server.Alias }}'
 {{- else }}
     acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.Alias }}{{ if $needport }} {{ $server.Alias }}:80 {{ $server.Alias }}:443{{ end }}


### PR DESCRIPTION
Give precedence on hosts without wildcard and alias without regex.

Implements #147.