### PR TITLE
Fix ssl-dh-param option

### DIFF
--- a/pkg/common/net/ssl/ssl.go
+++ b/pkg/common/net/ssl/ssl.go
@@ -282,9 +282,9 @@ func AddCertAuth(name string, ca []byte) (*ingress.SSLCert, error) {
 // AddOrUpdateDHParam creates a dh parameters file with the specified name
 func AddOrUpdateDHParam(name string, dh []byte) (string, error) {
 	pemName := fmt.Sprintf("%v.pem", name)
-	pemFileName := fmt.Sprintf("%v/%v", ingress.DefaultSSLDirectory, pemName)
+	pemFileName := fmt.Sprintf("%v/%v", "/ingress-controller", pemName)
 
-	tempPemFile, err := ioutil.TempFile(ingress.DefaultSSLDirectory, pemName)
+	tempPemFile, err := ioutil.TempFile("/ingress-controller", pemName)
 
 	glog.V(3).Infof("Creating temp file %v for DH param: %v", tempPemFile.Name(), pemName)
 	if err != nil {


### PR DESCRIPTION
Move dh-param file outside the ssl dir. Since v0.6, all pem files from the ssl dir are used on the frontend's ssl config.