### PR TITLE
Add http/https port map configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,20 +256,21 @@ The following parameters are supported:
 
 ||Name|Type|Default|
 |---|---|---|---|
-||[`balance-algorithm`](#balance-algorithm)|algorithm name|`roundrobin`|
 ||[`backend-check-interval`](#backend-check-interval)|time with suffix|`2s`|
 ||[`backend-server-slots-increment`](#dynamic-scaling)|number of slots|`32`|
+||[`balance-algorithm`](#balance-algorithm)|algorithm name|`roundrobin`|
 |`[0]`|[`bind-ip-addr-healthz`](#bind-ip-addr)|IP address|`*`|
 |`[0]`|[`bind-ip-addr-http`](#bind-ip-addr)|IP address|`*`|
 |`[0]`|[`bind-ip-addr-stats`](#bind-ip-addr)|IP address|`*`|
 |`[0]`|[`bind-ip-addr-tcp`](#bind-ip-addr)|IP address|`*`|
 |`[0]`|[`cookie-key`](#cookie-key)|secret key|`Ingress`|
-|`[1]`|[`dns-resolvers`](#dns-resolvers)|multiline resolver=ip[:port]|``|
-|`[1]`|[`dns-timeout-retry`](#dns-resolvers)|time with suffix|`1s`|
-|`[1]`|[`dns-hold-obsolete`](#dns-resolvers)|time with suffix|`0s`|
-|`[1]`|[`dns-hold-valid`](#dns-resolvers)|time with suffix|`1s`|
 |`[1]`|[`dns-accepted-payload-size`](#dns-resolvers)|number|`8192`|
 |`[1]`|[`dns-cluster-domain`](#dns-resolvers)|cluster name|`cluster.local`|
+|`[1]`|[`dns-hold-obsolete`](#dns-resolvers)|time with suffix|`0s`|
+|`[1]`|[`dns-hold-valid`](#dns-resolvers)|time with suffix|`1s`|
+|`[1]`|[`dns-resolvers`](#dns-resolvers)|multiline resolver=ip[:port]|``|
+|`[1]`|[`dns-timeout-retry`](#dns-resolvers)|time with suffix|`1s`|
+|`[0]`|[`drain-support`](#drain-support)|[true\|false]|`false`|
 ||[`dynamic-scaling`](#dynamic-scaling)|[true\|false]|`false`|
 ||[`forwardfor`](#forwardfor)|[add\|ignore\|ifmissing]|`add`|
 ||[`healthz-port`](#healthz-port)|port number|`10253`|
@@ -278,7 +279,9 @@ The following parameters are supported:
 ||[`hsts-max-age`](#hsts)|number of seconds|`15768000`|
 ||[`hsts-preload`](#hsts)|[true\|false]|`false`|
 ||[`http-log-format`](#log-format)|http log format|HAProxy default log format|
+|`[1]`|[`http-port`](#bind-ip-addr)|port number|`80`|
 ||[`https-log-format`](#log-format)|https(tcp) log format\|`default`|do not log|
+|`[1]`|[`https-port`](#bind-ip-addr)|port number|`443`|
 ||[`https-to-http-port`](#https-to-http-port)|port number|0 (do not listen)|
 ||[`load-server-state`](#load-server-state) (experimental)|[true\|false]|`false`|
 ||[`max-connections`](#max-connections)|number|`2000`|
@@ -295,19 +298,18 @@ The following parameters are supported:
 ||[`stats-proxy-protocol`](#stats)|[true\|false]|`false`|
 ||[`syslog-endpoint`](#syslog-endpoint)|IP:port (udp)|do not log|
 ||[`tcp-log-format`](#log-format)|tcp log format|HAProxy default log format|
-||[`timeout-client`](#timeout)|time with suffix|`50s`|
 ||[`timeout-client-fin`](#timeout)|time with suffix|`50s`|
+||[`timeout-client`](#timeout)|time with suffix|`50s`|
 ||[`timeout-connect`](#timeout)|time with suffix|`5s`|
 ||[`timeout-http-request`](#timeout)|time with suffix|`5s`|
 ||[`timeout-keep-alive`](#timeout)|time with suffix|`1m`|
 ||[`timeout-queue`](#timeout)|time with suffix|`5s`|
-||[`timeout-server`](#timeout)|time with suffix|`50s`|
 ||[`timeout-server-fin`](#timeout)|time with suffix|`50s`|
+||[`timeout-server`](#timeout)|time with suffix|`50s`|
 |`[0]`|[`timeout-stop`](#timeout)|time with suffix|no timeout|
 ||[`timeout-tunnel`](#timeout)|time with suffix|`1h`|
 ||[`use-host-on-https`](#use-host-on-https)|[true\|false]|`false`|
 ||[`use-proxy-protocol`](#use-proxy-protocol)|[true\|false]|`false`|
-|`[0]`|[`drain-support`](#drain-support)|[true\|false]|`false`|
 
 ### balance-algorithm
 
@@ -352,7 +354,7 @@ http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#dynamic-cookie-key
 ### dns-resolvers
 Define a list of HAProxy DNS resolvers
 
-Multiline list of DNS resolvers in `resolvername=ip:port` format 
+Multiline list of DNS resolvers in `resolvername=ip:port` format
 
 https://cbonte.github.io/haproxy-dconv/1.8/configuration.html#resolvers%20(The%20resolvers%20section)
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -130,11 +130,13 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		UseProxyProtocol:       false,
 		StatsProxyProtocol:     false,
 		UseHostOnHTTPS:         false,
+		HTTPPort:               80,
 		HTTPLogFormat:          "",
+		HTTPSPort:              443,
 		HTTPSLogFormat:         "",
 		TCPLogFormat:           "",
 		DrainSupport:           false,
-        DNSResolvers:		    "",
+		DNSResolvers:           "",
 		DNSTimeoutRetry:        "1s",
 		DNSHoldObsolete:        "0s",
 		DNSHoldValid:           "1s",
@@ -204,8 +206,8 @@ func (cfg *haConfig) createDNSResolvers() {
 			}
 		}
 		resolvers[resolverData[0]] = dnsresolvers.DNSResolver{
-			Name:                resolverData[0],
-			Nameservers:         nameservers,
+			Name:        resolverData[0],
+			Nameservers: nameservers,
 		}
 	}
 

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -83,7 +83,9 @@ type (
 		UseProxyProtocol       bool   `json:"use-proxy-protocol"`
 		StatsProxyProtocol     bool   `json:"stats-proxy-protocol"`
 		UseHostOnHTTPS         bool   `json:"use-host-on-https"`
+		HTTPPort               int    `json:"http-port"`
 		HTTPLogFormat          string `json:"http-log-format"`
+		HTTPSPort              int    `json:"https-port"`
 		HTTPSLogFormat         string `json:"https-log-format"`
 		TCPLogFormat           string `json:"tcp-log-format"`
 		DrainSupport           bool   `json:"drain-support"`
@@ -170,7 +172,7 @@ type (
 		// resolver name used for this Backend definition
 		UseResolver string
 		// total slots for backend
-		TotalSlots       int
+		TotalSlots int
 	}
 	// HAProxyBackendSlot combines BackendServerName with an ingress.Endpoint
 	HAProxyBackendSlot struct {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -140,7 +140,7 @@ backend {{ $backend.Name }}
 ###### HTTPS frontend (tcp mode)
 ######
 frontend httpsfront
-    bind {{ $cfg.BindIPAddrHTTP }}:443{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
+    bind {{ $cfg.BindIPAddrHTTP }}:{{ $cfg.HTTPSPort }}{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
     mode tcp
 
 {{- if ne $cfg.Syslog "" }}
@@ -217,10 +217,10 @@ backend httpback-default-backend
 {{- $isCACert := isCACert $singleserver }}
 {{- $servers := getServers $ing.HAServers $singleserver }}
 {{- $hasHTTPStoHTTP := gt $cfg.HTTPStoHTTPPort 0 }}
-{{- $reuseHTTPPort := eq $cfg.HTTPStoHTTPPort 80 }}
+{{- $reuseHTTPPort := eq $cfg.HTTPStoHTTPPort $cfg.HTTPPort }}
 frontend httpfront-{{ if $isShared }}shared-frontend{{ else if $isDefault }}default-backend{{ else }}{{ $singleserver.Hostname }}{{ end }}
 {{- if $isShared }}
-    bind {{ $cfg.BindIPAddrHTTP }}:80{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
+    bind {{ $cfg.BindIPAddrHTTP }}:{{ $cfg.HTTPPort }}{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
 {{- if and $hasHTTPStoHTTP (not $reuseHTTPPort) }}
     bind {{ $cfg.BindIPAddrHTTP }}:{{ $cfg.HTTPStoHTTPPort }}{{ if $cfg.UseProxyProtocol }} accept-proxy{{ end }}
 {{- end }}
@@ -465,13 +465,13 @@ frontend httpfront-{{ if $isShared }}shared-frontend{{ else if $isDefault }}defa
 {{- if $server.HostnameIsWildcard }}
     acl {{ $server.ACLLabel }} {{ $fetch }} -m reg -i {{ hostnameRegex $server.Hostname }}
 {{- else }}
-    acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.Hostname }}{{ if $needport }} {{ $server.Hostname }}:80 {{ $server.Hostname }}:443{{ if and $cfg.HTTPStoHTTPPort (ne $cfg.HTTPStoHTTPPort 80) }} {{ $server.Hostname }}:{{ $cfg.HTTPStoHTTPPort }}{{ end }}{{ end }}
+    acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.Hostname }}{{ if $needport }} {{ $server.Hostname }}:{{ $cfg.HTTPPort }} {{ $server.Hostname }}:{{ $cfg.HTTPSPort }}{{ if and $cfg.HTTPStoHTTPPort (ne $cfg.HTTPStoHTTPPort $cfg.HTTPPort) }} {{ $server.Hostname }}:{{ $cfg.HTTPStoHTTPPort }}{{ end }}{{ end }}
 {{- end }}
 {{- if ne $server.Alias "" }}
 {{- if $server.AliasIsRegex }}
     acl {{ $server.ACLLabel }} {{ $fetch }} -m reg -i '{{ aliasRegex $server.Alias }}'
 {{- else }}
-    acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.Alias }}{{ if $needport }} {{ $server.Alias }}:80 {{ $server.Alias }}:443{{ end }}
+    acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.Alias }}{{ if $needport }} {{ $server.Alias }}:{{ $cfg.HTTPPort }} {{ $server.Alias }}:{{ $cfg.HTTPSPort }}{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
On some haproxy-ingress setups several instances of haproxy can coexists
on same node, to avoid port mapping clashes, add configuration options
to allow change ports