### PR TITLE
Add proxy-protocol annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ The following annotations are supported:
 ||[`ingress.kubernetes.io/limit-whitelist`](#limit)|cidr list|-|
 |`[0]`|[`ingress.kubernetes.io/maxconn-server`](#connection)|qty|-|
 |`[0]`|[`ingress.kubernetes.io/maxqueue-server`](#connection)|qty|-|
+|`[1]`|[`ingress.kubernetes.io/proxy-protocol`](#proxy-protocol)|[v1\|v2\|v2-ssl\|v2-ssl-cn]|-|
 |`[0]`|[`ingress.kubernetes.io/slots-increment`](#dynamic-scaling)|qty|-|
 |`[0]`|[`ingress.kubernetes.io/timeout-queue`](#connection)|qty|-|
 ||[`ingress.kubernetes.io/proxy-body-size`](#proxy-body-size)|size (bytes)|-|
@@ -210,6 +211,18 @@ Configurations of connection limit and timeout.
 * http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-maxqueue
 * http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4-timeout%20queue
 * Time suffix: http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#2.4
+
+### Proxy Protocol
+
+Define if the upstream backends support proxy protocol and what version of the protocol should be used.
+
+* `ingress.kubernetes.io/proxy-protocol`: The proxy protocol version the backend expect. Supported values are `v1`, `v2`, `v2-ssl`, `v2-ssl-cn` or `no`. The default behavior if not declared is that the protocol is not supported by the backends and should not be used.
+
+* http://www.haproxy.org/download/1.8/doc/proxy-protocol.txt
+* http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-send-proxy
+* http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-send-proxy-v2
+* http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-send-proxy-v2-ssl
+* http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-send-proxy-v2-ssl-cn
 
 ### Secure Backend
 

--- a/pkg/common/ingress/annotations/proxybackend/main.go
+++ b/pkg/common/ingress/annotations/proxybackend/main.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxybackend
+
+import (
+	"github.com/golang/glog"
+	extensions "k8s.io/api/extensions/v1beta1"
+	"regexp"
+
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/parser"
+)
+
+const (
+	proxyProtocolAnn = "ingress.kubernetes.io/proxy-protocol"
+)
+
+var (
+	// "" (empty) is also a valid content
+	proxyProtocolRegex = regexp.MustCompile(`^(|no|v1|v2|v2-ssl|v2-ssl-cn)$`)
+)
+
+// Config is the proxybackend configuration instance
+type Config struct {
+	ProxyProtocol string `json:"proxyProtocol"`
+}
+
+// Equal tests for equality between two Config types
+func (c1 *Config) Equal(c2 *Config) bool {
+	if c1.ProxyProtocol != c2.ProxyProtocol {
+		return false
+	}
+	return true
+}
+
+type proxy struct{}
+
+// NewParser creates a new proxybackend configuration annotation parser
+func NewParser() parser.IngressAnnotation {
+	return proxy{}
+}
+
+// ParseAnnotations parses the annotations contained in the ingress
+// rule used to configure the backend
+func (p proxy) Parse(ing *extensions.Ingress) (interface{}, error) {
+	pp, err := parser.GetStringAnnotation(proxyProtocolAnn, ing)
+	if err != nil {
+		pp = ""
+	}
+	// "no", "" (empty) or any other non "v1|v2|v2-ssl|..." value is
+	// ignored by the template, falling back to not using proxy protocol
+	if !proxyProtocolRegex.MatchString(pp) {
+		glog.Warningf("ignoring invalid proxy protocol option '%v' on %v/%v", pp, ing.Namespace, ing.Name)
+		pp = ""
+	}
+
+	return &Config{
+		ProxyProtocol: pp,
+	}, nil
+}

--- a/pkg/common/ingress/controller/annotations.go
+++ b/pkg/common/ingress/controller/annotations.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"github.com/golang/glog"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/proxybackend"
 
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/alias"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/auth"
@@ -83,6 +84,7 @@ func newAnnotationExtractor(cfg extractorConfig) annotationExtractor {
 			"Whitelist":            ipwhitelist.NewParser(cfg),
 			"UsePortInRedirects":   portinredirect.NewParser(cfg),
 			"Proxy":                proxy.NewParser(cfg),
+			"ProxyBackend":         proxybackend.NewParser(),
 			"RateLimit":            ratelimit.NewParser(cfg),
 			"Connection":           connection.NewParser(),
 			"Redirect":             redirect.NewParser(),
@@ -144,6 +146,7 @@ const (
 	secureUpstream       = "SecureUpstream"
 	healthCheck          = "HealthCheck"
 	blueGreen            = "BlueGreen"
+	proxyBackend         = "ProxyBackend"
 	sslPassthrough       = "SSLPassthrough"
 	configSnippet        = "ConfigurationSnippet"
 	sessionAffinity      = "SessionAffinity"
@@ -201,6 +204,14 @@ func (e *annotationExtractor) BlueGreen(ing *extensions.Ingress) *bluegreen.Conf
 		}
 	}
 	return val.(*bluegreen.Config)
+}
+
+func (e *annotationExtractor) ProxyBackend(ing *extensions.Ingress) *proxybackend.Config {
+	val, err := e.annotations[proxyBackend].Parse(ing)
+	if err != nil {
+		return &proxybackend.Config{}
+	}
+	return val.(*proxybackend.Config)
 }
 
 func (e *annotationExtractor) SSLPassthrough(ing *extensions.Ingress) bool {

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"fmt"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/proxybackend"
 	"math/rand"
 	"net"
 	"reflect"
@@ -530,6 +531,7 @@ type backendContext struct {
 	affinity    *sessionaffinity.AffinityConfig
 	balance     string
 	blueGreen   *bluegreen.Config
+	proxy       *proxybackend.Config
 	snippet     snippet.Config
 	conn        *connection.Config
 	slotsInc    int
@@ -541,6 +543,7 @@ func (ic *GenericController) createBackendContext(ing *extensions.Ingress) *back
 		affinity:    ic.annotations.SessionAffinity(ing),
 		balance:     ic.annotations.BalanceAlgorithm(ing),
 		blueGreen:   ic.annotations.BlueGreen(ing),
+		proxy:       ic.annotations.ProxyBackend(ing),
 		snippet:     ic.annotations.ConfigurationSnippet(ing),
 		conn:        ic.annotations.Connection(ing),
 		slotsInc:    ic.annotations.SlotsIncrement(ing),
@@ -744,6 +747,10 @@ func (ctx *backendContext) copyBackendAnnotations(backend *ingress.Backend) {
 
 	if len(backend.BlueGreen.DeployWeight) == 0 {
 		backend.BlueGreen = *ctx.blueGreen
+	}
+
+	if backend.Proxy.ProxyProtocol == "" {
+		backend.Proxy.ProxyProtocol = ctx.proxy.ProxyProtocol
 	}
 
 	if len(backend.ConfigurationSnippet.Backend) == 0 {

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -19,6 +19,7 @@ package ingress
 import (
 	"fmt"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/hsts"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/proxybackend"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/secureupstream"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/snippet"
 	"time"
@@ -195,6 +196,8 @@ type Backend struct {
 	SlotsIncrement int `json:"slotsIncrement"`
 	// BlueGreen has the blue/green deployment configuration
 	BlueGreen bluegreen.Config `json:"blueGreen"`
+	// Proxy has proxy configurations used on the backend, eg version of the proxy protocol
+	Proxy proxybackend.Config `json:"proxyBackend"`
 	// ConfigurationSnippet contains additional configuration to be considered in the backend configuration
 	ConfigurationSnippet snippet.Config `json:"configurationSnippet"`
 	// Connection has backend or server connection limits and timeouts

--- a/pkg/common/ingress/types_equals.go
+++ b/pkg/common/ingress/types_equals.go
@@ -190,6 +190,10 @@ func (b1 *Backend) Equal(b2 *Backend) bool {
 		return false
 	}
 
+	if !b1.Proxy.Equal(&b2.Proxy) {
+		return false
+	}
+
 	if !b1.ConfigurationSnippet.Equal(&b2.ConfigurationSnippet) {
 		return false
 	}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -172,6 +172,11 @@ backend {{ $backend.Name }}
         {{- if ne $cacert.CAFileName "" }} verify required ca-file {{ $cacert.CAFileName }}
         {{- else }} verify none{{ end }}
     {{- end }}
+    {{- if eq $backend.Proxy.ProxyProtocol "v1" }} send-proxy
+        {{- else if eq $backend.Proxy.ProxyProtocol "v2" }} send-proxy-v2
+        {{- else if eq $backend.Proxy.ProxyProtocol "v2-ssl" }} send-proxy-v2-ssl
+        {{- else if eq $backend.Proxy.ProxyProtocol "v2-ssl-cn" }} send-proxy-v2-ssl-cn
+    {{- end }}
     {{- if ne $cfg.BackendCheckInterval "" }} check inter {{ $cfg.BackendCheckInterval }}{{ end }}
 {{- end }}
 


### PR DESCRIPTION
Add `ingress.kubernetes.io/proxy-protocol` annotation for backends. Supported protocols are `v1`, `v2`, `v2-ssl`, `v2-ssl-cn`, falling back to not using the protocol if not specified.