### PR TITLE
Add client cert auth for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,9 @@ The following annotations are supported:
 |`[0]`|[`ingress.kubernetes.io/slots-increment`](#dynamic-scaling)|qty|-|
 |`[0]`|[`ingress.kubernetes.io/timeout-queue`](#connection)|qty|-|
 ||[`ingress.kubernetes.io/proxy-body-size`](#proxy-body-size)|size (bytes)|-|
-||`ingress.kubernetes.io/secure-backends`|[true\|false]|-|
-||`ingress.kubernetes.io/secure-verify-ca-secret`|secret name|-|
+||[`ingress.kubernetes.io/secure-backends`](#secure-backend)|[true\|false]|-|
+||[`ingress.kubernetes.io/secure-crt-secret`](#secure-backend)|secret name|-|
+||[`ingress.kubernetes.io/secure-verify-ca-secret`](#secure-backend)|secret name|-|
 ||[`ingress.kubernetes.io/session-cookie-name`](#affinity)|cookie name|-|
 |`[0]`|[`ingress.kubernetes.io/session-cookie-strategy`](#affinity)|[insert\|prefix\|rewrite]|-|
 ||`ingress.kubernetes.io/ssl-passthrough`|[true\|false]|-|
@@ -193,6 +194,14 @@ Configurations of connection limit and timeout.
 * http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-maxqueue
 * http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4-timeout%20queue
 * Time suffix: http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#2.4
+
+### Secure Backend
+
+Configure secure (TLS) connection to the backends.
+
+* `ingress.kubernetes.io/secure-backends`: Define as true if the backend provide a TLS connection.
+* `ingress.kubernetes.io/secure-crt-secret`: Optional secret name of client certificate and key. This cert/key pair must be provided if the backend requests a client certificate. Expected secret keys are `tls.crt` and `tls.key`, the same used if secret is built with `kubectl create secret tls <name>`.
+* `ingress.kubernetes.io/secure-verify-ca-secret`: Optional secret name with certificate authority bundle used to validate server certificate, preventing man-in-the-middle attacks. Expected secret key is `ca.crt`.
 
 ### Server Alias
 

--- a/pkg/common/ingress/annotations/secureupstream/main_test.go
+++ b/pkg/common/ingress/annotations/secureupstream/main_test.go
@@ -69,6 +69,9 @@ type mockCfg struct {
 }
 
 func (cfg mockCfg) GetFullResourceName(name, currentNamespace string) string {
+	if name == "" {
+		return ""
+	}
 	return fmt.Sprintf("%v/%v", currentNamespace, name)
 }
 

--- a/pkg/common/ingress/controller/annotations_test.go
+++ b/pkg/common/ingress/controller/annotations_test.go
@@ -55,6 +55,9 @@ type mockCfg struct {
 }
 
 func (m mockCfg) GetFullResourceName(name, currentNamespace string) string {
+	if name == "" {
+		return ""
+	}
 	return fmt.Sprintf("%v/%v", currentNamespace, name)
 }
 
@@ -78,7 +81,7 @@ func (m mockCfg) GetAuthCertificate(name string) (*resolver.AuthSSLCert, error) 
 			PemSHA:     "123",
 		}, nil
 	}
-	return nil, nil
+	return nil, fmt.Errorf("secret not found")
 }
 
 func TestAnnotationExtractor(t *testing.T) {
@@ -148,7 +151,7 @@ func TestSecureUpstream(t *testing.T) {
 	for _, foo := range fooAnns {
 		ing.SetAnnotations(foo.annotations)
 		r := ec.SecureUpstream(ing)
-		if r.Secure != foo.er {
+		if r.IsSecure != foo.er {
 			t.Errorf("Returned %v but expected %v", r, foo.er)
 		}
 	}

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -770,9 +770,10 @@ func (ic GenericController) GetAuthCertificate(name string) (*resolver.AuthSSLCe
 		return &resolver.AuthSSLCert{}, err
 	}
 	return &resolver.AuthSSLCert{
-		Secret:     name,
-		CAFileName: cert.CAFileName,
-		PemSHA:     cert.PemSHA,
+		Secret:      name,
+		CrtFileName: cert.PemFileName,
+		CAFileName:  cert.CAFileName,
+		PemSHA:      cert.PemSHA,
 	}, nil
 }
 
@@ -876,12 +877,8 @@ func (ic *GenericController) createUpstreams(data []*extensions.Ingress, du *ing
 				upstreams[name] = newUpstream(name)
 				upstreams[name].Port = path.Backend.ServicePort
 
-				if !upstreams[name].Secure {
-					upstreams[name].Secure = secUpstream.Secure
-				}
-
-				if upstreams[name].SecureCACert.Secret == "" {
-					upstreams[name].SecureCACert = secUpstream.CACert
+				if secUpstream != nil && !upstreams[name].Secure.IsSecure {
+					upstreams[name].Secure = *secUpstream
 				}
 
 				if upstreams[name].UpstreamHashBy == "" {

--- a/pkg/common/ingress/resolver/main.go
+++ b/pkg/common/ingress/resolver/main.go
@@ -57,6 +57,8 @@ type Service interface {
 type AuthSSLCert struct {
 	// Secret contains the name of the secret this was fetched from
 	Secret string `json:"secret"`
+	// CrtFileName contains the path to the secrets 'tls.crt' and 'tls.key'
+	CrtFileName string `json:"crtFilename"`
 	// CAFileName contains the path to the secrets 'ca.crt'
 	CAFileName string `json:"caFilename"`
 	// PemSHA contains the SHA1 hash of the 'ca.crt' or combinations of (tls.crt, tls.key, tls.crt) depending on certs in secret
@@ -65,7 +67,13 @@ type AuthSSLCert struct {
 
 // Equal tests for equality between two AuthSSLCert types
 func (asslc1 *AuthSSLCert) Equal(assl2 *AuthSSLCert) bool {
+	if asslc1 == nil || assl2 == nil {
+		return asslc1 == assl2
+	}
 	if asslc1.Secret != assl2.Secret {
+		return false
+	}
+	if asslc1.CrtFileName != assl2.CrtFileName {
 		return false
 	}
 	if asslc1.CAFileName != assl2.CAFileName {

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -19,6 +19,7 @@ package ingress
 import (
 	"fmt"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/hsts"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/secureupstream"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/snippet"
 	"time"
 
@@ -42,7 +43,6 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/rewrite"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/waf"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/defaults"
-	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/resolver"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/store"
 )
 
@@ -178,14 +178,11 @@ type Backend struct {
 	Name    string             `json:"name"`
 	Service *apiv1.Service     `json:"service,omitempty"`
 	Port    intstr.IntOrString `json:"port"`
-	// This indicates if the communication protocol between the backend and the endpoint is HTTP or HTTPS
-	// Allowing the use of HTTPS
-	// The endpoint/s must provide a TLS connection.
-	// The certificate used in the endpoint cannot be a self signed certificate
-	Secure bool `json:"secure"`
-	// SecureCACert has the filename and SHA1 of the certificate authorities used to validate
-	// a secured connection to the backend
-	SecureCACert resolver.AuthSSLCert `json:"secureCACert"`
+	// Secure indicates if the communication protocol between the backend and the endpoint
+	// is HTTP or HTTPS and also an optional client certificate for TLS authentication and
+	// the certificate authority bundle to validate server certificate. The endpoint/s must
+	// provide a TLS connection.
+	Secure secureupstream.Secure `json:"secure"`
 	// SSLPassthrough indicates that Ingress controller will delegate TLS termination to the endpoints.
 	SSLPassthrough bool `json:"sslPassthrough"`
 	// Endpoints contains the list of endpoints currently running

--- a/pkg/common/ingress/types_equals.go
+++ b/pkg/common/ingress/types_equals.go
@@ -161,10 +161,7 @@ func (b1 *Backend) Equal(b2 *Backend) bool {
 	if b1.Port != b2.Port {
 		return false
 	}
-	if b1.Secure != b2.Secure {
-		return false
-	}
-	if !(&b1.SecureCACert).Equal(&b2.SecureCACert) {
+	if !(&b1.Secure).Equal(&b2.Secure) {
 		return false
 	}
 	if b1.SSLPassthrough != b2.SSLPassthrough {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -135,7 +135,11 @@ backend {{ $backend.Name }}
 {{- range $snippet := $backend.ConfigurationSnippet.Backend }}
     {{ $snippet }}
 {{- end }}
-{{- $cacert := $backend.SecureCACert }}
+{{- $clcert := $backend.Secure.Cert }}
+{{- $cacert := $backend.Secure.CACert }}
+{{- if ne $clcert.PemSHA "" }}
+    # Cli cert PEM checksum: {{ $clcert.PemSHA }}
+{{- end }}
 {{- if ne $cacert.PemSHA "" }}
     # CA PEM checksum: {{ $cacert.PemSHA }}
 {{- end }}
@@ -159,10 +163,12 @@ backend {{ $backend.Name }}
 {{- define "backend" }}
     {{- $cfg := .p1 }}
     {{- $backend := .p2 }}
-    {{- $cacert := $backend.SecureCACert }}
+    {{- $clcert := $backend.Secure.Cert }}
+    {{- $cacert := $backend.Secure.CACert }}
     {{- if gt $backend.Connection.MaxConnServer 0 }} maxconn {{ $backend.Connection.MaxConnServer }}{{ end }}
     {{- if gt $backend.Connection.MaxQueueServer 0 }} maxqueue {{ $backend.Connection.MaxQueueServer }}{{ end }}
-    {{- if $backend.Secure }} ssl
+    {{- if $backend.Secure.IsSecure }} ssl
+        {{- if ne $clcert.CrtFileName "" }} crt {{ $clcert.CrtFileName }}{{ end }}
         {{- if ne $cacert.CAFileName "" }} verify required ca-file {{ $cacert.CAFileName }}
         {{- else }} verify none{{ end }}
     {{- end }}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -141,16 +141,33 @@ backend {{ $backend.Name }}
 {{- end }}
 {{- $BackendSlots := index $ing.BackendSlots $backend.Name }}
 {{- if $BackendSlots.UseResolver }}
-    server-template server-dns {{ $BackendSlots.TotalSlots }} {{$backend.Service.Name }}.{{ $backend.Service.Namespace }}.svc.{{- $cfg.DNSClusterDomain -}}:{{ $backend.Port }} resolvers {{ $BackendSlots.UseResolver }}{{ if ne $cfg.BackendCheckInterval "" }} check inter {{ $cfg.BackendCheckInterval }}{{ end }} resolve-prefer ipv4 init-addr none
+    server-template server-dns {{ $BackendSlots.TotalSlots }} {{ $backend.Service.Name }}.{{ $backend.Service.Namespace }}.svc.{{ $cfg.DNSClusterDomain }}:{{ $backend.Port }} resolvers {{ $BackendSlots.UseResolver }} resolve-prefer ipv4 init-addr none
+        {{- template "backend" map $cfg $backend }}
 {{- else }}
 {{- range $target, $slot := $BackendSlots.FullSlots }}
-    server {{ $slot.BackendServerName }} {{ $target }} {{ if gt $backend.Connection.MaxConnServer 0 }}maxconn {{ $backend.Connection.MaxConnServer }} {{ end }}{{ if gt $backend.Connection.MaxQueueServer 0 }}maxqueue {{ $backend.Connection.MaxQueueServer }} {{ end }}{{ if $backend.Secure }}ssl {{ if ne $cacert.CAFileName "" }}verify required ca-file {{ $cacert.CAFileName }} {{ else }}verify none {{ end }}{{ end }}{{ if ge $slot.BackendEndpoint.Weight 0 }}weight {{ $slot.BackendEndpoint.Weight }} {{ end }}{{ if ne $cfg.BackendCheckInterval "" }}check inter {{ $cfg.BackendCheckInterval }}{{ end }}
+    server {{ $slot.BackendServerName }} {{ $target }}
+        {{- if ge $slot.BackendEndpoint.Weight 0 }} weight {{ $slot.BackendEndpoint.Weight }}{{ end }}
+        {{- template "backend" map $cfg $backend }}
 {{- end }}
 {{- range $empty := $BackendSlots.EmptySlots }}
-    server {{ $empty }} 127.0.0.1:81 {{ if gt $backend.Connection.MaxConnServer 0 }}maxconn {{ $backend.Connection.MaxConnServer }} {{ end }}{{ if gt $backend.Connection.MaxQueueServer 0 }}maxqueue {{ $backend.Connection.MaxQueueServer }} {{ end }}{{ if $backend.Secure }}ssl {{ if ne $cacert.CAFileName "" }}verify required ca-file {{ $cacert.CAFileName }} {{ else }}verify none {{ end }}{{ end }}{{ if ne $cfg.BackendCheckInterval "" }}check inter {{ $cfg.BackendCheckInterval }} {{ end }}disabled
+    server {{ $empty }} 127.0.0.1:81 disabled
+        {{- template "backend" map $cfg $backend }}
 {{- end }}
 {{- end }}{{/* if $BackendSlots.UseResolver */}}
 {{- end }}{{/* range Backends */}}
+
+{{- define "backend" }}
+    {{- $cfg := .p1 }}
+    {{- $backend := .p2 }}
+    {{- $cacert := $backend.SecureCACert }}
+    {{- if gt $backend.Connection.MaxConnServer 0 }} maxconn {{ $backend.Connection.MaxConnServer }}{{ end }}
+    {{- if gt $backend.Connection.MaxQueueServer 0 }} maxqueue {{ $backend.Connection.MaxQueueServer }}{{ end }}
+    {{- if $backend.Secure }} ssl
+        {{- if ne $cacert.CAFileName "" }} verify required ca-file {{ $cacert.CAFileName }}
+        {{- else }} verify none{{ end }}
+    {{- end }}
+    {{- if ne $cfg.BackendCheckInterval "" }} check inter {{ $cfg.BackendCheckInterval }}{{ end }}
+{{- end }}
 
 ######
 ###### HTTPS frontend (tcp mode)

--- a/tests/manifests/configuration-a.json
+++ b/tests/manifests/configuration-a.json
@@ -32,11 +32,18 @@
 		},
 		"port": 0,
 		"upstream-hash-by": "$request_uri",
-		"secure": false,
-		"secureCert": {
-			"secret": "",
-			"caFilename": "",
-			"pemSha": ""
+		"secure": {
+			"IsSecure": false,
+			"Cert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			},
+			"CACert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			}
 		},
 		"sslPassthrough": false,
 		"endpoints": [{
@@ -93,11 +100,18 @@
 			}
 		},
 		"port": 80,
-		"secure": false,
-		"secureCert": {
-			"secret": "",
-			"caFilename": "",
-			"pemSha": ""
+		"secure": {
+			"IsSecure": false,
+			"Cert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			},
+			"CACert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			}
 		},
 		"sslPassthrough": false,
 		"endpoints": [{
@@ -171,11 +185,18 @@
 			}
 		},
 		"port": 80,
-		"secure": false,
-		"secureCert": {
-			"secret": "",
-			"caFilename": "",
-			"pemSha": ""
+		"secure": {
+			"IsSecure": false,
+			"Cert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			},
+			"CACert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			}
 		},
 		"sslPassthrough": false,
 		"endpoints": [{

--- a/tests/manifests/configuration-b.json
+++ b/tests/manifests/configuration-b.json
@@ -32,11 +32,18 @@
 		},
 		"port": 0,
 		"upstream-hash-by": "$request_uri",
-		"secure": false,
-		"secureCert": {
-			"secret": "",
-			"caFilename": "",
-			"pemSha": ""
+		"secure": {
+			"IsSecure": false,
+			"Cert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			},
+			"CACert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			}
 		},
 		"sslPassthrough": false,
 		"endpoints": [{
@@ -93,11 +100,18 @@
 			}
 		},
 		"port": 80,
-		"secure": false,
-		"secureCert": {
-			"secret": "",
-			"caFilename": "",
-			"pemSha": ""
+		"secure": {
+			"IsSecure": false,
+			"Cert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			},
+			"CACert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			}
 		},
 		"sslPassthrough": false,
 		"endpoints": [{
@@ -171,11 +185,18 @@
 			}
 		},
 		"port": 80,
-		"secure": false,
-		"secureCert": {
-			"secret": "",
-			"caFilename": "",
-			"pemSha": ""
+		"secure": {
+			"IsSecure": false,
+			"Cert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			},
+			"CACert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			}
 		},
 		"sslPassthrough": false,
 		"endpoints": [{

--- a/tests/manifests/configuration-c.json
+++ b/tests/manifests/configuration-c.json
@@ -3,11 +3,18 @@
 		"name": "upstream-default-backend",
 		"service": null,
 		"port": 0,
-		"secure": false,
-		"secureCert": {
-			"secret": "",
-			"caFilename": "",
-			"pemSha": ""
+		"secure": {
+			"IsSecure": false,
+			"Cert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			},
+			"CACert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			}
 		},
 		"sslPassthrough": false,
 		"endpoints": [{
@@ -65,11 +72,18 @@
 			}
 		},
 		"port": 8000,
-		"secure": false,
-		"secureCert": {
-			"secret": "",
-			"caFilename": "",
-			"pemSha": ""
+		"secure": {
+			"IsSecure": false,
+			"Cert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			},
+			"CACert": {
+				"secret": "",
+				"caFilename": "",
+				"pemSha": ""
+			}
 		},
 		"sslPassthrough": false,
 		"endpoints": [{


### PR DESCRIPTION
Add annotation `ingress.kubernetes.io/secure-crt-secret` to provide a client cert on TLS connections to backend.

Implements #177 