### PR TITLE
Fix endless loop if SSL/TLS secret does not exist

### DIFF
--- a/pkg/common/ingress/controller/backend_ssl_test.go
+++ b/pkg/common/ingress/controller/backend_ssl_test.go
@@ -215,7 +215,7 @@ func TestGetPemCertificate(t *testing.T) {
 			secret := buildSecretForBackendSSL()
 			secret.Data = foo.Data
 			ic.listers.Secret.Add(secret)
-			sslCert, err := ic.getPemCertificate(foo.secretName)
+			sslCert, err := ic.getPemCertificate(secret)
 
 			if foo.eErr {
 				if err == nil {

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -1033,10 +1033,12 @@ func (ic *GenericController) createServers(data []*extensions.Ingress,
 
 	// Tries to fetch the default Certificate from nginx configuration.
 	// If it does not exists, use the ones generated on Start()
-	defaultCertificate, err := ic.getPemCertificate(ic.cfg.DefaultSSLCertificate)
-	if err == nil {
-		defaultPemFileName = defaultCertificate.PemFileName
-		defaultPemSHA = defaultCertificate.PemSHA
+	if secret, err := ic.listers.Secret.GetByName(ic.cfg.DefaultSSLCertificate); err == nil {
+		defaultCertificate, err := ic.getPemCertificate(secret)
+		if err == nil {
+			defaultPemFileName = defaultCertificate.PemFileName
+			defaultPemSHA = defaultCertificate.PemSHA
+		}
 	}
 
 	// initialize the default server
@@ -1188,7 +1190,7 @@ func (ic *GenericController) createServers(data []*extensions.Ingress,
 
 			cert := bc.(*ingress.SSLCert)
 			if ic.cfg.VerifyHostname {
-				err = cert.Certificate.VerifyHostname(host)
+				err := cert.Certificate.VerifyHostname(host)
 				if err != nil {
 					glog.Warningf("ssl certificate %v does not contain a Subject Alternative Name for host %v. Using the default cert", key, host)
 					continue


### PR DESCRIPTION
Change the responsibility of `getPemCertificate` in order to know that err is a parsing failure and not a secret not found. A parsing failure means that the secret isn't a ca/crt and should sync; a secret not found should not.