### PR TITLE
Add publish-service documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -727,6 +727,8 @@ The following command-line arguments are supported:
 ||[`sort-backends`](#sort-backends)|[true\|false]|`false`|
 ||[`tcp-services-configmap`](#tcp-services-configmap)|namespace/configmapname|no tcp svc|
 ||[`verify-hostname`](#verify-hostname)|[true\|false]|`true`|
+|`[0]`|[`publish-service`](#publish-service)|namespace/servicename|``|
+
 
 ### allow-cross-namespace
 
@@ -847,3 +849,17 @@ match the hostname are discarded and a warning is logged into the ingress contro
 
 Use `--verify-hostname=false` argument to bypass this validation. If used, HAProxy will provide
 the certificate declared in the `secretName` ignoring if the certificate is or is not valid.
+
+### publish-service
+
+Some infrastructure tools like `external-DNS` relay in the ingress status to created access routes to the services exposed with ingress object.
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+...
+status:
+  loadBalancer:
+    ingress:
+    - hostname: <ingressControllerLoadbalancerFQDN>
+```
+Use `--publish-service=namespace/servicename` to indicate the services fronting the ingress controller. The controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies.

--- a/README.md
+++ b/README.md
@@ -722,12 +722,12 @@ The following command-line arguments are supported:
 ||[`ingress-class`](#ingress-class)|name|`haproxy`|
 ||[`kubeconfig`](#kubeconfig)|/path/to/kubeconfig|in cluster config|
 |`[0]`|[`max-old-config-files`](#max-old-config-files)|num of files|`0`|
+||[`publish-service`](#publish-service)|namespace/servicename|``|
 ||[`rate-limit-update`](#rate-limit-update)|uploads per second (float)|`0.5`|
 ||[`reload-strategy`](#reload-strategy)|[native\|reusesocket]|`native`|
 ||[`sort-backends`](#sort-backends)|[true\|false]|`false`|
 ||[`tcp-services-configmap`](#tcp-services-configmap)|namespace/configmapname|no tcp svc|
 ||[`verify-hostname`](#verify-hostname)|[true\|false]|`true`|
-|`[0]`|[`publish-service`](#publish-service)|namespace/servicename|``|
 
 
 ### allow-cross-namespace
@@ -775,6 +775,20 @@ Everytime a configuration change need to update HAProxy, a configuration file is
 dynamic update is used. By default the same file is recreated and the old configuration is lost.
 Use `--max-old-config-files` to configure after how much files Ingress controller should start to
 remove old configuration files. If `0`, the default value, a single `haproxy.cfg` is used.
+
+### publish-service
+
+Some infrastructure tools like `external-DNS` relay in the ingress status to created access routes to the services exposed with ingress object.
+```
+apiVersion: extensions/v1beta1
+kind: Ingress
+...
+status:
+  loadBalancer:
+    ingress:
+    - hostname: <ingressControllerLoadbalancerFQDN>
+```
+Use `--publish-service=namespace/servicename` to indicate the services fronting the ingress controller. The controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies.
 
 ### rate-limit-update
 
@@ -849,17 +863,3 @@ match the hostname are discarded and a warning is logged into the ingress contro
 
 Use `--verify-hostname=false` argument to bypass this validation. If used, HAProxy will provide
 the certificate declared in the `secretName` ignoring if the certificate is or is not valid.
-
-### publish-service
-
-Some infrastructure tools like `external-DNS` relay in the ingress status to created access routes to the services exposed with ingress object.
-```
-apiVersion: extensions/v1beta1
-kind: Ingress
-...
-status:
-  loadBalancer:
-    ingress:
-    - hostname: <ingressControllerLoadbalancerFQDN>
-```
-Use `--publish-service=namespace/servicename` to indicate the services fronting the ingress controller. The controller mirrors the address of this service's endpoints to the load-balancer status of all Ingress objects it satisfies.


### PR DESCRIPTION
I am running v0.6-beta.3 in AWS, k8s 1.9 and external-dns. It is perfectly working. I hope were in the documentation to save time the next person. 👍 

Related to this issue https://github.com/jcmoraisjr/haproxy-ingress/issues/93