### PR TITLE
Fix SSL redirect if no TLS config is used

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -433,6 +433,10 @@ func (cfg *haConfig) newHAProxyLocations(server *ingress.Server) ([]*types.HAPro
 	var haRootLocation *types.HAProxyLocation
 	otherPaths := ""
 	for i, location := range locations {
+		// Template trust only in the SSLRedirect attr to configure
+		// the redirect itself and the URL rewrite
+		// So turn SSLRedirect off despite of its original configuration
+		// if there isn't a certificate to this server
 		haLocation := types.HAProxyLocation{
 			IsRootLocation: location.Path == "/",
 			IsDefBackend:   location.IsDefBackend,
@@ -443,7 +447,7 @@ func (cfg *haConfig) newHAProxyLocations(server *ingress.Server) ([]*types.HAPro
 			WAF:            location.WAF,
 			Rewrite:        location.Rewrite,
 			Redirect:       location.Redirect,
-			SSLRedirect:    location.Rewrite.SSLRedirect && cfg.allowRedirect(location.Path),
+			SSLRedirect:    location.Rewrite.SSLRedirect && server.SSLCertificate != "" && cfg.allowRedirect(location.Path),
 			Proxy:          location.Proxy,
 			RateLimit:      location.RateLimit,
 		}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -486,14 +486,12 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- /*------------------------------------*/}}
 {{- if $hasBalance }}
 {{- range $server := $servers }}
-{{- if $server.UseHTTPS }}
 {{- if $server.SSLRedirect }}
     redirect scheme https if !from-https {{ $server.ACLLabel }}
 {{- else }}
 {{- range $location := $server.Locations }}
 {{- if $location.SSLRedirect }}
     redirect scheme https if !from-https {{ $server.ACLLabel }}{{ $location.HAMatchTxnPath }}
-{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Template trust only in the SSLRedirect attribute to configure the redirect itself and the URL rewrite.
So turn SSLRedirect off despite of its original configuration if the server doesn’t have a certificate.

Revert #231

Related with #229