### PR TITLE
Fix stop/terminate signal of the controller process

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -24,4 +24,5 @@ RUN wget -O/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.0
 
 COPY . /
 
+STOPSIGNAL SIGTERM
 ENTRYPOINT ["/dumb-init", "--", "/start.sh"]


### PR DESCRIPTION
The upstream image is used to start HAProxy itself as pid1. Its stop signal was changed to SIGUSR1 which does a soft reload on HAProxy. Our pid1 is the controller which only listen SIGTERM (docker stop) and SIGINT (^C).

Changing the stop signal in the container image as a way to document what the controller process is expecting.