### PR TITLE
Improve optional client cert auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The following annotations are supported:
 * `ingress.kubernetes.io/auth-tls-cert-header`: if true HAProxy will add `X-SSL-Client-Cert` http header with a base64 encoding of the X509 certificate provided by the client. Default is to not provide the client certificate.
 * `ingress.kubernetes.io/auth-tls-error-page`: optional URL of the page to redirect the user if he doesn't provide a certificate or the certificate is invalid.
 * `ingress.kubernetes.io/auth-tls-secret`: mandatory secret name with `ca.crt` key providing all certificate authority bundles used to validate client certificates.
+* `ingress.kubernetes.io/auth-tls-verify-client`: optional configuration of Client Verification behaviour. Supported values are `on`, `optional` and `optional_no_ca`
 
 See also client cert [sample](/examples/auth/client-certs).
 

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -536,12 +536,18 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 
 {{- /*------------------------------------*/}}
 {{- if and $hasSSL $isCACert }}
+{{- if or ( eq $singleserver.CertificateAuth.VerifyClient "on" ) ( eq $singleserver.CertificateAuth.VerifyClient "optional" ) }}
 {{- if eq $singleserver.CertificateAuth.ErrorPage "" }}
     use_backend error495 if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
+{{- if eq $singleserver.CertificateAuth.VerifyClient "on" }}
     use_backend error496 if { ssl_fc } !{ ssl_c_used }
+{{- end }}
 {{- else }}
     redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if { ssl_c_ca_err gt 0 } || { ssl_c_err gt 0 }
+{{- if eq $singleserver.CertificateAuth.VerifyClient "on" }}
     redirect location {{ $singleserver.CertificateAuth.ErrorPage }} if { ssl_fc } !{ ssl_c_used }
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@serpro.gov.br>

Improve optional client cert auth. 

The following will happen:

* When the annotation `ingress.kubernetes.io/auth-tls-verify-client` is set to `optional` or `on`, the following validations will be made

* If the certificate is invalid, expired, not recognized by any CA configured as the `auth-tls-secret` the error 495 will be used (the customized one, or the default one)

* If the certificate isn't presented by the client and it's required, using the `auth-tls-verify-client: "on"` the error 496 will be used (the customized one, or the default one)




