### PR TITLE
Add stats-ssl-cert configmap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ configmap with `haproxy.tmpl` key mounting into `/etc/haproxy/template` will wor
 The following annotations are supported:
 
 * `[0]` only in `canary` tag
+* `[1]` only in `snapshot` tag
 
 ||Name|Data|Usage|
 |---|---|---|:---:|
@@ -253,6 +254,7 @@ A ConfigMap can be created with `kubectl create configmap`.
 The following parameters are supported:
 
 * `[0]` only in `canary` tag
+* `[1]` only in `snapshot` tag
 
 ||Name|Type|Default|
 |---|---|---|---|
@@ -296,6 +298,7 @@ The following parameters are supported:
 ||[`stats-auth`](#stats)|user:passwd|no auth|
 ||[`stats-port`](#stats)|port number|`1936`|
 ||[`stats-proxy-protocol`](#stats)|[true\|false]|`false`|
+|`[1]`|[`stats-ssl-cert`](#stats)|namespace/secret name|no ssl/plain http|
 ||[`syslog-endpoint`](#syslog-endpoint)|IP:port (udp)|do not log|
 ||[`tcp-log-format`](#log-format)|tcp log format|HAProxy default log format|
 ||[`timeout-client-fin`](#timeout)|time with suffix|`50s`|
@@ -545,11 +548,12 @@ to https if TLS is [configured](https://github.com/kubernetes/ingress/tree/maste
 
 ### stats
 
-Configurations of the HAProxy status page:
+Configurations of the HAProxy statistics page:
 
 * `stats-auth`: Enable basic authentication with clear-text password - `<user>:<passwd>`
 * `stats-port`: Change the port HAProxy should listen to requests
 * `stats-proxy-protocol`: Define if the stats endpoint should enforce the PROXY protocol
+* `stats-ssl-cert`: Optional namespace/secret-name of `tls.crt` and `tls.key` pair used to enable SSL on stats page. Plain http will be used if not provided, the secret wasn't found or the secret doesn't have a crt/key pair.
 
 ### syslog-endpoint
 

--- a/pkg/common/ingress/types_equals.go
+++ b/pkg/common/ingress/types_equals.go
@@ -513,3 +513,11 @@ func (l4b1 *ProxyProtocol) Equal(l4b2 *ProxyProtocol) bool {
 	}
 	return true
 }
+
+// Equal tests for equality between two SSLCert types
+func (c1 *SSLCert) Equal(c2 *SSLCert) bool {
+	if c1.PemSHA != c2.PemSHA {
+		return false
+	}
+	return true
+}

--- a/pkg/types/equal.go
+++ b/pkg/types/equal.go
@@ -51,5 +51,8 @@ func (c1 *ControllerConfig) Equal(c2 *ControllerConfig) bool {
 	if !reflect.DeepEqual(c1.Cfg, c2.Cfg) {
 		return false
 	}
+	if !c1.StatsSSLCert.Equal(c2.StatsSSLCert) {
+		return false
+	}
 	return true
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -42,6 +42,7 @@ type (
 		UDPEndpoints        []ingress.L4Service
 		PassthroughBackends []*ingress.SSLPassthroughBackend
 		HAPassthrough       []*HAProxyPassthrough
+		StatsSSLCert        *ingress.SSLCert
 		Cfg                 *HAProxyConfig
 		BackendSlots        map[string]*HAProxyBackendSlots
 		DNSResolvers        map[string]dnsresolvers.DNSResolver
@@ -77,6 +78,7 @@ type (
 		HTTPStoHTTPPort        int    `json:"https-to-http-port"`
 		StatsPort              int    `json:"stats-port"`
 		StatsAuth              string `json:"stats-auth"`
+		StatsSSLCert           string `json:"stats-ssl-cert"`
 		CookieKey              string `json:"cookie-key"`
 		DynamicScaling         bool   `json:"dynamic-scaling"`
 		StatsSocket            string

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -528,7 +528,11 @@ listen error503noendpoints
 ###### Stats page
 ######
 listen stats
-    bind {{ $cfg.BindIPAddrStats }}:{{ $cfg.StatsPort }}{{ if $cfg.StatsProxyProtocol }} accept-proxy{{ end }}
+{{- $ssl := $ing.StatsSSLCert }}
+{{- if ne $ssl.PemSHA "" }}
+    # CRT PEM checksum: {{ $ssl.PemSHA }}
+{{- end }}
+    bind {{ $cfg.BindIPAddrStats }}:{{ $cfg.StatsPort }}{{ if ne $ssl.PemFileName "" }} ssl crt {{ $ssl.PemFileName }}{{ end }}{{ if $cfg.StatsProxyProtocol }} accept-proxy{{ end }}
     mode http
     stats enable
     stats realm HAProxy\ Statistics


### PR DESCRIPTION
A new configmap option to enable SSL on stats page.

Implements #180