### PR TITLE
Add server-alias-regex annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,12 +257,12 @@ Configure secure (TLS) connection to the backends.
 
 ### Server Alias
 
-Creates an alias of the server that annotation belongs to.
-It'll be using the same backend but different ACL.
-Alias rules will be checked at the very end of list or rules.
-It is allowed to be a regex.
+Configure hostname alias. All annotations will be combined together with the host
+attribute in the same ACL, and any of them might be used to match SNI extensions
+(TLS) or Host HTTP header. The matching is case insensitive.
 
-Note: `^` and `$` cannot be used because they are already included in ACL.
+* `ingress.kubernetes.io/server-alias`: Defines an alias with hostname-like syntax. On v0.6 and older, wildcard `*` wasn't converted to match a subdomain. Regular expression was also accepted but dots were escaped, making this alias less useful as a regex. Starting v0.7 the same hostname syntax is used, so `*.my.domain` will match `app.my.domain` but won't match `sub.app.my.domain`.
+* `ingress.kubernetes.io/server-alias-regex`: Only in v0.7 and newer. Match hostname using a POSIX extended regular expression. The regex will be used verbatim, so add `^` and `$` if strict hostname is desired and escape `\.` dots in order to strictly match them. Some HTTP clients add the port number in the Host header, so remember to add `(:[0-9]+)?$` in the end of the regex if a dollar sign `$` is being used to match the end of the string.
 
 ### Rewrite Target
 

--- a/pkg/common/ingress/annotations/alias/main.go
+++ b/pkg/common/ingress/annotations/alias/main.go
@@ -23,10 +23,17 @@ import (
 )
 
 const (
-	annotation = "ingress.kubernetes.io/server-alias"
+	aliasAnn      = "ingress.kubernetes.io/server-alias"
+	aliasRegexAnn = "ingress.kubernetes.io/server-alias-regex"
 )
 
 type alias struct {
+}
+
+// Config has the server alias configuration
+type Config struct {
+	Host  string
+	Regex string
 }
 
 // NewParser creates a new Alias annotation parser
@@ -37,5 +44,24 @@ func NewParser() parser.IngressAnnotation {
 // Parse parses the annotations contained in the ingress rule
 // used to add an alias to the provided hosts
 func (a alias) Parse(ing *extensions.Ingress) (interface{}, error) {
-	return parser.GetStringAnnotation(annotation, ing)
+	host, _ := parser.GetStringAnnotation(aliasAnn, ing)
+	regex, _ := parser.GetStringAnnotation(aliasRegexAnn, ing)
+	return &Config{
+		Host:  host,
+		Regex: regex,
+	}, nil
+}
+
+// Equal tests equality between two Config objects
+func (c1 *Config) Equal(c2 *Config) bool {
+	if c1 == nil || c2 == nil {
+		return c1 == c2
+	}
+	if c1.Host != c2.Host {
+		return false
+	}
+	if c1.Regex != c2.Regex {
+		return false
+	}
+	return true
 }

--- a/pkg/common/ingress/annotations/alias/main_test.go
+++ b/pkg/common/ingress/annotations/alias/main_test.go
@@ -32,14 +32,14 @@ func TestParse(t *testing.T) {
 
 	testCases := []struct {
 		annotations map[string]string
-		expected    string
+		expected    Config
 	}{
-		{map[string]string{annotation: "www.example.com"}, "www.example.com"},
-		{map[string]string{annotation: "*.example.com www.example.*"}, "*.example.com www.example.*"},
-		{map[string]string{annotation: `~^www\d+\.example\.com$`}, `~^www\d+\.example\.com$`},
-		{map[string]string{annotation: ""}, ""},
-		{map[string]string{}, ""},
-		{nil, ""},
+		{map[string]string{aliasAnn: "www.example.com"}, Config{Host: "www.example.com"}},
+		{map[string]string{aliasAnn: "*.example.com www.example.*"}, Config{Host: "*.example.com www.example.*"}},
+		{map[string]string{aliasAnn: `~^www\d+\.example\.com$`}, Config{Host: `~^www\d+\.example\.com$`}},
+		{map[string]string{aliasAnn: ""}, Config{}},
+		{map[string]string{}, Config{}},
+		{nil, Config{}},
 	}
 
 	ing := &extensions.Ingress{
@@ -53,7 +53,7 @@ func TestParse(t *testing.T) {
 	for _, testCase := range testCases {
 		ing.SetAnnotations(testCase.annotations)
 		result, _ := ap.Parse(ing)
-		if result != testCase.expected {
+		if !result.(*Config).Equal(&testCase.expected) {
 			t.Errorf("expected %v but returned %v, annotations: %s", testCase.expected, result, testCase.annotations)
 		}
 	}

--- a/pkg/common/ingress/controller/annotations.go
+++ b/pkg/common/ingress/controller/annotations.go
@@ -226,9 +226,9 @@ func (e *annotationExtractor) ConfigurationSnippet(ing *extensions.Ingress) snip
 	return val.(snippet.Config)
 }
 
-func (e *annotationExtractor) Alias(ing *extensions.Ingress) string {
+func (e *annotationExtractor) Alias(ing *extensions.Ingress) *alias.Config {
 	val, _ := e.annotations[serverAlias].Parse(ing)
-	return val.(string)
+	return val.(*alias.Config)
 }
 
 func (e *annotationExtractor) ClientBodyBufferSize(ing *extensions.Ingress) string {

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -18,6 +18,7 @@ package ingress
 
 import (
 	"fmt"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/alias"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/hsts"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/proxybackend"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress/annotations/secureupstream"
@@ -280,7 +281,7 @@ type Server struct {
 	// Locations list of URIs configured in the server.
 	Locations []*Location `json:"locations,omitempty"`
 	// Alias return the alias of the server name
-	Alias string `json:"alias,omitempty"`
+	Alias alias.Config `json:"alias,omitempty"`
 	// RedirectFromToWWW returns if a redirect to/from prefix www is required
 	RedirectFromToWWW bool `json:"redirectFromToWWW,omitempty"`
 	// CertificateAuth indicates the this server requires mutual authentication

--- a/pkg/common/ingress/types_equals.go
+++ b/pkg/common/ingress/types_equals.go
@@ -292,7 +292,7 @@ func (s1 *Server) Equal(s2 *Server) bool {
 	if s1.Hostname != s2.Hostname {
 		return false
 	}
-	if s1.Alias != s2.Alias {
+	if !s1.Alias.Equal(&s2.Alias) {
 		return false
 	}
 	if !s1.SSLPassthrough.Equal(&s2.SSLPassthrough) {

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -324,8 +324,9 @@ func (cfg *haConfig) createHAProxyServers() {
 			HasRateLimit:       serverHasRateLimit(server),
 			OAuth:              serverOAuth(server),
 			CertificateAuth:    server.CertificateAuth,
-			Alias:              server.Alias,
-			AliasIsRegex:       idHasRegex(server.Alias),
+			AliasHost:          server.Alias.Host,
+			AliasHostIsRegex:   idHasRegex(server.Alias.Host),
+			AliasRegex:         server.Alias.Regex,
 		}
 		if isDefaultServer {
 			haDefaultServer = &haServer
@@ -334,18 +335,18 @@ func (cfg *haConfig) createHAProxyServers() {
 		}
 	}
 	sort.SliceStable(haServers, func(i, j int) bool {
-		// Move hosts without wildcard and alias without regex to the top,
-		// following are hosts without wildcard whose alias has regex, and
-		// finally with the least precedence are hosts with wildcards
+		// Move hosts without wildcard and alias without regex/wildcard to the top,
+		// following are hosts without wildcard whose alias has regex or wildcard,
+		// and finally with the least precedence are hosts with wildcards
 		a, b := 0, 0
 		if haServers[i].HostnameIsWildcard {
 			a = 2
-		} else if haServers[i].AliasIsRegex {
+		} else if haServers[i].AliasHostIsRegex || haServers[i].AliasRegex != "" {
 			a = 1
 		}
 		if haServers[j].HostnameIsWildcard {
 			b = 2
-		} else if haServers[j].AliasIsRegex {
+		} else if haServers[j].AliasHostIsRegex || haServers[i].AliasRegex != "" {
 			b = 1
 		}
 		return a < b

--- a/pkg/controller/template.go
+++ b/pkg/controller/template.go
@@ -69,10 +69,6 @@ var funcMap = gotemplate.FuncMap{
 		rtn = regexp.MustCompile(`\*`).ReplaceAllLiteralString(rtn, "([^\\.]+)")
 		return "^" + rtn + "(:[0-9]+)?$"
 	},
-	"aliasRegex": func(hostname string) string {
-		rtn := regexp.MustCompile(`\.`).ReplaceAllLiteralString(hostname, "\\.")
-		return "^" + rtn + "(:[0-9]+)?$"
-	},
 	"sizeSuffix": func(size string) string {
 		value, err := utils.SizeSuffixToInt64(size)
 		if err != nil {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -150,8 +150,9 @@ type (
 		HasRateLimit       bool                  `json:"hasRateLimit"`
 		OAuth              *oauth.Config         `json:"oauth,omitempty"`
 		CertificateAuth    authtls.AuthSSLConfig `json:"certificateAuth,omitempty"`
-		Alias              string                `json:"alias,omitempty"`
-		AliasIsRegex       bool                  `json:"aliasIsRegex"`
+		AliasHost          string                `json:"aliasHost,omitempty"`
+		AliasHostIsRegex   bool                  `json:"aliasHostIsRegex"`
+		AliasRegex         string                `json:"aliasRegex"`
 	}
 	// HAProxyLocation has location data as a HAProxy friendly syntax
 	HAProxyLocation struct {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -646,12 +646,15 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- else }}
     acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.Hostname }}{{ if $needport }} {{ $server.Hostname }}:{{ $cfg.HTTPPort }} {{ $server.Hostname }}:{{ $cfg.HTTPSPort }}{{ if and $cfg.HTTPStoHTTPPort (ne $cfg.HTTPStoHTTPPort $cfg.HTTPPort) }} {{ $server.Hostname }}:{{ $cfg.HTTPStoHTTPPort }}{{ end }}{{ end }}
 {{- end }}
-{{- if $server.Alias }}
-{{- if $server.AliasIsRegex }}
-    acl {{ $server.ACLLabel }} {{ $fetch }} -m reg -i '{{ aliasRegex $server.Alias }}'
+{{- if $server.AliasHost }}
+{{- if $server.AliasHostIsRegex }}
+    acl {{ $server.ACLLabel }} {{ $fetch }} -m reg -i '{{ hostnameRegex $server.AliasHost }}'
 {{- else }}
-    acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.Alias }}{{ if $needport }} {{ $server.Alias }}:{{ $cfg.HTTPPort }} {{ $server.Alias }}:{{ $cfg.HTTPSPort }}{{ end }}
+    acl {{ $server.ACLLabel }} {{ $fetch }} -i {{ $server.AliasHost }}{{ if $needport }} {{ $server.AliasHost }}:{{ $cfg.HTTPPort }} {{ $server.AliasHost }}:{{ $cfg.HTTPSPort }}{{ end }}
 {{- end }}
+{{- end }}
+{{- if $server.AliasRegex }}
+    acl {{ $server.ACLLabel }} {{ $fetch }} -m reg -i '{{ $server.AliasRegex }}'
 {{- end }}
 {{- end }}
 {{- end }}{{/* define "acl" */}}


### PR DESCRIPTION
Changing the behavior of server-alias:

* `server-alias-regex`: new annotation, used to match hostname with POSIX extended regular expression. The regex is used verbatim and the matching is case insensitive.
* `server-alias`: changed to mimic hostname behavior - accept wildcard hostnames and usage of regex is discouraged. The matching is also case insensitive.

Implements #246