### PR TITLE
Add strict-host configmap option

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ The following parameters are supported:
 ||[`stats-port`](#stats)|port number|`1936`|
 ||[`stats-proxy-protocol`](#stats)|[true\|false]|`false`|
 |`[1]`|[`stats-ssl-cert`](#stats)|namespace/secret name|no ssl/plain http|
+|`[1]`|[`strict-host`](#strict-host)|[true\|false]|`true`|
 ||[`syslog-endpoint`](#syslog-endpoint)|IP:port (udp)|do not log|
 ||[`tcp-log-format`](#log-format)|tcp log format|HAProxy default log format|
 ||[`timeout-client-fin`](#timeout)|time with suffix|`50s`|
@@ -655,6 +656,40 @@ Configurations of the HAProxy statistics page:
 * `stats-port`: Change the port HAProxy should listen to requests
 * `stats-proxy-protocol`: Define if the stats endpoint should enforce the PROXY protocol
 * `stats-ssl-cert`: Optional namespace/secret-name of `tls.crt` and `tls.key` pair used to enable SSL on stats page. Plain http will be used if not provided, the secret wasn't found or the secret doesn't have a crt/key pair.
+
+### strict-host
+
+Defines whether the path of another matching host/FQDN should be used to try
+to serve a request. The default value is `true`, which means a strict
+configuration and the `default-backend` should be used if a path couldn't be
+matched. If `false`, all matching wildcard hosts will be visited in order to
+try to match the path.
+
+Using the following configuration:
+
+```
+  spec:
+    rules:
+    - host: my.domain.com
+      http:
+        paths:
+        - path: /a
+          backend:
+            serviceName: svc1
+            servicePort: 8080
+    - host: *.domain.com
+      http:
+        paths:
+        - path: /
+          backend:
+            serviceName: svc2
+            servicePort: 8080
+```
+
+A request to `my.domain.com/b` would serve:
+
+* `default-backend` if `strict-host` is true, the default value
+* `svc2` if `strict-host` is false
 
 ### syslog-endpoint
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -137,6 +137,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		StatsAuth:              "",
 		StatsSSLCert:           "",
 		CookieKey:              "Ingress",
+		StrictHost:             true,
 		DynamicScaling:         false,
 		StatsSocket:            "/var/run/haproxy-stats.sock",
 		UseProxyProtocol:       false,
@@ -405,6 +406,7 @@ func (cfg *haConfig) newHAProxyLocations(server *ingress.Server) ([]*types.HAPro
 	for i, location := range locations {
 		haLocation := types.HAProxyLocation{
 			IsRootLocation: location.Path == "/",
+			IsDefBackend:   location.IsDefBackend,
 			Path:           location.Path,
 			Backend:        location.Backend,
 			CORS:           location.CorsConfig,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -88,6 +88,7 @@ type (
 		StatsAuth              string `json:"stats-auth"`
 		StatsSSLCert           string `json:"stats-ssl-cert"`
 		CookieKey              string `json:"cookie-key"`
+		StrictHost             bool   `json:"strict-host"`
 		DynamicScaling         bool   `json:"dynamic-scaling"`
 		StatsSocket            string
 		UseProxyProtocol       bool   `json:"use-proxy-protocol"`
@@ -152,7 +153,8 @@ type (
 	}
 	// HAProxyLocation has location data as a HAProxy friendly syntax
 	HAProxyLocation struct {
-		IsRootLocation       bool                `json:"isDefaultLocation"`
+		IsRootLocation       bool                `json:"isRootLocation"`
+		IsDefBackend         bool                `json:"isDefBackend"`
 		Path                 string              `json:"path"`
 		Backend              string              `json:"backend"`
 		CORS                 cors.CorsConfig     `json:"cors"`

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -543,7 +543,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- range $location := $server.Locations }}
 {{- if not $location.IsRootLocation }}
     use_backend {{ $location.Backend }} if {{ $server.ACLLabel }} { var(txn.path) -m beg {{ $location.Path }} }
-{{- else if $server.ACLLabel }}
+{{- else if and $server.ACLLabel (or $cfg.StrictHost (not $location.IsDefBackend)) }}
     use_backend {{ $location.Backend }} if {{ $server.ACLLabel }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This configmap option defines whether another matching host/FQDN should be visited in order to match the path of a request.

Implements #157 