### PR TITLE
Respect sort-backends flag

### DIFF
--- a/pkg/controller/dynconfig/dynconfig.go
+++ b/pkg/controller/dynconfig/dynconfig.go
@@ -328,8 +328,8 @@ func (d *DynConfig) fillBackendServerSlots() {
 					BackendServerName: target,
 					BackendEndpoint:   &curEndpoint,
 				}
+				newBackend.FullSlotIndices = append(newBackend.FullSlotIndices, target)
 			}
-			newBackend.FullSlotIndices = append(newBackend.FullSlotIndices, target)
 		}
 		d.updatedConfig.BackendSlots[backendName] = &newBackend
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -187,6 +187,8 @@ type (
 	HAProxyBackendSlots struct {
 		// map from ip:port to server name
 		FullSlots map[string]HAProxyBackendSlot
+		// Keep track of the ordering of backends
+		FullSlotIndices []string
 		// list of unused server names
 		EmptySlots []string
 		// resolver name used for this Backend definition

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -149,8 +149,9 @@ backend {{ $backend.Name }}
     server-template server-dns {{ $BackendSlots.TotalSlots }} {{ $backend.Service.Name }}.{{ $backend.Service.Namespace }}.svc.{{ $cfg.DNSClusterDomain }}:{{ $backend.Port }} resolvers {{ $BackendSlots.UseResolver }} resolve-prefer ipv4 init-addr none
         {{- template "backend" map $cfg $backend }}
 {{- else }}
-{{- range $target, $slot := $BackendSlots.FullSlots }}
-    server {{ $slot.BackendServerName }} {{ $target }}
+{{- range $value := $BackendSlots.FullSlotIndices }}
+        {{ $slot := index $BackendSlots.FullSlots  $value }}
+        server {{ $slot.BackendServerName }} {{ $value }}
         {{- if ge $slot.BackendEndpoint.Weight 0 }} weight {{ $slot.BackendEndpoint.Weight }}{{ end }}
         {{- template "backend" map $cfg $backend }}
 {{- end }}


### PR DESCRIPTION
Resolves the issue discussed in #240 

* Adds a new field to `HAProxyBackendSlots` struct called `FullSlotIndices` of type []string - this is used purely to track the order of processing of endpoint targets

* Appends new targets to `FullSlotIndices` as each upstream is processed and added to the backend

* Updates the template to range over `FullSlotIndices` for each backend rather than `range $target, $slot := $BackendSlots.FullSlots` as this causes the map to become ordered alphabetically

* Tested in a local fork and build with both the default behaviour of `sort-backends=false` and explicitly setting `sort-backends=true`