### PR TITLE
[WIP] - Add optional client authentication verification

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -536,12 +536,14 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 
 {{- /*------------------------------------*/}}
 {{- if and $hasSSL $isCACert }}
+{{- if eq $singleserver.CertificateAuth.VerifyClient "on" }}
 {{- if eq $singleserver.CertificateAuth.ErrorPage "" }}
     use_backend error495 if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
     use_backend error496 if { ssl_fc } !{ ssl_c_used }
 {{- else }}
     redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
     redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if { ssl_fc } !{ ssl_c_used }
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
When using optional client certificate authentication, HAProxy should not redirect users to the errorpage (495, 496 or whatever the user have customized), and must continue the communication flow, as this authentication is Optional.

TODO: 

* Improve go templating for this conditional loop
* Document the annotation ``ingress.kubernetes.io/auth-tls-verify-client: optional`` and improve, as if the 'optional' authentication is used and the user provides a certificate, but with invalid CA, the error495 must be presented to him. 
