### PR TITLE
Update ssl-dh-param documentation for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,21 +615,26 @@ http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#tune.ssl.default-dh
 Define DH parameters file used on ephemeral Diffie-Hellman key exchange during
 the SSL/TLS handshake.
 
+When stored locally, the DH secret may look like:
+
+```
+-----BEGIN DH PARAMETERS-----
+MIICCAKCAgEAg9dDI+Z1dk7A0ctnFqPuS2cq8lIQLc36nvaLE5zcbI5IfiyxmxNh
+...
+-----END DH PARAMETERS-----
+```
+
+To create your secret you can define the secret with a template and a base64
+encoded copy of the DH parameter, or you can generate the secret with:
+
+```
+kubectl create secret generic ingress-dh-param --from-file dhparam.pem
+```
+
+Then, in the haproxy ingress configuration, `ssl-dh-param` should reference the
+resulting secret.
+
 http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#3.1-ssl-dh-param-file
-
-Example DH parameters secret file:
-
-```
-apiVersion: v1
-data:
-  dhparam.pem: **DH_SECRET_HERE**
-kind: Secret
-metadata:
-  name: ingress-dh-param
-type: Opaque
-```
-
-With `ssl-dh-param` referencing the resulting secret in the haproxy-ingress configuration.
 
 ### ssl-headers-prefix
 

--- a/README.md
+++ b/README.md
@@ -617,6 +617,20 @@ the SSL/TLS handshake.
 
 http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#3.1-ssl-dh-param-file
 
+Example DH parameters secret file:
+
+```
+apiVersion: v1
+data:
+  dhparam.pem: **DH_SECRET_HERE**
+kind: Secret
+metadata:
+  name: ingress-dh-param
+type: Opaque
+```
+
+With `ssl-dh-param` referencing the resulting secret in the haproxy-ingress configuration.
+
 ### ssl-headers-prefix
 
 Define the http header prefix that should be used with certificate parameters such as


### PR DESCRIPTION
As documented in https://github.com/jcmoraisjr/haproxy-ingress/issues/210, we were seeing the DH parameter configuration spam our logs. This turned out to be an issue with our configuration where we included the certificate in the `ssl-dh-param` instead of having it reference a secret with that data. 

This documentation PR hopes to help others from making the same mistake by providing an example of the secret and specifying that the secret should be referenced in your haproxy-ingress configuration.