### PR TITLE
Fix ssl-passthrough

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -290,11 +290,14 @@ func (cfg *haConfig) createHAProxyServers() {
 	for _, server := range cfg.ingress.PassthroughBackends {
 		haServer := &types.HAProxyPassthrough{
 			Hostname:           server.Hostname,
-			Alias:              false,
 			ACLLabel:           labelizeACL(server.Hostname),
 			Backend:            server.Backend,
 			HTTPPassBackend:    server.HTTPPassBackend,
 			HostnameIsWildcard: idHasWildcard(server.Hostname),
+			// implements the "interface" of the "acl" template
+			AliasHost:        false,
+			AliasHostIsRegex: false,
+			AliasRegex:       false,
 		}
 		haPassthrough = append(haPassthrough, haServer)
 	}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -183,11 +183,13 @@ type (
 	// HAProxyPassthrough has SSL passthrough configurations
 	HAProxyPassthrough struct {
 		Hostname           string `json:"hostname"`
-		Alias              bool   `json:"alias"`
 		ACLLabel           string `json:"aclLabel"`
 		Backend            string `json:"backend"`
 		HTTPPassBackend    string `json:"httpPassBackend"`
 		HostnameIsWildcard bool   `json:"hostnameIsWildcard"`
+		AliasHost          bool   `json:"aliasHost"`
+		AliasHostIsRegex   bool   `json:"aliasHostIsRegex"`
+		AliasRegex         bool   `json:"aliasRegex"`
 	}
 	// HAProxyBackendSlots contains used and empty backend server definitions
 	HAProxyBackendSlots struct {


### PR DESCRIPTION
SSL-passthrough configuration reuse acl template to build routes on SSL/TLS frontend. Currently ssl-passthrough doesn’t support alias annotations. This change implements some fields expected by the acl template

Fixes #257 