### PR TITLE
Use a multi pem file instead the ssl dir on shared frontend

### DIFF
--- a/pkg/common/net/ssl/ssl.go
+++ b/pkg/common/net/ssl/ssl.go
@@ -282,9 +282,9 @@ func AddCertAuth(name string, ca []byte) (*ingress.SSLCert, error) {
 // AddOrUpdateDHParam creates a dh parameters file with the specified name
 func AddOrUpdateDHParam(name string, dh []byte) (string, error) {
 	pemName := fmt.Sprintf("%v.pem", name)
-	pemFileName := fmt.Sprintf("%v/%v", "/ingress-controller", pemName)
+	pemFileName := fmt.Sprintf("%v/%v", ingress.DefaultSSLDirectory, pemName)
 
-	tempPemFile, err := ioutil.TempFile("/ingress-controller", pemName)
+	tempPemFile, err := ioutil.TempFile(ingress.DefaultSSLDirectory, pemName)
 
 	glog.V(3).Infof("Creating temp file %v for DH param: %v", tempPemFile.Name(), pemName)
 	if err != nil {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -272,7 +272,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
     bind unix@/var/run/haproxy-http-{{ $singleserver.HostnameSocket }}.sock accept-proxy
 {{- end }}
 {{- if $hasSSL }}
-    bind unix@/var/run/haproxy-https{{ if not $isShared }}-{{ $singleserver.HostnameSocket }}{{ end }}.sock ssl alpn h2,http/1.1 crt {{ if $isShared }}/ingress-controller/ssl{{ else }}{{ $singleserver.SSLCertificate }}{{ end }}{{ if $isCACert }} ca-file {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
+    bind unix@/var/run/haproxy-https{{ if not $isShared }}-{{ $singleserver.HostnameSocket }}{{ end }}.sock ssl alpn h2,http/1.1 crt {{ if $isShared }}/ingress-controller/ssl/+default.pem{{ else }}{{ $singleserver.SSLCertificate }}{{ end }}{{ if $isCACert }} ca-file {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
 {{- end }}
 {{- if gt $ing.Procs.Nbproc 1 }}
 {{- if and $hasBalance (not $hasSSL) }}


### PR DESCRIPTION
A small improvement on v0.7 after adding client cert for backends. All crt/key pairs are added to the ssl directory. This PR create a new `+default.pem` file with all and only the crt/keys that should be used in the shared frontend.

This will change again on v0.8 after create an array of frontends, each one with their array of servers/crt/key.