### PR TITLE
Add valid CIDRs on whitelists

### DIFF
--- a/pkg/common/ingress/annotations/ipwhitelist/main_test.go
+++ b/pkg/common/ingress/annotations/ipwhitelist/main_test.go
@@ -86,12 +86,12 @@ func TestParseAnnotations(t *testing.T) {
 		"test parse a invalid net": {
 			net:       "ww",
 			expectErr: true,
-			errOut:    "the annotation does not contain a valid IP address or network: invalid CIDR address: ww",
+			errOut:    "the annotation does not contain a valid IP address or network: invalid CIDR or IP address: ww",
 		},
 		"test parse a empty net": {
 			net:       "",
 			expectErr: true,
-			errOut:    "the annotation does not contain a valid IP address or network: invalid CIDR address: ",
+			errOut:    "the annotation does not contain a valid IP address or network: invalid CIDR or IP address: ",
 		},
 		"test parse multiple valid cidr": {
 			net:        "2.2.2.2/32,1.1.1.1/32,3.3.3.0/24",
@@ -146,12 +146,12 @@ func TestParseAnnotationsWithDefaultConfig(t *testing.T) {
 		"test parse a invalid net": {
 			net:       "ww",
 			expectErr: true,
-			errOut:    "the annotation does not contain a valid IP address or network: invalid CIDR address: ww",
+			errOut:    "the annotation does not contain a valid IP address or network: invalid CIDR or IP address: ww",
 		},
 		"test parse a empty net": {
 			net:       "",
 			expectErr: true,
-			errOut:    "the annotation does not contain a valid IP address or network: invalid CIDR address: ",
+			errOut:    "the annotation does not contain a valid IP address or network: invalid CIDR or IP address: ",
 		},
 		"test parse multiple valid cidr": {
 			net:        "2.2.2.2/32,1.1.1.1/32,3.3.3.0/24",

--- a/pkg/common/net/ipnet.go
+++ b/pkg/common/net/ipnet.go
@@ -17,6 +17,7 @@ limitations under the License.
 package net
 
 import (
+	"fmt"
 	"net"
 	"strings"
 )
@@ -31,6 +32,7 @@ type IP map[string]net.IP
 func ParseIPNets(specs ...string) (IPNet, IP, error) {
 	ipnetset := make(IPNet)
 	ipset := make(IP)
+	invalidSpec := []string{}
 
 	for _, spec := range specs {
 		spec = strings.TrimSpace(spec)
@@ -38,16 +40,19 @@ func ParseIPNets(specs ...string) (IPNet, IP, error) {
 		if err != nil {
 			ip := net.ParseIP(spec)
 			if ip == nil {
-				return nil, nil, err
+				invalidSpec = append(invalidSpec, spec)
+				continue
 			}
 			i := ip.String()
 			ipset[i] = ip
 			continue
 		}
-
 		k := ipnet.String()
 		ipnetset[k] = ipnet
 	}
 
+	if len(invalidSpec) > 0 {
+		return ipnetset, ipset, fmt.Errorf("invalid CIDR or IP address: %v", strings.Join(invalidSpec, ", "))
+	}
 	return ipnetset, ipset, nil
 }

--- a/pkg/common/net/ipnet_test.go
+++ b/pkg/common/net/ipnet_test.go
@@ -26,9 +26,25 @@ func TestNewIPSet(t *testing.T) {
 		t.Errorf("error parsing IPNets: %v", err)
 	}
 	if len(ipsets) != 2 {
-		t.Errorf("Expected len=2: %d", len(ipsets))
+		t.Errorf("Expected len(ipsets)=2: %d", len(ipsets))
 	}
 	if len(ips) != 1 {
-		t.Errorf("Expected len=1: %d", len(ips))
+		t.Errorf("Expected len(ips)=1: %d", len(ips))
+	}
+}
+
+func TestPartialIPParsing(t *testing.T) {
+	ipsets, ips, err := ParseIPNets("1.355.0.0", "2.0.0.0/8", "3.0.0.0/33")
+	if err == nil {
+		t.Error("expected error parsing IPs")
+	}
+	if len(ipsets) != 1 {
+		t.Errorf("expected len(ipsets)=1: %d -- %v", len(ipsets), ipsets)
+	}
+	if _, ok := ipsets["2.0.0.0/8"]; !ok {
+		t.Errorf("expected ipsets['2.0.0.0/8'], was %v", ipsets)
+	}
+	if len(ips) != 0 {
+		t.Errorf("expected len(ips)=0: %d -- %v", len(ips), ips)
 	}
 }


### PR DESCRIPTION
Changes how CIDR list used on whitelists (source and ratelimit) are built. Now if a whitelist annotation has invalid CIDRs, at least the valid CIDRs will be applied. Before this PR the whitelist configuration would be removed.

Fix #86 