### PR TITLE
Change dh param size

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -102,7 +102,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		SSLCiphers: defaultSSLCiphers,
 		SSLOptions: "no-sslv3 no-tls-tickets",
 		SSLDHParam: types.SSLDHParam{
-			DefaultMaxSize: 1024,
+			DefaultMaxSize: 2048,
 			SecretName:     "",
 		},
 		NbprocBalance:          1,


### PR DESCRIPTION
The SSL test is [capped at B](https://www.ssllabs.com/ssltest/analyze.html?d=janco-it.de) with the default settings. Changing dh-param in the configmap to `2048` [results in an A+](https://www.ssllabs.com/ssltest/analyze.html?d=cerberus-systems.com)