### PR TITLE
Fix host match of rate limit on shared frontend

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -318,15 +318,6 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- if or $isShared $singleserver.HasRateLimit }}
     stick-table type ip size 200k expire 5m store conn_cur,conn_rate(1s)
     tcp-request content track-sc1 src
-{{- range $server := $servers }}
-{{- range $location := $server.Locations }}
-{{- $conn_cur_limit := $location.RateLimit.Connections.Limit }}
-{{- $conn_rate_limit := $location.RateLimit.RPS.Limit }}
-{{- if or (gt $conn_cur_limit 0) (gt $conn_rate_limit 0) }}
-    tcp-request content reject if {{ $server.ACLLabel }}{{ $location.HAMatchPath }}{{ if ne $location.HARateLimitWhiteList "" }} !{ src{{ $location.HARateLimitWhiteList }} }{{ end }}{{ if gt $conn_cur_limit 0 }} { sc1_conn_cur gt {{ $conn_cur_limit }} } ||{{ end }}{{ if gt $conn_rate_limit 0 }} { sc1_conn_rate gt {{ $conn_rate_limit }} } ||{{ end }} { always_false }
-{{- end }}
-{{- end }}
-{{- end }}
 {{- end }}
 {{- end }}
 
@@ -342,6 +333,24 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
     http-request set-var(txn.hdr_host) req.hdr(host)
     http-request set-var(txn.hdr_proto) hdr(x-forwarded-proto)
 {{- end }}
+
+{{- /*------------------------------------*/}}
+{{- if $hasBalance }}
+{{- range $server := $servers }}
+{{- range $location := $server.Locations }}
+{{- $conn_cur_limit := $location.RateLimit.Connections.Limit }}
+{{- $conn_rate_limit := $location.RateLimit.RPS.Limit }}
+{{- if gt $conn_cur_limit 0 }}
+    http-request deny if {{ $server.ACLLabel }}{{ $location.HAMatchPath }}{{ if ne $location.HARateLimitWhiteList "" }} !{ src{{ $location.HARateLimitWhiteList }} }{{ end }} { sc1_conn_cur gt {{ $conn_cur_limit }} }
+{{- end }}
+{{- if gt $conn_rate_limit 0 }}
+    http-request deny if {{ $server.ACLLabel }}{{ $location.HAMatchPath }}{{ if ne $location.HARateLimitWhiteList "" }} !{ src{{ $location.HARateLimitWhiteList }} }{{ end }} { sc1_conn_rate gt {{ $conn_rate_limit }} }
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
 {{- if not $reuseHTTPPort }}
     http-request set-header X-Forwarded-Proto https{{ if $hasBalance }} if from-https{{ end }}
 {{- end }}


### PR DESCRIPTION
Change rate limit check from tcp to http in order to match the host header. This will also change the response, from closing the connection with an empty reply to http 403 status code.