### PR TITLE
Add per directory TLS configuration of shared frontend

### DIFF
--- a/pkg/common/net/ssl/ssl.go
+++ b/pkg/common/net/ssl/ssl.go
@@ -282,9 +282,9 @@ func AddCertAuth(name string, ca []byte) (*ingress.SSLCert, error) {
 // AddOrUpdateDHParam creates a dh parameters file with the specified name
 func AddOrUpdateDHParam(name string, dh []byte) (string, error) {
 	pemName := fmt.Sprintf("%v.pem", name)
-	pemFileName := fmt.Sprintf("%v/%v", ingress.DefaultSSLDirectory, pemName)
+	pemFileName := fmt.Sprintf("%v/%v", "/ingress-controller", pemName)
 
-	tempPemFile, err := ioutil.TempFile(ingress.DefaultSSLDirectory, pemName)
+	tempPemFile, err := ioutil.TempFile("/ingress-controller", pemName)
 
 	glog.V(3).Infof("Creating temp file %v for DH param: %v", tempPemFile.Name(), pemName)
 	if err != nil {

--- a/pkg/common/net/ssl/ssl.go
+++ b/pkg/common/net/ssl/ssl.go
@@ -282,9 +282,9 @@ func AddCertAuth(name string, ca []byte) (*ingress.SSLCert, error) {
 // AddOrUpdateDHParam creates a dh parameters file with the specified name
 func AddOrUpdateDHParam(name string, dh []byte) (string, error) {
 	pemName := fmt.Sprintf("%v.pem", name)
-	pemFileName := fmt.Sprintf("%v/%v", "/ingress-controller", pemName)
+	pemFileName := fmt.Sprintf("%v/%v", ingress.DefaultSSLDirectory, pemName)
 
-	tempPemFile, err := ioutil.TempFile("/ingress-controller", pemName)
+	tempPemFile, err := ioutil.TempFile(ingress.DefaultSSLDirectory, pemName)
 
 	glog.V(3).Infof("Creating temp file %v for DH param: %v", tempPemFile.Name(), pemName)
 	if err != nil {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -31,7 +31,6 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/net/ssl"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
-	"io/ioutil"
 	api "k8s.io/api/core/v1"
 	"os"
 	"regexp"
@@ -338,39 +337,11 @@ func (cfg *haConfig) createHAProxyServers() {
 }
 
 func (cfg *haConfig) createDefaultCert() error {
-	sharedCertsFile := fmt.Sprintf("%v/%v", ingress.DefaultSSLDirectory, "+default.pem")
-	sharedCerts, err := os.OpenFile(sharedCertsFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
-	if err != nil {
-		return err
-	}
-	cat := func(file *os.File, fileName string) error {
-		fileCat, err := ioutil.ReadFile(fileName)
-		if err != nil {
-			return err
-		}
-		_, err = file.Write(append(fileCat, byte(10)))
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-	defer sharedCerts.Close()
-	defaultCertFile := cfg.haDefaultServer.SSLCertificate
-	if err = cat(sharedCerts, defaultCertFile); err != nil {
-		return err
-	}
-	certUsed := make(map[string]bool, len(cfg.haServers))
-	for _, server := range cfg.haServers {
-		certFile := server.SSLCertificate
-		// only if it's an unused non default certificate
-		if certFile != "" && !certUsed[certFile] && certFile != defaultCertFile {
-			if err = cat(sharedCerts, certFile); err != nil {
-				return err
-			}
-		}
-		certUsed[certFile] = true
-	}
-	return nil
+	// HAProxy uses the first file from ssldir as the default certificate
+	defaultCert := fmt.Sprintf("%v/%v", ingress.DefaultSSLDirectory, "+default.pem")
+	os.Remove(defaultCert)
+	err := os.Link(cfg.haDefaultServer.SSLCertificate, defaultCert)
+	return err
 }
 
 func (cfg *haConfig) createProcs() {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -295,7 +295,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
     bind unix@/var/run/haproxy-http-{{ $singleserver.HostnameSocket }}.sock accept-proxy
 {{- end }}
 {{- if $hasSSL }}
-    bind unix@/var/run/haproxy-https{{ if not $isShared }}-{{ $singleserver.HostnameSocket }}{{ end }}.sock ssl alpn h2,http/1.1 crt {{ if $isShared }}/ingress-controller/ssl/+default.pem{{ else }}{{ $singleserver.SSLCertificate }}{{ end }}{{ if $isCACert }} ca-file {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
+    bind unix@/var/run/haproxy-https{{ if not $isShared }}-{{ $singleserver.HostnameSocket }}{{ end }}.sock ssl alpn h2,http/1.1 crt {{ if $isShared }}/ingress-controller/ssl{{ else }}{{ $singleserver.SSLCertificate }}{{ end }}{{ if $isCACert }} ca-file {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
 {{- end }}
 {{- if gt $ing.Procs.Nbproc 1 }}
 {{- if and $hasBalance (not $hasSSL) }}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -295,7 +295,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
     bind unix@/var/run/haproxy-http-{{ $singleserver.HostnameSocket }}.sock accept-proxy
 {{- end }}
 {{- if $hasSSL }}
-    bind unix@/var/run/haproxy-https{{ if not $isShared }}-{{ $singleserver.HostnameSocket }}{{ end }}.sock ssl alpn h2,http/1.1 crt {{ if $isShared }}/ingress-controller/ssl{{ else }}{{ $singleserver.SSLCertificate }}{{ end }}{{ if $isCACert }} ca-file {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
+    bind unix@/var/run/haproxy-https{{ if not $isShared }}-{{ $singleserver.HostnameSocket }}{{ end }}.sock ssl alpn h2,http/1.1 crt {{ if $isShared }}/ingress-controller/ssl/shared-frontend/{{ else }}{{ $singleserver.SSLCertificate }}{{ end }}{{ if $isCACert }} ca-file {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
 {{- end }}
 {{- if gt $ing.Procs.Nbproc 1 }}
 {{- if and $hasBalance (not $hasSSL) }}


### PR DESCRIPTION
A single HAProxy frontend can handle several domains using a single `bind` keyword and a single `crt` configuration. This change create a directory that receives (hard link) all certificates used on the shared frontend.

This will change again on v0.8 after create an array of frontends, each one with their array of servers/crt/key.

Fixes #223 