### PR TITLE
Timeout stop configmap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ The following parameters are supported:
 ||[`timeout-keep-alive`](#timeout)|time with suffix|`1m`|
 ||[`timeout-server`](#timeout)|time with suffix|`50s`|
 ||[`timeout-server-fin`](#timeout)|time with suffix|`50s`|
+|`[1]`|[`timeout-stop`](#timeout)|time with suffix|no timeout|
 ||[`timeout-tunnel`](#timeout)|time with suffix|`1h`|
 |`[0]`|[`use-host-on-https`](#use-host-on-https)|[true\|false]|`false`|
 ||[`use-proxy-protocol`](#use-proxy-protocol)|[true\|false]|`false`|
@@ -453,7 +454,12 @@ Define timeout configurations:
 * `timeout-keep-alive`: Maximum time to wait for a new HTTP request on keep-alive connections
 * `timeout-server`: Maximum inactivity time on the backend side
 * `timeout-server-fin`: Maximum inactivity time on the backend side for half-closed connections - FIN_WAIT state
+* `timeout-stop`: Maximum time to wait for long lived connections to finish, eg websocket, before hard-stop a HAProxy process due to a reload
 * `timeout-tunnel`: Maximum inactivity time on the client and backend side for tunnels
+
+Docs:
+
+* `timeout-stop` - http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#3.1-hard-stop-after
 
 ### use-host-on-https
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -95,6 +95,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		TimeoutClientFin:            "50s",
 		TimeoutServer:               "50s",
 		TimeoutServerFin:            "50s",
+		TimeoutStop:                 "",
 		TimeoutTunnel:               "1h",
 		TimeoutKeepAlive:            "1m",
 		Syslog:                      "",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -55,6 +55,7 @@ type (
 		TimeoutClientFin            string `json:"timeout-client-fin"`
 		TimeoutServer               string `json:"timeout-server"`
 		TimeoutServerFin            string `json:"timeout-server-fin"`
+		TimeoutStop                 string `json:"timeout-stop"`
 		TimeoutTunnel               string `json:"timeout-tunnel"`
 		TimeoutKeepAlive            string `json:"timeout-keep-alive"`
 		Syslog                      string `json:"syslog-endpoint"`

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -8,6 +8,9 @@ global
     server-state-base /var/lib/haproxy/
 {{- end}}
     maxconn {{ $cfg.MaxConn }}
+{{- if ne $cfg.TimeoutStop "" }}
+    hard-stop-after {{ $cfg.TimeoutStop }}
+{{- end }}
 {{- if ne $cfg.Syslog "" }}
     log {{ $cfg.Syslog }} format rfc5424 local0
     log-tag ingress


### PR DESCRIPTION
Add `timeout-stop` configmap option - time to wait for long lived connections to finish before perform a hard-stop.