### PR TITLE
Fixed oauth2_proxy cmd arg

### DIFF
--- a/examples/auth/oauth/oauth2-proxy.yaml
+++ b/examples/auth/oauth/oauth2-proxy.yaml
@@ -19,7 +19,7 @@ spec:
         image: quay.io/jcmoraisjr/oauth2-proxy
         imagePullPolicy: IfNotPresent
         args:
-        - /oauth2-proxy
+        - /oauth2_proxy
         - --http-address=http://:4180
         - --upstream=file:///dev/null
         - --provider=XXXXX


### PR DESCRIPTION
The `quay.io/jcmoraisjr/oauth2-proxy` [Dockerfile](https://github.com/jcmoraisjr/oauth2-proxy/blob/1b85e2035fa3d45f705944b33c107b19d55d9c6b/Dockerfile#L5) adds the binary as /oauth2_proxy instead of oauth2-proxy:
```FROM alpine:3.8
ARG URL=https://github.com/bitly/oauth2_proxy/releases/download/v2.2/oauth2_proxy-2.2.0.linux-amd64.go1.8.1.tar.gz
RUN apk add --no-cache ca-certificates \
 && wget -O- $URL | tar xzf - --strip-components=1\
 && chown root.root /oauth2_proxy\
 && addgroup -g 1001 oauth2proxy\
 && adduser -u 1001 -G oauth2proxy -D -s /bin/false oauth2proxy
USER oauth2proxy
```