### PR TITLE
ConfigMap: add options to set ssl-engine and ssl-mode-async

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,9 @@ The following parameters are supported:
 ||[`ssl-ciphers`](#ssl-ciphers)|colon-separated list|[link to code](https://github.com/jcmoraisjr/haproxy-ingress/blob/v0.6/pkg/controller/config.go#L40)|
 ||[`ssl-dh-default-max-size`](#ssl-dh-default-max-size)|number|`1024`|
 ||[`ssl-dh-param`](#ssl-dh-param)|namespace/secret name|no custom DH param|
+||[`ssl-engine`](#ssl-engine)|OpenSSL engine name and parameters|no engine set|
 ||[`ssl-headers-prefix`](#ssl-headers-prefix)|prefix|`X-SSL`|
+||[`ssl-mode-async`](#ssl-engine)|[true\|false]|`false`|
 ||[`ssl-options`](#ssl-options)|space-separated list|`no-sslv3` `no-tls-tickets`|
 ||[`ssl-redirect`](#ssl-redirect)|[true\|false]|`true`|
 ||[`stats-auth`](#stats)|user:passwd|no auth|
@@ -742,6 +744,19 @@ Then, in the haproxy ingress configuration, `ssl-dh-param` should reference the
 resulting secret.
 
 http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#3.1-ssl-dh-param-file
+
+### ssl-engine
+
+Set the name of the OpenSSL engine to use. The string shall include the engine name
+and its parameters.
+
+Additionally, ssl-mode-async can be set to enable asynchronous TLS I/O operations if
+the ssl-engine used supports it.
+
+Reference:
+
+* http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#ssl-engine
+* http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#ssl-mode-async
 
 ### ssl-headers-prefix
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -148,6 +148,8 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		CookieKey:              "Ingress",
 		StrictHost:             true,
 		DynamicScaling:         false,
+		SSLEngine:              "",
+		SSLModeAsync:           false,
 		StatsSocket:            "/var/run/haproxy-stats.sock",
 		UseProxyProtocol:       false,
 		StatsProxyProtocol:     false,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -96,6 +96,8 @@ type (
 		CookieKey              string `json:"cookie-key"`
 		StrictHost             bool   `json:"strict-host"`
 		DynamicScaling         bool   `json:"dynamic-scaling"`
+		SSLEngine              string `json:"ssl-engine"`
+		SSLModeAsync           bool   `json:"ssl-mode-async"`
 		StatsSocket            string
 		UseProxyProtocol       bool   `json:"use-proxy-protocol"`
 		StatsProxyProtocol     bool   `json:"stats-proxy-protocol"`

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -32,6 +32,12 @@ global
 {{- else }}
     tune.ssl.default-dh-param {{ $cfg.SSLDHParam.DefaultMaxSize }}
 {{- end }}
+{{- if ne $cfg.SSLEngine "" }}
+    ssl-engine {{ $cfg.SSLEngine }}
+{{- if $cfg.SSLModeAsync }}
+    ssl-mode-async
+{{- end }}
+{{- end }}
     ssl-default-bind-ciphers {{ $cfg.SSLCiphers }}
     ssl-default-bind-options {{ $cfg.SSLOptions }}
 {{- range $snippet := $ing.ConfigGlobal }}


### PR DESCRIPTION
Some deployments may have the access to an OpenSSL engine to benefit
from, e.g., TLS offloading to a hardware engine.

Add new ConfigMap options to be able to more easily configure HAproxy
to use the engines available.