### PR TITLE
Fix ssl-passthrough annotation

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -141,7 +141,7 @@ frontend httpsfront
 {{- end }}
 
 {{- range $server := $ing.PassthroughBackends }}
-    use_backend {{ $server.Backend }} if {{ $server.ACLLabel }}
+    use_backend {{ $server.Backend }} if { req.ssl_sni -i {{ $server.Hostname }} }
 {{- end }}
 
 {{- range $server := $ing.HAServers }}


### PR DESCRIPTION
ACLLabel is not expected to be here.
This commit (a80d2c648369c7a58ae32cc278e9d8cbbb588669) breaks the `ingress.kubernetes.io/ssl-passthrough` annotation.

/milestone v0.6
/label fix