### PR TITLE
Add http-port on ssl-passthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ The following annotations are supported:
 ||[`ingress.kubernetes.io/secure-verify-ca-secret`](#secure-backend)|secret name|-|
 ||[`ingress.kubernetes.io/session-cookie-name`](#affinity)|cookie name|-|
 |`[0]`|[`ingress.kubernetes.io/session-cookie-strategy`](#affinity)|[insert\|prefix\|rewrite]|-|
-||`ingress.kubernetes.io/ssl-passthrough`|[true\|false]|-|
+||[`ingress.kubernetes.io/ssl-passthrough`](#ssl-passthrough)|[true\|false]|-|
+|`[1]`|[`ingress.kubernetes.io/ssl-passthrough-http-port`](#ssl-passthrough)|backend port|-|
 ||`ingress.kubernetes.io/ssl-redirect`|[true\|false]|[doc](/examples/rewrite)|
 ||`ingress.kubernetes.io/app-root`|/url|[doc](/examples/rewrite)|
 ||`ingress.kubernetes.io/whitelist-source-range`|CIDR|-|
@@ -257,6 +258,17 @@ The following table shows some examples:
 |/abc/|/abc|/|**404**|
 |/abc/|/abc/|/|/|
 |/abc/|/abc/x|/|/x|
+
+### SSL passthrough
+
+Defines if HAProxy should work in TCP proxy mode and leave the SSL offload to the backend.
+SSL passthrough is a per domain configuration, which means that other domains can be
+configured to SSL offload on HAProxy.
+
+If using SSL passthrough, only root `/` path is supported.
+
+* `ingress.kubernetes.io/ssl-passthrough`: Enable ssl passthrough if defined as `True` and the backend is expected to SSL offload the incoming traffic. The default value is `False`, which means HAProxy should do the SSL handshake.
+* `ingress.kubernetes.io/ssl-passthrough-http-port`: Since v0.7. Optional HTTP port number of the backend. If defined, connections to the HAProxy HTTP port, default `80`, is sent to that port which expects to speak plain HTTP. If not defined, connections to the HTTP port will redirect connections to the HTTPS one.
 
 ### WAF
 

--- a/pkg/common/ingress/annotations/sslpassthrough/main_test.go
+++ b/pkg/common/ingress/annotations/sslpassthrough/main_test.go
@@ -50,7 +50,8 @@ func TestParseAnnotations(t *testing.T) {
 	}
 
 	data := map[string]string{}
-	data[passthrough] = "true"
+	data[passthroughAnn] = "true"
+	data[httpPortAnn] = "8000"
 	ing.SetAnnotations(data)
 	// test ingress using the annotation without a TLS section
 	_, err = NewParser().Parse(ing)
@@ -68,11 +69,14 @@ func TestParseAnnotations(t *testing.T) {
 	if err != nil {
 		t.Errorf("expected error parsing ingress with sslpassthrough")
 	}
-	val, ok := i.(bool)
+	cfg, ok := i.(*Config)
 	if !ok {
-		t.Errorf("expected a bool type")
+		t.Errorf("expected a sslpassthrough.Config type")
 	}
-	if !val {
+	if !cfg.HasSSLPassthrough {
 		t.Errorf("expected true but false returned")
+	}
+	if cfg.HTTPPort != 8000 {
+		t.Errorf("expected 8000 but %v returned", cfg.HTTPPort)
 	}
 }

--- a/pkg/common/ingress/controller/annotations.go
+++ b/pkg/common/ingress/controller/annotations.go
@@ -214,9 +214,9 @@ func (e *annotationExtractor) ProxyBackend(ing *extensions.Ingress) *proxybacken
 	return val.(*proxybackend.Config)
 }
 
-func (e *annotationExtractor) SSLPassthrough(ing *extensions.Ingress) bool {
+func (e *annotationExtractor) SSLPassthrough(ing *extensions.Ingress) *sslpassthrough.Config {
 	val, _ := e.annotations[sslPassthrough].Parse(ing)
-	return val.(bool)
+	return val.(*sslpassthrough.Config)
 }
 
 func (e *annotationExtractor) ConfigurationSnippet(ing *extensions.Ingress) snippet.Config {

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/proxybackend"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/secureupstream"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/snippet"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/sslpassthrough"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -265,7 +266,7 @@ type Server struct {
 	Hostname string `json:"hostname"`
 	// SSLPassthrough indicates if the TLS termination is realized in
 	// the server or in the remote endpoint
-	SSLPassthrough bool `json:"sslPassthrough"`
+	SSLPassthrough sslpassthrough.Config `json:"sslPassthrough"`
 	// SSLCertificate path to the SSL certificate on disk
 	SSLCertificate string `json:"sslCertificate"`
 	// SSLExpireTime has the expire date of this certificate
@@ -321,6 +322,8 @@ type Location struct {
 	Ingress *extensions.Ingress `json:"ingress"`
 	// Backend describes the name of the backend to use.
 	Backend string `json:"backend"`
+	// HTTPPassBackend describes the optional name of the plain http backend of a ssl passthrough server.
+	HTTPPassBackend string `json:"httpPassBackend"`
 	// Service describes the referenced services from the ingress
 	Service *apiv1.Service `json:"service,omitempty"`
 	// Port describes to which port from the service
@@ -394,6 +397,8 @@ type SSLPassthroughBackend struct {
 	Port    intstr.IntOrString `json:"port"`
 	// Backend describes the endpoints to use.
 	Backend string `json:"namespace,omitempty"`
+	// HTTPPassBackend describes the optional name of the plain http backend of a ssl passthrough server.
+	HTTPPassBackend string `json:"httpPassBackend"`
 	// Hostname returns the FQDN of the server
 	Hostname string `json:"hostname"`
 }

--- a/pkg/common/ingress/types_equals.go
+++ b/pkg/common/ingress/types_equals.go
@@ -295,7 +295,7 @@ func (s1 *Server) Equal(s2 *Server) bool {
 	if s1.Alias != s2.Alias {
 		return false
 	}
-	if s1.SSLPassthrough != s2.SSLPassthrough {
+	if !s1.SSLPassthrough.Equal(&s2.SSLPassthrough) {
 		return false
 	}
 	if s1.SSLCertificate != s2.SSLCertificate {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -285,13 +285,16 @@ func (cfg *haConfig) createHAProxyServers() {
 	for _, server := range cfg.ingress.PassthroughBackends {
 		haServer := &types.HAProxyPassthrough{
 			Hostname:           server.Hostname,
+			Alias:              false,
+			ACLLabel:           labelizeACL(server.Hostname),
 			Backend:            server.Backend,
+			HTTPPassBackend:    server.HTTPPassBackend,
 			HostnameIsWildcard: idHasWildcard(server.Hostname),
 		}
 		haPassthrough = append(haPassthrough, haServer)
 	}
 	for _, server := range cfg.ingress.Servers {
-		if server.SSLPassthrough {
+		if server.SSLPassthrough.HasSSLPassthrough {
 			// remove SSLPassthrough hosts from haServers array
 			continue
 		}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -174,7 +174,10 @@ type (
 	// HAProxyPassthrough has SSL passthrough configurations
 	HAProxyPassthrough struct {
 		Hostname           string `json:"hostname"`
+		Alias              bool   `json:"alias"`
+		ACLLabel           string `json:"aclLabel"`
 		Backend            string `json:"backend"`
+		HTTPPassBackend    string `json:"httpPassBackend"`
 		HostnameIsWildcard bool   `json:"hostnameIsWildcard"`
 	}
 	// HAProxyBackendSlots contains used and empty backend server definitions

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -339,6 +339,11 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- range $server := $servers }}
     {{- template "acl" map $cfg $server "var(txn.hdr_host)" true }}
 {{- end }}
+{{- if $isShared }}
+{{- range $server := $ing.HAPassthrough }}
+    {{- template "acl" map $cfg $server "var(txn.hdr_host)" true }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -501,6 +506,13 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 {{- end }}
 {{- end }}
+{{- if $isShared }}
+{{- range $server := $ing.HAPassthrough }}
+{{- if eq $server.HTTPPassBackend "" }}
+    redirect scheme https if !from-https {{ $server.ACLLabel }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -577,6 +589,13 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 {{- end }}
 {{- if $isShared }}
+{{- range $server := $ing.HAPassthrough }}
+{{- if ne $server.HTTPPassBackend "" }}
+    use_backend {{ $server.HTTPPassBackend }} if {{ $server.ACLLabel }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $isShared }}
     default_backend httpback-default-backend
 {{- else if $isDefault }}
     default_backend {{ $ing.DefaultServer.RootLocation.Backend }}
@@ -609,7 +628,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- else }}
     acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.Hostname }}{{ if $needport }} {{ $server.Hostname }}:{{ $cfg.HTTPPort }} {{ $server.Hostname }}:{{ $cfg.HTTPSPort }}{{ if and $cfg.HTTPStoHTTPPort (ne $cfg.HTTPStoHTTPPort $cfg.HTTPPort) }} {{ $server.Hostname }}:{{ $cfg.HTTPStoHTTPPort }}{{ end }}{{ end }}
 {{- end }}
-{{- if ne $server.Alias "" }}
+{{- if $server.Alias }}
 {{- if $server.AliasIsRegex }}
     acl {{ $server.ACLLabel }} {{ $fetch }} -m reg -i '{{ aliasRegex $server.Alias }}'
 {{- else }}

--- a/tests/manifests/configuration-a.json
+++ b/tests/manifests/configuration-a.json
@@ -222,7 +222,10 @@
 	}],
 	"servers": [{
 		"hostname": "_",
-		"sslPassthrough": false,
+		"sslPassthrough": {
+			"hasSSLPassthrough": false,
+			"httpPort": 0
+		},
 		"sslCertificate": "/ingress-controller/ssl/default-fake-certificate.pem",
 		"sslExpireTime": "0001-01-01T00:00:00Z",
 		"sslPemChecksum": "84d4ecb651dae44d625531bf77b6265d660b60b2",
@@ -328,7 +331,10 @@
 		}]
 	}, {
 		"hostname": "dev.mycompany.com",
-		"sslPassthrough": false,
+		"sslPassthrough": {
+			"hasSSLPassthrough": false,
+			"httpPort": 0
+		},
 		"sslCertificate": "/ingress-controller/ssl/default-mycompany.pem",
 		"sslExpireTime": "2027-06-20T20:28:25Z",
 		"sslPemChecksum": "b9282485e120e4fad8c25d15dc1b7984fcde99ba",
@@ -515,7 +521,10 @@
 		}]
 	}, {
 		"hostname": "domain.tld",
-		"sslPassthrough": false,
+		"sslPassthrough": {
+			"hasSSLPassthrough": false,
+			"httpPort": 0
+		},
 		"sslCertificate": "",
 		"sslExpireTime": "0001-01-01T00:00:00Z",
 		"sslPemChecksum": "",

--- a/tests/manifests/configuration-b.json
+++ b/tests/manifests/configuration-b.json
@@ -222,7 +222,10 @@
 	}],
 	"servers": [{
 		"hostname": "_",
-		"sslPassthrough": false,
+		"sslPassthrough": {
+			"hasSSLPassthrough": false,
+			"httpPort": 0
+		},
 		"sslCertificate": "/ingress-controller/ssl/default-fake-certificate.pem",
 		"sslExpireTime": "0001-01-01T00:00:00Z",
 		"sslPemChecksum": "84d4ecb651dae44d625531bf77b6265d660b60b2",
@@ -328,7 +331,10 @@
 		}]
 	}, {
 		"hostname": "dev.mycompany.com",
-		"sslPassthrough": false,
+		"sslPassthrough": {
+			"hasSSLPassthrough": false,
+			"httpPort": 0
+		},
 		"sslCertificate": "/ingress-controller/ssl/default-mycompany.pem",
 		"sslExpireTime": "2027-06-20T20:28:25Z",
 		"sslPemChecksum": "b9282485e120e4fad8c25d15dc1b7984fcde99ba",
@@ -515,7 +521,10 @@
 		}]
 	}, {
 		"hostname": "domain.tld",
-		"sslPassthrough": false,
+		"sslPassthrough": {
+			"hasSSLPassthrough": false,
+			"httpPort": 0
+		},
 		"sslCertificate": "",
 		"sslExpireTime": "0001-01-01T00:00:00Z",
 		"sslPemChecksum": "",

--- a/tests/manifests/configuration-c.json
+++ b/tests/manifests/configuration-c.json
@@ -103,7 +103,10 @@
 	}],
 	"servers": [{
 		"hostname": "_",
-		"sslPassthrough": false,
+		"sslPassthrough": {
+			"hasSSLPassthrough": false,
+			"httpPort": 0
+		},
 		"sslCertificate": "/ingress-controller/ssl/default-fake-certificate.pem",
 		"sslExpireTime": "0001-01-01T00:00:00Z",
 		"sslPemChecksum": "123b44425920a2e4825ae779fba0e6e07fbac03d",
@@ -174,7 +177,10 @@
 		}]
 	}, {
 		"hostname": "deis.minikube",
-		"sslPassthrough": false,
+		"sslPassthrough": {
+			"hasSSLPassthrough": false,
+			"httpPort": 0
+		},
 		"sslCertificate": "",
 		"sslExpireTime": "0001-01-01T00:00:00Z",
 		"sslPemChecksum": "",


### PR DESCRIPTION
New annotation `ingress.kubernetes.io/ssl-passthrough-http-port` used to configure an optional http port of a ssl-passthrough backend service. If http-port isn't provided, HAProxy will 302 redirect from http to https. If provided, requests to HAProxy http port, default `80`, will be sent to the specified port of the same service.

This is a useful configuration when HAProxy is transparently fronting another ingress controllers or loadbalancers.