### PR TITLE
Add OAuth2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ The following annotations are supported:
 ||[`ingress.kubernetes.io/limit-whitelist`](#limit)|cidr list|-|
 |`[0]`|[`ingress.kubernetes.io/maxconn-server`](#connection)|qty|-|
 |`[0]`|[`ingress.kubernetes.io/maxqueue-server`](#connection)|qty|-|
+|`[1]`|[`ingress.kubernetes.io/oauth`](#oauth)|"oauth2_proxy"|[doc](/examples/auth/oauth)|
+|`[1]`|[`ingress.kubernetes.io/oauth-uri-prefix`](#oauth)|URI prefix|[doc](/examples/auth/oauth)|
+|`[1]`|[`ingress.kubernetes.io/oauth-headers`](#oauth)|`<header>:<var>,...`|[doc](/examples/auth/oauth)|
 |`[1]`|[`ingress.kubernetes.io/proxy-protocol`](#proxy-protocol)|[v1\|v2\|v2-ssl\|v2-ssl-cn]|-|
 |`[0]`|[`ingress.kubernetes.io/slots-increment`](#dynamic-scaling)|qty|-|
 |`[0]`|[`ingress.kubernetes.io/timeout-queue`](#connection)|qty|-|
@@ -211,6 +214,25 @@ Configurations of connection limit and timeout.
 * http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.2-maxqueue
 * http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#4-timeout%20queue
 * Time suffix: http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#2.4
+
+### OAuth
+
+Configure OAuth2 via Bitly's `oauth2_proxy`.
+
+* `ingress.kubernetes.io/oauth`: Defines the oauth implementation. The only supported option is `oauth2_proxy`.
+* `ingress.kubernetes.io/oauth-uri-prefix`: Defines the URI prefix of the oauth service. The default value is `/oauth2`. There should be a backend with this path in the ingress resource.
+* `ingress.kubernetes.io/oauth-headers`: Defines an optional comma-separated list of `<header>:<haproxy-var>` used to configure request headers to the upstream backends. The default value is `X-Auth-Request-Email:auth_response_email` which means configuring a header `X-Auth-Request-Email` with the value of the var `auth_response_email`. New variables can be added overwriting the default `auth-request.lua` script.
+
+The `oauth2_proxy` implementation expects Bitly's [oauth2_proxy](https://github.com/bitly/oauth2_proxy)
+running as a backend of the same domain that should be protected. `oauth2_proxy` has support
+to GitHub, Google, Facebook, OIDC and many others.
+
+All paths of a domain will have the same oauth configurations, despite if the path is configured
+on an ingress resource without oauth annotations. In other words, if two ingress resources share
+the same domain but only one has oauth annotations - the one that has at least the `oauth2_proxy`
+service - all paths from that domain will be protected.
+
+See also the [example](/examples/auth/oauth) page.
 
 ### Proxy Protocol
 

--- a/examples/auth/oauth/README.md
+++ b/examples/auth/oauth/README.md
@@ -1,0 +1,103 @@
+# HAProxy Ingress OAuth2 authentication
+
+This example demonstrates how to configure
+[OAuth2](https://oauth.net/2/) on HAProxy Ingress controller.
+
+## Prerequisites
+
+This document has the following prerequisite:
+
+* A Kubernetes cluster with a running HAProxy Ingress controller v0.7 or above.
+See the [five minutes deployment](/examples/setup-cluster.md#five-minutes-deployment)
+or the [deployment example](/examples/deployment)
+
+## How it works
+
+An OAuth2 configured domain will proxy all of its requests to a local oauth2 proxy.
+If the request doesn't provide a cookie with a valid signed token, the browser will
+redirect to the OAuth2 provider page, asking the user to login and authorize seding
+his email to the application.
+
+If the user authenticate and authorize to share his email address, the provider
+will redirect back to the application and the oauth2 proxy will provide a signed
+token to the user. If the cookie expires, is removed or its token has an invalid
+signature, the OAuth provider will be used again, otherwise only the local oauth2
+proxy is used.
+
+The whole process is transparent to the application, all the access control is
+built in the HAProxy configuration.
+
+## Configure an OAuth2 provider
+
+[oauth2_proxy](https://github.com/bitly/oauth2_proxy#oauth-provider-configuration)
+has the steps to configure several OAuth2 providers.
+
+## Deploy the proxy
+
+Download and edit
+[oauth2-proxy.yaml](https://raw.githubusercontent.com/jcmoraisjr/haproxy-ingress/master/examples/auth/oauth/oauth2-proxy.yaml)
+to fit your needs. Change at least the following command-line options:
+
+* `--provider`: See the options on oauth2_proxy [readme](https://github.com/bitly/oauth2_proxy#oauth-provider-configuration).
+* `--client-id` and `--client-secret`: ID and secret from the OAuth provider.
+* `--cookie-secret`: A base64 encoded 128 bits value.
+* `--cookie-secure`: Use true if the application domain uses TLS, use false otherwise. This option is used to choose the protocol in the last redirect.
+
+The cookie secret is used to sign the token sent back to the user's browser.
+Use one of the following options to create it - and leave it in a safe place.
+
+On a macOS or Linux terminal:
+
+```
+$ dd if=/dev/urandom of=/dev/stdout bs=16 count=1 2>/dev/null|base64
+```
+
+Using a python script:
+
+```
+$ python -c 'import os,base64; print base64.urlsafe_b64encode(os.urandom(16))'
+```
+
+After editing, create the oauth2-proxy deployment and service:
+
+```
+$ kubectl create -f oauth2-proxy.yaml
+deployment.extensions "oauth2-proxy" created
+service "oauth2-proxy" exposed
+```
+
+## Deploy the application
+
+Create an echoserver deployment. It'll be used to simulate the application
+and also check the headers provided by the oauth proxy.
+
+```
+$ kubectl run echoserver \
+  --image=gcr.io/google_containers/echoserver:1.3 \
+  --port=8080 \
+  --expose
+deployment.apps "echoserver" created
+service "echoserver" created
+```
+
+Download and edit
+[app.yaml](https://raw.githubusercontent.com/jcmoraisjr/haproxy-ingress/master/examples/auth/oauth/app.yaml)
+to fit your needs. Change at least the domain on `rules/host` and `tls/hosts`.
+Use the same domain configured in the OAuth2 provider and the same URI
+prefix configured in the oauth2_proxy deployment.
+
+Internal domains and IPs are supported. Edit `/etc/hosts` or use
+[nip.io](http://nip.io) to use a valid domain if you don't have one.
+
+After editing, create the ingress resource:
+
+```
+$ kubectl create -f app.yaml
+ingress.extensions "app" created
+```
+
+Fire a request to your domain and an optional `/uri`. Your OAuth2
+provider will ask you to authenticate. If everything is fine you'll
+see `x-auth-request-email` http header with your email account and a
+new cookie `_oauth2_proxy` with a signed token. The `/uri` will be
+preserved in the last redirect.

--- a/examples/auth/oauth/app.yaml
+++ b/examples/auth/oauth/app.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.kubernetes.io/oauth: oauth2_proxy
+  name: app
+spec:
+  rules:
+  - host: app.192.168.100.99.nip.io
+    http:
+      paths:
+      - backend:
+          serviceName: oauth2-proxy
+          servicePort: 4180
+        path: /oauth2
+      - backend:
+          serviceName: echoserver
+          servicePort: 8080
+        path: /
+  tls:
+  - hosts:
+    - app.192.168.100.99.nip.io

--- a/examples/auth/oauth/oauth2-proxy.yaml
+++ b/examples/auth/oauth/oauth2-proxy.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    run: oauth2-proxy
+  name: oauth2-proxy
+spec:
+  selector:
+    matchLabels:
+      run: oauth2-proxy
+  template:
+    metadata:
+      labels:
+        run: oauth2-proxy
+    spec:
+      containers:
+      - name: oauth2-proxy
+        image: quay.io/jcmoraisjr/oauth2-proxy
+        imagePullPolicy: IfNotPresent
+        args:
+        - --http-address=http://:4180
+        - --upstream=file:///dev/null
+        - --provider=XXXXX
+        - --client-id=XXXXX
+        - --client-secret=XXXXX
+        - --proxy-prefix=/oauth2
+        - --redirect-url=/oauth2/callback
+        - --email-domain=*
+        - --cookie-name=_oauth2_proxy
+        - --cookie-secret=XXXXX
+        - --cookie-secure=true
+        - --cookie-expire=24h
+        - --set-xauthrequest=true
+        ports:
+        - containerPort: 4180
+          protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    run: oauth2-proxy
+  name: oauth2-proxy
+spec:
+  ports:
+  - port: 4180
+    protocol: TCP
+    targetPort: 4180
+  selector:
+    run: oauth2-proxy

--- a/pkg/common/ingress/annotations/oauth/main.go
+++ b/pkg/common/ingress/annotations/oauth/main.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package oauth
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/parser"
+	extensions "k8s.io/api/extensions/v1beta1"
+	"regexp"
+	"strings"
+)
+
+const (
+	oauthAnn          = "ingress.kubernetes.io/oauth"
+	oauthURIPrefixAnn = "ingress.kubernetes.io/oauth-uri-prefix"
+	oauthHeadersAnn   = "ingress.kubernetes.io/oauth-headers"
+)
+
+var (
+	headerRegex = regexp.MustCompile(`^[A-Za-z0-9_-]+$`)
+)
+
+// Config has oauth configurations
+type Config struct {
+	OAuthImpl   string            `json:"oauthImpl"`
+	URIPrefix   string            `json:"uriAuth"`
+	BackendName string            `json:"backendName"`
+	Headers     map[string]string `json:"headers"`
+}
+
+type oauth struct {
+}
+
+// NewParser creates a new oauth annotation parser
+func NewParser() parser.IngressAnnotation {
+	return oauth{}
+}
+
+// Parse parses oauth annotations and create a Config struct
+func (a oauth) Parse(ing *extensions.Ingress) (interface{}, error) {
+	var uriPrefix string
+	var headers []string
+	oauthImpl, _ := parser.GetStringAnnotation(oauthAnn, ing)
+	if oauthImpl == "" {
+		return &Config{}, nil
+	}
+	switch oauthImpl {
+	case "oauth2_proxy":
+		uriPrefix = "/oauth2"
+		headers = []string{"X-Auth-Request-Email:auth_response_email"}
+	default:
+		glog.Warningf("ignoring invalid oauth implementation '%v' on %v/%v", oauthImpl, ing.Namespace, ing.Name)
+		return &Config{}, nil
+	}
+	if uriPrefixTmp, err := parser.GetStringAnnotation(oauthURIPrefixAnn, ing); err == nil {
+		uriPrefix = uriPrefixTmp
+	}
+	if headersTmp, err := parser.GetStringAnnotation(oauthHeadersAnn, ing); err == nil {
+		headers = strings.Split(headersTmp, ",")
+	}
+	uriPrefix = strings.TrimRight(uriPrefix, "/")
+	backend := findBackend(uriPrefix, ing)
+	if backend == nil {
+		return &Config{}, fmt.Errorf("path '%v' was not found on %v/%v", uriPrefix, ing.Namespace, ing.Name)
+	}
+	// TODO this is a controller construction
+	backendName := fmt.Sprintf("%s-%s-%s", ing.Namespace, backend.ServiceName, backend.ServicePort.String())
+	headersMap := make(map[string]string, len(headers))
+	for _, header := range headers {
+		if len(header) == 0 {
+			continue
+		}
+		h := strings.Split(header, ":")
+		if len(h) != 2 {
+			glog.Warningf("invalid header format '%v' on %v/%v", header, ing.Namespace, ing.Name)
+			continue
+		}
+		headersMap[h[0]] = h[1]
+	}
+	return &Config{
+		OAuthImpl:   oauthImpl,
+		URIPrefix:   uriPrefix,
+		BackendName: backendName,
+		Headers:     headersMap,
+	}, nil
+}
+
+func findBackend(p string, ing *extensions.Ingress) *extensions.IngressBackend {
+	for _, rule := range ing.Spec.Rules {
+		for _, path := range rule.HTTP.Paths {
+			if p == strings.TrimRight(path.Path, "/") {
+				return &path.Backend
+			}
+		}
+	}
+	return nil
+}
+
+// Equal tests equality between two Config objects
+func (c1 *Config) Equal(c2 *Config) bool {
+	if c1 == c2 {
+		return true
+	}
+	if c1 == nil || c2 == nil {
+		return false
+	}
+	if c1.OAuthImpl != c2.OAuthImpl {
+		return false
+	}
+	if c1.URIPrefix != c2.URIPrefix {
+		return false
+	}
+	if len(c1.Headers) != len(c2.Headers) {
+		return false
+	}
+	for hkey, hval := range c1.Headers {
+		if c2.Headers[hkey] != hval {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/common/ingress/controller/annotations.go
+++ b/pkg/common/ingress/controller/annotations.go
@@ -34,6 +34,7 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/healthcheck"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/hsts"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/ipwhitelist"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/oauth"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/parser"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/portinredirect"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/proxy"
@@ -77,6 +78,7 @@ func newAnnotationExtractor(cfg extractorConfig) annotationExtractor {
 			"BasicDigestAuth":      auth.NewParser(auth.AuthDirectory, cfg, cfg),
 			"ExternalAuth":         authreq.NewParser(),
 			"CertificateAuth":      authtls.NewParser(cfg),
+			"OAuth":                oauth.NewParser(),
 			"CorsConfig":           cors.NewParser(),
 			"UseResolver":          dnsresolvers.NewParser(cfg),
 			"HealthCheck":          healthcheck.NewParser(cfg),

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -38,6 +38,7 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/connection"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/cors"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/ipwhitelist"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/oauth"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/proxy"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/ratelimit"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/redirect"
@@ -345,6 +346,8 @@ type Location struct {
 	// authentication using an external provider
 	// +optional
 	ExternalAuth authreq.External `json:"externalAuth,omitempty"`
+	// OAuth has external oauth configuration
+	OAuth oauth.Config `json:"oauth,omitempty"`
 	// RateLimit describes a limit in the number of connections per IP
 	// address or connections per second.
 	// The Redirect annotation precedes RateLimit

--- a/pkg/common/ingress/types_equals.go
+++ b/pkg/common/ingress/types_equals.go
@@ -376,6 +376,9 @@ func (l1 *Location) Equal(l2 *Location) bool {
 	if !(&l1.ExternalAuth).Equal(&l2.ExternalAuth) {
 		return false
 	}
+	if !l1.OAuth.Equal(&l2.OAuth) {
+		return false
+	}
 	if !(&l1.RateLimit).Equal(&l2.RateLimit) {
 		return false
 	}

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/cors"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/dnsresolvers"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/hsts"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/oauth"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/proxy"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/waf"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/defaults"
@@ -318,6 +319,7 @@ func (cfg *haConfig) createHAProxyServers() {
 			CORS:               serverCORS(server),
 			WAF:                serverWAF(server),
 			HasRateLimit:       serverHasRateLimit(server),
+			OAuth:              serverOAuth(server),
 			CertificateAuth:    server.CertificateAuth,
 			Alias:              server.Alias,
 			AliasIsRegex:       idHasRegex(server.Alias),
@@ -454,6 +456,7 @@ func (cfg *haConfig) newHAProxyLocations(server *ingress.Server) ([]*types.HAPro
 			IsDefBackend:   location.IsDefBackend,
 			Path:           location.Path,
 			Backend:        location.Backend,
+			OAuth:          location.OAuth,
 			CORS:           location.CorsConfig,
 			HSTS:           location.HSTS,
 			WAF:            location.WAF,
@@ -670,4 +673,13 @@ func serverHasRateLimit(server *ingress.Server) bool {
 		}
 	}
 	return false
+}
+
+func serverOAuth(server *ingress.Server) *oauth.Config {
+	for _, location := range server.Locations {
+		if location.OAuth.OAuthImpl != "" {
+			return &location.OAuth
+		}
+	}
+	return nil
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/cors"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/dnsresolvers"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/hsts"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/oauth"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/proxy"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/ratelimit"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/redirect"
@@ -147,6 +148,7 @@ type (
 		CORS               *cors.CorsConfig      `json:"cors"`
 		WAF                *waf.Config           `json:"waf"`
 		HasRateLimit       bool                  `json:"hasRateLimit"`
+		OAuth              *oauth.Config         `json:"oauth,omitempty"`
 		CertificateAuth    authtls.AuthSSLConfig `json:"certificateAuth,omitempty"`
 		Alias              string                `json:"alias,omitempty"`
 		AliasIsRegex       bool                  `json:"aliasIsRegex"`
@@ -157,6 +159,7 @@ type (
 		IsDefBackend         bool                `json:"isDefBackend"`
 		Path                 string              `json:"path"`
 		Backend              string              `json:"backend"`
+		OAuth                oauth.Config        `json:"oauth"`
 		CORS                 cors.CorsConfig     `json:"cors"`
 		HSTS                 hsts.Config         `json:"hsts"`
 		WAF                  waf.Config          `json:"waf"`

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 FROM haproxy:1.8-alpine
-RUN apk --no-cache add socat openssl
+RUN apk --no-cache add socat openssl lua5.3 lua-socket
 
 # dumb-init kindly manages SIGCHLD from forked HAProxy processes
 ARG DUMB_INIT_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -25,6 +25,7 @@ global
     log-tag ingress
 {{- end }}
     lua-load /usr/local/etc/haproxy/lua/send-response.lua
+    lua-load /usr/local/etc/haproxy/lua/auth-request.lua
 {{- if ne $cfg.SSLDHParam.Filename "" }}
     # DH PEM checksum: {{ $cfg.SSLDHParam.PemSHA }}
     ssl-dh-param-file {{ $cfg.SSLDHParam.Filename }}
@@ -417,6 +418,23 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- if ne $listName "" }}
 {{- $realm := $location.Userlist.Realm }}
     http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if {{ $server.ACLLabel }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
+{{- if $hasBalance }}
+{{- range $server := $servers }}
+{{- if $server.OAuth }}
+{{- $oauth := $server.OAuth }}
+{{- if eq $oauth.OAuthImpl "oauth2_proxy" }}
+    http-request set-header X-Real-IP %[src] if {{ $server.ACLLabel }}
+    http-request lua.auth-request {{ $oauth.BackendName }} {{ $oauth.URIPrefix }}/auth if {{ $server.ACLLabel }}
+    http-request redirect location {{ $oauth.URIPrefix }}/start?rd=%[path] if {{ $server.ACLLabel }} !{ path_beg {{ $oauth.URIPrefix }}/ } !{ var(txn.auth_response_successful) -m bool }
+{{- range $header, $attr := $oauth.Headers }}
+    http-request set-header {{ $header }} %[var(txn.{{ $attr }})] if {{ $server.ACLLabel }} { var(txn.{{ $attr }}) -m found }
 {{- end }}
 {{- end }}
 {{- end }}

--- a/rootfs/usr/local/etc/haproxy/lua/auth-request.lua
+++ b/rootfs/usr/local/etc/haproxy/lua/auth-request.lua
@@ -1,0 +1,123 @@
+-- The MIT License (MIT)
+--
+-- Copyright (c) 2018 Tim Düsterhus
+--
+-- Permission is hereby granted, free of charge, to any person obtaining a copy
+-- of this software and associated documentation files (the "Software"), to deal
+-- in the Software without restriction, including without limitation the rights
+-- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+-- copies of the Software, and to permit persons to whom the Software is
+-- furnished to do so, subject to the following conditions:
+--
+-- The above copyright notice and this permission notice shall be included in all
+-- copies or substantial portions of the Software.
+--
+-- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+-- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+-- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+-- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+-- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+-- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+-- SOFTWARE.
+
+local http = require("socket.http")
+
+--- Monkey Patches around bugs in haproxy's Socket class
+-- This function calls core.tcp(), fixes a few methods and
+-- returns the resulting socket.
+-- @return Socket
+function create_sock()
+	local sock = core.tcp()
+
+	-- https://www.mail-archive.com/haproxy@formilux.org/msg28574.html
+	sock.old_receive = sock.receive
+	sock.receive = function(socket, pattern, prefix)
+		local a, b
+		if pattern == nil then pattern = "*l" end
+		if prefix == nil then
+			a, b = sock:old_receive(pattern)
+		else
+			a, b = sock:old_receive(pattern, prefix)
+		end
+		return a, b
+	end
+
+	-- https://www.mail-archive.com/haproxy@formilux.org/msg28604.html
+	sock.old_settimeout = sock.settimeout
+	sock.settimeout = function(socket, timeout)
+		socket:old_settimeout(timeout)
+
+		return 1
+	end
+
+	return sock
+end
+
+core.register_action("auth-request", { "http-req" }, function(txn, be, path)
+	txn:set_var("txn.auth_response_successful", false)
+
+	-- Check whether the given backend exists.
+	if core.backends[be] == nil then
+		txn:Alert("Unknown auth-request backend '" .. be .. "'")
+		txn:set_var("txn.auth_response_code", 500)
+		return
+	end
+
+	-- Check whether the given backend has servers that
+	-- are not `DOWN`.
+	local addr = nil
+	for name, server in pairs(core.backends[be].servers) do
+		if server:get_stats()['status'] == "UP" then
+			addr = server:get_addr()
+			break
+		end
+	end
+	if addr == nil then
+		txn:Warning("No servers available for auth-request backend: '" .. be .. "'")
+		txn:set_var("txn.auth_response_code", 500)
+		return
+	end
+
+	-- Transform table of request headers from haproxy's to
+	-- socket.http's format.
+	local headers = {}
+	for header, values in pairs(txn.http:req_get_headers()) do
+		for i, v in pairs(values) do
+			if headers[header] == nil then
+				headers[header] = v
+			else
+				headers[header] = headers[header] .. ", " .. v
+			end
+		end
+	end
+
+	-- Make request to backend.
+	local b, c, h = http.request {
+		url = "http://" .. addr .. path,
+		headers = headers,
+		create = create_sock,
+		-- Disable redirects, because DNS does not work here.
+		redirect = false
+	}
+
+	-- Check whether we received a valid HTTP response.
+	if b == nil then
+		txn:Warning("Failure in auth-request backend '" .. be .. "': " .. c)
+		txn:set_var("txn.auth_response_code", 500)
+		return
+	end
+
+	-- 2xx: Allow request.
+	if 200 <= c and c < 300 then
+		txn:set_var("txn.auth_response_successful", true)
+		txn:set_var("txn.auth_response_code", c)
+		txn:set_var("txn.auth_response_email", h["x-auth-request-email"])
+	-- 401 / 403: Do not allow request.
+	elseif c == 401 or c == 403 then
+		txn:set_var("txn.auth_response_code", c)
+	-- Everything else: Do not allow request and log.
+	else
+		txn:Warning("Invalid status code in auth-request backend '" .. be .. "': " .. c)
+		txn:set_var("txn.auth_response_code", c)
+	end
+end, 2)


### PR DESCRIPTION
Starting implementation of OAuth2 support. An oauth2 proxy should be configured as a deployment+service to make the OAuth handshake and sign a token. The current implementation uses Bitly’s `oauth2_proxy`.

Implements #200 