### PR TITLE
added "httponly" for cookie affinity

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -98,7 +98,7 @@ backend {{ $backend.Name }}
 {{- end }}
 {{- $sticky := $backend.SessionAffinity }}
 {{- if eq $sticky.AffinityType "cookie" }}
-    cookie {{ $sticky.CookieSessionAffinity.Name }} {{ $sticky.CookieSessionAffinity.Strategy }} {{ if eq $sticky.CookieSessionAffinity.Strategy "insert" }}indirect nocache{{ end }} dynamic
+    cookie {{ $sticky.CookieSessionAffinity.Name }} {{ $sticky.CookieSessionAffinity.Strategy }} {{ if eq $sticky.CookieSessionAffinity.Strategy "insert" }}indirect nocache httponly{{ end }} dynamic
     dynamic-cookie-key "{{ $cfg.CookieKey }}"
 {{- end }}
 {{- range $snippet := $backend.ConfigurationSnippet.Backend }}


### PR DESCRIPTION
Summary
The application is missing the 'httpOnly' cookie attribute

Vulnerability Detection Result
The cookies:

Set-Cookie: JSESSIONID=lGbJl57jz/c=; path=/ 

are missing the "httpOnly" attribute.
Solution
Solution type: Mitigation Mitigation

Set the 'httpOnly' attribute for any session cookie.

Affected Software/OS
Application with session handling in cookies.

Vulnerability Insight
The flaw is due to a cookie is not using the 'httpOnly' attribute. This allows a cookie to be accessed by JavaScript which could lead to session hijacking attacks.

Vulnerability Detection Method
Check all cookies sent by the application for a missing 'httpOnly' attribute

Details: Missing `httpOnly` Cookie Attribute (OID: 1.3.6.1.4.1.25623.1.0.105925)

Version used: $Revision: 5270 $

References
Other:	https://www.owasp.org/index.php/HttpOnly
https://www.owasp.org/index.php/Testing_for_cookies_attributes_(OTG-SESS-002)