### PR TITLE
Add multi process and multi thread support

### DIFF
--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -48,6 +48,7 @@ type (
 		Cfg                 *HAProxyConfig
 		BackendSlots        map[string]*HAProxyBackendSlots
 		DNSResolvers        map[string]dnsresolvers.DNSResolver
+		Procs               *HAProxyProcs
 	}
 	// HAProxyConfig has HAProxy specific configurations from ConfigMap
 	HAProxyConfig struct {
@@ -55,6 +56,9 @@ type (
 		SSLCiphers             string `json:"ssl-ciphers"`
 		SSLOptions             string `json:"ssl-options"`
 		SSLDHParam             `json:",squash"`
+		NbprocBalance          int    `json:"nbproc-balance"`
+		NbprocSSL              int    `json:"nbproc-ssl"`
+		Nbthread               int    `json:"nbthread"`
 		LoadServerState        bool   `json:"load-server-state"`
 		TimeoutHTTPRequest     string `json:"timeout-http-request"`
 		TimeoutConnect         string `json:"timeout-connect"`
@@ -186,5 +190,15 @@ type (
 	HAProxyBackendSlot struct {
 		BackendServerName string
 		BackendEndpoint   *ingress.Endpoint
+	}
+	// HAProxyProcs process and thread related configuration
+	HAProxyProcs struct {
+		Nbproc          int
+		NbprocBalance   int
+		NbprocSSL       int
+		Nbthread        int
+		BindprocBalance string
+		BindprocSSL     string
+		CPUMap          string
 	}
 )

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -100,7 +100,7 @@ listen tcp-{{ $tcp.Port }}
 {{- end }}
     bind {{ $cfg.BindIPAddrTCP }}:{{ $tcp.Port }}{{ if ne $ssl.PemSHA "" }} ssl crt {{ $ssl.PemFileName }}{{ end }}{{ if $inProxyProt }} accept-proxy{{ end }}
 {{- if gt $ing.Procs.Nbproc 1 }}
-    bind-process {{ $ing.Procs.BindprocBalance }}
+    bind-process {{ if ne $ssl.PemSHA "" }}{{ $ing.Procs.BindprocSSL }}{{ else }}{{ $ing.Procs.BindprocBalance }}{{ end }}
 {{- end }}
     mode tcp
 {{- if ne $cfg.Syslog "" }}
@@ -283,9 +283,8 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
     mode http
 
-{{- if $hasBalance }}{{- /* this `if` is closed in the end of this `define "http_front"` */}}
-
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- if ne $cfg.Syslog "" }}
 {{- if eq $cfg.HTTPLogFormat "" }}
     option httplog
@@ -293,23 +292,29 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
     log-format {{ $cfg.HTTPLogFormat }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $hasHTTPStoHTTP }}
+{{- if or (and $hasBalance $hasHTTPStoHTTP) (not $hasSSL) }}
     acl from-https var(txn.hdr_proto) https
-{{- if not $reuseHTTPPort }}
+{{- end }}
+{{- if and $hasBalance $hasHTTPStoHTTP (not $reuseHTTPPort) }}
     acl from-https dst_port eq {{ $cfg.HTTPStoHTTPPort }}
 {{- end }}
-{{- end }}
+{{- if $hasSSL }}
     acl from-https ssl_fc
     acl ssl-offload ssl_fc
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $server := $servers }}
     {{- template "acl" map $cfg $server "var(txn.hdr_host)" true }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- if or $isShared $singleserver.HasRateLimit }}
     stick-table type ip size 200k expire 5m store conn_cur,conn_rate(1s)
     tcp-request content track-sc1 src
@@ -323,22 +328,26 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $snippet := $ing.ConfigFrontend }}
     {{ $snippet }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
     http-request set-var(txn.hdr_host) req.hdr(host)
-{{- if $hasHTTPStoHTTP }}
     http-request set-var(txn.hdr_proto) hdr(x-forwarded-proto)
+{{- end }}
 {{- if not $reuseHTTPPort }}
     http-request set-header X-Forwarded-Proto https if from-https
 {{- end }}
-{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- if ne $cfg.ModSecurity "" }}
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
 {{- range $server := $servers }}
@@ -355,8 +364,10 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $server := $servers }}
 {{- if and $server.IsCACert (not $isCACert) }}
     http-request deny if from-https {{ $server.ACLLabel }}
@@ -373,17 +384,18 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
-    http-request set-header X-Forwarded-Proto https if ssl-offload
+{{- if $hasSSL }}
 {{- if $isCACert }}
-    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-SHA1  %{+Q}[ssl_c_sha1,hex]   if {{ $singleserver.ACLLabel }} ssl-offload
-    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-DN    %{+Q}[ssl_c_s_dn]       if {{ $singleserver.ACLLabel }} ssl-offload
-    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-CN    %{+Q}[ssl_c_s_dn(cn)]   if {{ $singleserver.ACLLabel }} ssl-offload
+    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-SHA1  %{+Q}[ssl_c_sha1,hex]   if ssl-offload
+    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-DN    %{+Q}[ssl_c_s_dn]       if ssl-offload
+    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-CN    %{+Q}[ssl_c_s_dn(cn)]   if ssl-offload
 {{- if $singleserver.CertificateAuth.CertHeader }}
-    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert  %{+Q}[ssl_c_der,base64] if {{ $singleserver.ACLLabel }} ssl-offload
+    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert  %{+Q}[ssl_c_der,base64] if ssl-offload
 {{- else }}
-    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert  if {{ $singleserver.ACLLabel }} ssl-offload
+    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert  if ssl-offload
 {{- end }}
 {{- else }}
     http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert  if ssl-offload
@@ -391,17 +403,21 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
     http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-DN    if ssl-offload
     http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-CN    if ssl-offload
 {{- end }}
-    http-request set-var(txn.path) path
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
+    http-request set-var(txn.path) path
 {{- if eq $cfg.Forwardfor "add" }}
     http-request del-header x-forwarded-for
     option forwardfor
 {{- else if eq $cfg.Forwardfor "ifmissing" }}
     option forwardfor if-none
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $server := $servers }}
 {{- if $server.CORS }}
 {{- if $server.CORS.CorsEnabled }}
@@ -417,8 +433,10 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $server := $servers }}
 {{- range $location := $server.Locations }}
 {{- $rewriteTarget := $location.Rewrite.Target }}
@@ -431,8 +449,10 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $server := $servers }}
 {{- if $server.SSLRedirect }}
     redirect scheme https if !from-https {{ $server.ACLLabel }}
@@ -444,27 +464,31 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $isCACert }}
+{{- if and $hasSSL $isCACert }}
 {{- if eq $singleserver.CertificateAuth.ErrorPage "" }}
-    use_backend error495 if {{ $singleserver.ACLLabel }} { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
-    use_backend error496 if {{ $singleserver.ACLLabel }} ssl-offload !{ ssl_c_used }
+    use_backend error495 if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
+    use_backend error496 if ssl-offload !{ ssl_c_used }
 {{- else }}
-    redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if {{ $singleserver.ACLLabel }} { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
-    redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if {{ $singleserver.ACLLabel }} ssl-offload !{ ssl_c_used }
+    redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
+    redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if ssl-offload !{ ssl_c_used }
 {{- end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $server := $servers }}
 {{- $appRoot := $server.RootLocation.Rewrite.AppRoot }}
 {{- if ne $appRoot "" }}
     redirect location {{ $appRoot }} if {{ $server.ACLLabel }} { var(txn.path) -m str / }
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $server := $servers }}
 {{- range $location := $server.Locations }}
 {{- if ne $location.Proxy.BodySize "" }}
@@ -472,8 +496,10 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 {{- end }}
 {{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $server := $servers }}
 {{- if $server.HSTS }}
 {{- $hsts := $server.HSTS }}
@@ -500,8 +526,10 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}{{/* if $cors.CorsEnabled */}}
 {{- end }}{{/* if/else $server.CORS */}}
 {{- end }}{{/* range $servers */}}
+{{- end }}{{/* if $hasBalance */}}
 
 {{- /*------------------------------------*/}}
+{{- if $hasBalance }}
 {{- range $server := $servers }}
 {{- range $location := $server.Locations }}
 {{- if not $location.IsRootLocation }}
@@ -518,16 +546,16 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- else if $isCACert }}
     default_backend httpback-shared-backend
 {{- end }}
+{{- end }}
 
-{{- else }}{{/* if $hasBalance -- ssl-offload only process */}}
-
+{{- /*------------------------------------*/}}
+{{- if not $hasBalance }}
 {{- if $isShared }}
     default_backend httpback-shared-backend
 {{- else if $isCACert }}
     default_backend httpback-{{ $singleserver.HostnameLabel }}
 {{- end }}
-
-{{- end }}{{/* if $hasBalance */}}
+{{- end }}
 
 {{- end }}{{/* define "http_front" */}}
 

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -301,7 +301,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- if and $hasBalance $hasHTTPStoHTTP (not $reuseHTTPPort) }}
     acl from-https dst_port eq {{ $cfg.HTTPStoHTTPPort }}
 {{- end }}
-{{- if $hasSSL }}
+{{- if and $hasSSL $hasBalance }}
     acl from-https ssl_fc
     acl ssl-offload ssl_fc
 {{- end }}
@@ -343,7 +343,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
     http-request set-var(txn.hdr_proto) hdr(x-forwarded-proto)
 {{- end }}
 {{- if not $reuseHTTPPort }}
-    http-request set-header X-Forwarded-Proto https if from-https
+    http-request set-header X-Forwarded-Proto https{{ if $hasBalance }} if from-https{{ end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -389,19 +389,19 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- /*------------------------------------*/}}
 {{- if $hasSSL }}
 {{- if $isCACert }}
-    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-SHA1  %{+Q}[ssl_c_sha1,hex]   if ssl-offload
-    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-DN    %{+Q}[ssl_c_s_dn]       if ssl-offload
-    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-CN    %{+Q}[ssl_c_s_dn(cn)]   if ssl-offload
+    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-SHA1  %{+Q}[ssl_c_sha1,hex]{{ if $hasBalance}}   if ssl-offload{{ end }}
+    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-DN    %{+Q}[ssl_c_s_dn]{{ if $hasBalance}}       if ssl-offload{{ end }}
+    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-CN    %{+Q}[ssl_c_s_dn(cn)]{{ if $hasBalance}}   if ssl-offload{{ end }}
 {{- if $singleserver.CertificateAuth.CertHeader }}
-    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert  %{+Q}[ssl_c_der,base64] if ssl-offload
+    http-request set-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert  %{+Q}[ssl_c_der,base64]{{ if $hasBalance}} if ssl-offload{{ end }}
 {{- else }}
-    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert  if ssl-offload
+    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert{{ if $hasBalance}}  if ssl-offload{{ end }}
 {{- end }}
 {{- else }}
-    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert  if ssl-offload
-    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-SHA1  if ssl-offload
-    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-DN    if ssl-offload
-    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-CN    if ssl-offload
+    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-Cert{{ if $hasBalance}}  if ssl-offload{{ end }}
+    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-SHA1{{ if $hasBalance}}  if ssl-offload{{ end }}
+    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-DN{{ if $hasBalance}}    if ssl-offload{{ end }}
+    http-request del-header {{ $cfg.SSLHeadersPrefix }}-Client-CN{{ if $hasBalance}}    if ssl-offload{{ end }}
 {{- end }}
 {{- end }}
 
@@ -470,10 +470,10 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- if and $hasSSL $isCACert }}
 {{- if eq $singleserver.CertificateAuth.ErrorPage "" }}
     use_backend error495 if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
-    use_backend error496 if ssl-offload !{ ssl_c_used }
+    use_backend error496 if { ssl_fc } !{ ssl_c_used }
 {{- else }}
     redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
-    redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if ssl-offload !{ ssl_c_used }
+    redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if { ssl_fc } !{ ssl_c_used }
 {{- end }}
 {{- end }}
 

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -2,7 +2,16 @@
 {{- $cfg := .Cfg -}}
 global
     daemon
-    stats socket {{ $cfg.StatsSocket }} level admin expose-fd listeners
+{{- if gt $ing.Procs.Nbproc 1 }}
+    nbproc {{ $ing.Procs.Nbproc }}
+{{- end }}
+{{- if gt $ing.Procs.Nbthread 1 }}
+    nbthread {{ $ing.Procs.Nbthread }}
+{{- end }}
+{{- if ne $ing.Procs.CPUMap "" }}
+    cpu-map {{ $ing.Procs.CPUMap }}
+{{- end }}
+    stats socket {{ $cfg.StatsSocket }} level admin expose-fd listeners{{ if gt $ing.Procs.Nbproc 1 }} process 1{{ end }}
 {{- if $cfg.LoadServerState }}
     server-state-file state-global
     server-state-base /var/lib/haproxy/
@@ -90,6 +99,9 @@ listen tcp-{{ $tcp.Port }}
     # CRT PEM checksum: {{ $ssl.PemSHA }}
 {{- end }}
     bind {{ $cfg.BindIPAddrTCP }}:{{ $tcp.Port }}{{ if ne $ssl.PemSHA "" }} ssl crt {{ $ssl.PemFileName }}{{ end }}{{ if $inProxyProt }} accept-proxy{{ end }}
+{{- if gt $ing.Procs.Nbproc 1 }}
+    bind-process {{ $ing.Procs.BindprocBalance }}
+{{- end }}
     mode tcp
 {{- if ne $cfg.Syslog "" }}
 {{- if eq $cfg.TCPLogFormat "" }}
@@ -145,6 +157,9 @@ backend {{ $backend.Name }}
 ######
 frontend httpsfront
     bind {{ $cfg.BindIPAddrHTTP }}:{{ $cfg.HTTPSPort }}{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
+{{- if gt $ing.Procs.Nbproc 1 }}
+    bind-process {{ $ing.Procs.BindprocSSL }}
+{{- end }}
     mode tcp
 
 {{- if ne $cfg.Syslog "" }}
@@ -181,13 +196,16 @@ frontend httpsfront
 ######
 ###### HTTP(S) frontend - shared http mode
 ######
-backend httpback-shared-backend
-    mode http
-    server shared-http-frontend unix@/var/run/haproxy-http.sock send-proxy-v2
 backend httpsback-shared-backend
     mode tcp
     server shared-https-frontend unix@/var/run/haproxy-https.sock send-proxy-v2
-    {{- template "http_front" map $ing $cfg nil }}
+{{- if gt $ing.Procs.NbprocSSL 0 }}
+    {{- template "http_front" map $ing $cfg nil false true }}
+{{- end }}
+backend httpback-shared-backend
+    mode http
+    server shared-http-frontend unix@/var/run/haproxy-http.sock send-proxy-v2
+    {{- template "http_front" map $ing $cfg nil true (eq $ing.Procs.NbprocSSL 0) }}
 
 {{- range $server := $ing.HAServers }}
 {{- if $server.IsCACert }}
@@ -198,7 +216,13 @@ backend httpsback-shared-backend
 backend httpsback-{{ $server.HostnameLabel }}
     mode tcp
     server {{ $server.HostnameLabel }} unix@/var/run/haproxy-https-{{ $server.HostnameSocket }}.sock send-proxy-v2
-    {{- template "http_front" map $ing $cfg $server }}
+    {{- template "http_front" map $ing $cfg $server (eq $ing.Procs.NbprocSSL 0) true }}
+{{- if gt $ing.Procs.NbprocSSL 0 }}
+backend httpback-{{ $server.HostnameLabel }}
+    mode http
+    server {{ $server.HostnameLabel }} unix@/var/run/haproxy-http-{{ $server.HostnameSocket }}.sock send-proxy-v2
+    {{- template "http_front" map $ing $cfg $server true false }}
+{{- end }}
 {{- end }}
 {{- end }}
 
@@ -208,7 +232,7 @@ backend httpsback-{{ $server.HostnameLabel }}
 backend httpback-default-backend
     mode http
     server shared-http-frontend unix@/var/run/haproxy-http-{{ $ing.DefaultServer.HostnameSocket }}.sock send-proxy-v2
-    {{- template "http_front" map $ing $cfg $ing.DefaultServer }}
+    {{- template "http_front" map $ing $cfg $ing.DefaultServer true false }}
 
 {{- /*------------------------------------*/}}
 {{- /*------------------------------------*/}}
@@ -216,34 +240,50 @@ backend httpback-default-backend
 {{- $ing := .p1 }}
 {{- $cfg := .p2 }}
 {{- $singleserver := .p3 }}
+{{- $hasBalance := .p4 }}
+{{- $hasSSL := .p5 }}
 {{- $isShared := isShared $singleserver }}
 {{- $isDefault := isDefault $singleserver }}
 {{- $isCACert := isCACert $singleserver }}
 {{- $servers := getServers $ing.HAServers $singleserver }}
 {{- $hasHTTPStoHTTP := gt $cfg.HTTPStoHTTPPort 0 }}
 {{- $reuseHTTPPort := eq $cfg.HTTPStoHTTPPort $cfg.HTTPPort }}
-frontend httpfront-{{ if $isShared }}shared-frontend{{ else if $isDefault }}default-backend{{ else }}{{ $singleserver.Hostname }}{{ end }}
-{{- if $isShared }}
+frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShared }}shared-frontend{{ else if $isDefault }}default-backend{{ else }}{{ $singleserver.Hostname }}{{ end }}
+
+{{- /*------------------------------------*/}}
+{{- if and $hasBalance $isShared }}
     bind {{ $cfg.BindIPAddrHTTP }}:{{ $cfg.HTTPPort }}{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
 {{- if and $hasHTTPStoHTTP (not $reuseHTTPPort) }}
     bind {{ $cfg.BindIPAddrHTTP }}:{{ $cfg.HTTPStoHTTPPort }}{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
 {{- end }}
     bind unix@/var/run/haproxy-http.sock accept-proxy
 {{- end }}
+{{- if $hasSSL }}
 {{- range $server := $servers }}
 {{- if $server.UseHTTPS }}
     # CRT PEM checksum: {{ $server.SSLPemChecksum }}{{ if $isShared }} - {{ $server.Hostname }}{{ end }}
 {{- end }}
 {{- end }}
-{{- if $isCACert }}
+{{- end }}
+{{- if and $hasSSL $isCACert }}
     # CA PEM checksum: {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }}
 {{- end }}
-{{- if $isDefault }}
+{{- if or $isDefault (and $isCACert (not $hasSSL)) }}
     bind unix@/var/run/haproxy-http-{{ $singleserver.HostnameSocket }}.sock accept-proxy
-{{- else }}
+{{- end }}
+{{- if $hasSSL }}
     bind unix@/var/run/haproxy-https{{ if not $isShared }}-{{ $singleserver.HostnameSocket }}{{ end }}.sock ssl alpn h2,http/1.1 crt {{ if $isShared }}/ingress-controller/ssl{{ else }}{{ $singleserver.SSLCertificate }}{{ end }}{{ if $isCACert }} ca-file {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
 {{- end }}
+{{- if gt $ing.Procs.Nbproc 1 }}
+{{- if and $hasBalance (not $hasSSL) }}
+    bind-process {{ $ing.Procs.BindprocBalance }}
+{{- else if and $hasSSL (not $hasBalance) }}
+    bind-process {{ $ing.Procs.BindprocSSL }}
+{{- end }}
+{{- end }}
     mode http
+
+{{- if $hasBalance }}{{- /* this `if` is closed in the end of this `define "http_front"` */}}
 
 {{- /*------------------------------------*/}}
 {{- if ne $cfg.Syslog "" }}
@@ -479,6 +519,16 @@ frontend httpfront-{{ if $isShared }}shared-frontend{{ else if $isDefault }}defa
     default_backend httpback-shared-backend
 {{- end }}
 
+{{- else }}{{/* if $hasBalance -- ssl-offload only process */}}
+
+{{- if $isShared }}
+    default_backend httpback-shared-backend
+{{- else if $isCACert }}
+    default_backend httpback-{{ $singleserver.HostnameLabel }}
+{{- end }}
+
+{{- end }}{{/* if $hasBalance */}}
+
 {{- end }}{{/* define "http_front" */}}
 
 {{- /*------------------------------------*/}}
@@ -561,7 +611,7 @@ backend error496
     errorfile 400 /usr/local/etc/haproxy/errors/496.http
     http-request deny deny_status 400
 listen error503noendpoints
-    bind 127.0.0.1:8181
+    bind 127.0.0.1:8181{{ if gt $ing.Procs.Nbproc 1 }} process {{ $ing.Procs.BindprocBalance }}{{ end }}
     mode http
     errorfile 503 /usr/local/etc/haproxy/errors/503noendpoints.http
 
@@ -573,7 +623,7 @@ listen stats
 {{- if ne $ssl.PemSHA "" }}
     # CRT PEM checksum: {{ $ssl.PemSHA }}
 {{- end }}
-    bind {{ $cfg.BindIPAddrStats }}:{{ $cfg.StatsPort }}{{ if ne $ssl.PemFileName "" }} ssl crt {{ $ssl.PemFileName }}{{ end }}{{ if $cfg.StatsProxyProtocol }} accept-proxy{{ end }}
+    bind {{ $cfg.BindIPAddrStats }}:{{ $cfg.StatsPort }}{{ if ne $ssl.PemFileName "" }} ssl crt {{ $ssl.PemFileName }}{{ end }}{{ if $cfg.StatsProxyProtocol }} accept-proxy{{ end }}{{ if gt $ing.Procs.Nbproc 1 }} process 1{{ end }}
     mode http
     stats enable
     stats realm HAProxy\ Statistics
@@ -589,7 +639,7 @@ listen stats
 ###### Monitor URI
 ######
 frontend healthz
-    bind {{ $cfg.BindIPAddrHealthz }}:{{ $cfg.HealthzPort }}
+    bind {{ $cfg.BindIPAddrHealthz }}:{{ $cfg.HealthzPort }}{{ if gt $ing.Procs.Nbproc 1 }} process 1{{ end }}
     mode http
     monitor-uri /healthz
     no log


### PR DESCRIPTION
Add new configmap options to support multi process and/or multi thread configuration.

* `nbproc-ssl`: number of processes dedicated to ssl-offloading; plain http requests are handled on another dedicated process.
* `nbthread`: number of threads for each process.

Todo:

* [x] core implementation
* [x] fix acl ssl-offload
* [x] docs and warnings