### PR TITLE
Add support to customize haproxy logformat

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ The following parameters are supported:
 |`[0]`|[`stats-ssl-cert`](#stats)|namespace/secret name|no ssl/plain http|
 |`[0]`|[`strict-host`](#strict-host)|[true\|false]|`true`|
 ||[`syslog-endpoint`](#syslog-endpoint)|IP:port (udp)|do not log|
+||[`syslog-format`](#syslog-format)|rfc5424\|rfc3164|rfc5424|
 ||[`tcp-log-format`](#log-format)|tcp log format|HAProxy default log format|
 ||[`timeout-client`](#timeout)|time with suffix|`50s`|
 ||[`timeout-client-fin`](#timeout)|time with suffix|`50s`|
@@ -838,6 +839,10 @@ A request to `my.domain.com/b` would serve:
 ### syslog-endpoint
 
 Configure the UDP syslog endpoint where HAProxy should send access logs.
+
+### syslog-format
+
+Configure the log format to be either rfc5424 ( default ) or rfc3164
 
 ### timeout
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -129,6 +129,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		BindIPAddrStats:        "*",
 		BindIPAddrHealthz:      "*",
 		Syslog:                 "",
+		SyslogFormat:           "rfc5424",
 		ModSecurity:            "",
 		ModSecTimeoutHello:     "100ms",
 		ModSecTimeoutIdle:      "30s",

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -77,6 +77,7 @@ type (
 		BindIPAddrStats        string `json:"bind-ip-addr-stats"`
 		BindIPAddrHealthz      string `json:"bind-ip-addr-healthz"`
 		Syslog                 string `json:"syslog-endpoint"`
+		SyslogFormat           string `json:"syslog-format"`
 		ModSecurity            string `json:"modsecurity-endpoints"`
 		ModSecTimeoutHello     string `json:"modsecurity-timeout-hello"`
 		ModSecTimeoutIdle      string `json:"modsecurity-timeout-idle"`

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -21,7 +21,7 @@ global
     hard-stop-after {{ $cfg.TimeoutStop }}
 {{- end }}
 {{- if ne $cfg.Syslog "" }}
-    log {{ $cfg.Syslog }} format rfc5424 local0
+    log {{ $cfg.Syslog }} format {{ $cfg.SyslogFormat }} local0
     log-tag ingress
 {{- end }}
     lua-load /usr/local/etc/haproxy/lua/send-response.lua


### PR DESCRIPTION
Supported format from haproxy are : rfc5424 or rfc3164

I personally need this to make log forward work with filebeat which expect rfc3164 format rather than 5424 and currently print out errors like 

```
haproxy-ingress-7d59695959-q5sjc haproxy-beat 2019-01-07T13:35:02.759Z  ERROR   [syslog]        syslog/input.go:131     can't not parse event as syslog rfc3164 {"message": "<134>1 2019-01-07T13:35:02+00:00 haproxy-ingress-7d59695959-q5sjc ingress 44 - - 10.244.5.0:48548 [07/Jan/2019:13:35:02.165] httpfront-shared-frontend~ aaa-aaaa-web-staging-8000/10.244.13.99:8000 0/0/1/593/595 404 9085 - - ---- 4/2/1/1/0 0/0 \"GET /health/ HTTP/1.1\"\n"}
```