### PR TITLE
Remove ports 80/443 from reserved

### DIFF
--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -66,7 +66,7 @@ const (
 
 var (
 	// list of ports that cannot be used by TCP or UDP services
-	reservedPorts = []string{"80", "443", "8181", "18080"}
+	reservedPorts = []string{"8181", "18080"}
 
 	fakeCertificatePath = ""
 	fakeCertificateSHA  = ""


### PR DESCRIPTION
As default http/https ports can be overriden by ConfigMap
remove them from reserved