### PR TITLE
Add config-frontend configmap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,22 +155,6 @@ See also the [example](/examples/blue-green) page.
 
 http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-weight
 
-### Configuration snippet
-
-Add HAProxy configuration snippet to the configuration file. Use multiline content to add more than one
-line of configuration.
-
-Example:
-
-```yaml
-    annotations:
-      ingress.kubernetes.io/config-backend: |
-        acl bar-url path /bar
-        http-request deny if bar-url
-```
-
-* `ingress.kubernetes.io/config-backend`: Add configuration snippet to the HAProxy backend section.
-
 ### CORS
 
 Add CORS headers on OPTIONS http command (preflight) and reponses.
@@ -265,6 +249,7 @@ The following parameters are supported:
 |`[0]`|[`bind-ip-addr-http`](#bind-ip-addr)|IP address|`*`|
 |`[0]`|[`bind-ip-addr-stats`](#bind-ip-addr)|IP address|`*`|
 |`[0]`|[`bind-ip-addr-tcp`](#bind-ip-addr)|IP address|`*`|
+|`[1]`|[`config-frontend`](#configuration-snippet)|multiline HAProxy frontend config||
 |`[0]`|[`cookie-key`](#cookie-key)|secret key|`Ingress`|
 |`[1]`|[`dns-accepted-payload-size`](#dns-resolvers)|number|`8192`|
 |`[1]`|[`dns-cluster-domain`](#dns-resolvers)|cluster name|`cluster.local`|
@@ -348,6 +333,35 @@ Define listening IPv4/IPv6 address on several HAProxy frontends. All IP addresse
 `bind-ip-addr-stats`: IP address of the statistics page. See also [`stats-port`](#stats).
 
 http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4-bind
+
+### Configuration snippet
+
+Add HAProxy configuration snippet to the configuration file. Use multiline content to add more than one
+line of configuration.
+
+Examples - configmap:
+
+```yaml
+    config-frontend: |
+      capture request header X-User-Id len 32
+```
+
+Ingress annotation:
+
+```yaml
+    annotations:
+      ingress.kubernetes.io/config-backend: |
+        acl bar-url path /bar
+        http-request deny if bar-url
+```
+
+Global configmap option:
+
+* `config-frontend`: Add configuration snippet to all frontend sections.
+
+Annotation option:
+
+* `ingress.kubernetes.io/config-backend`: Add configuration snippet to the HAProxy backend section.
 
 ### cookie-key
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -67,6 +67,7 @@ func newControllerConfig(ingressConfig *ingress.Configuration, haproxyController
 	}
 	cfg.createDNSResolvers()
 	return &types.ControllerConfig{
+		ConfigFrontend:      cfg.configFrontend(),
 		Userlists:           cfg.userlists,
 		Servers:             cfg.ingress.Servers,
 		Backends:            cfg.ingress.Backends,
@@ -117,6 +118,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		BindIPAddrHealthz:      "*",
 		Syslog:                 "",
 		BackendCheckInterval:   "2s",
+		ConfigFrontend:         "",
 		Forwardfor:             "add",
 		MaxConn:                2000,
 		NoTLSRedirect:          "/.well-known/acme-challenge",
@@ -238,6 +240,14 @@ func (cfg *haConfig) statsSSLCert() *ingress.SSLCert {
 		return &ingress.SSLCert{}
 	}
 	return sslCert
+}
+
+func (cfg *haConfig) configFrontend() []string {
+	config := cfg.haproxyConfig.ConfigFrontend
+	if config == "" {
+		return []string{}
+	}
+	return strings.Split(strings.TrimRight(config, "\n"), "\n")
 }
 
 func (cfg *haConfig) createHAProxyServers() {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -33,6 +33,7 @@ type (
 	// ControllerConfig has ingress generated and some transformations
 	// compatible with HAProxy
 	ControllerConfig struct {
+		ConfigFrontend      []string
 		Userlists           map[string]Userlist
 		Servers             []*ingress.Server
 		Backends            []*ingress.Backend
@@ -70,6 +71,7 @@ type (
 		BindIPAddrHealthz      string `json:"bind-ip-addr-healthz"`
 		Syslog                 string `json:"syslog-endpoint"`
 		BackendCheckInterval   string `json:"backend-check-interval"`
+		ConfigFrontend         string `json:"config-frontend"`
 		Forwardfor             string `json:"forwardfor"`
 		MaxConn                int    `json:"max-connections"`
 		NoTLSRedirect          string `json:"no-tls-redirect-locations"`

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -281,6 +281,11 @@ frontend httpfront-{{ if $isShared }}shared-frontend{{ else if $isDefault }}defa
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- range $snippet := $ing.ConfigFrontend }}
+    {{ $snippet }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
     http-request set-var(txn.hdr_host) req.hdr(host)
 {{- if $hasHTTPStoHTTP }}
     http-request set-var(txn.hdr_proto) hdr(x-forwarded-proto)


### PR DESCRIPTION
A new configmap option to add configuration snippet on HAProxy http frontend sections.

Implements #118 and #188 