### PR TITLE
Adds a new variable containing the namespace to be used in logging

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -134,6 +134,7 @@ listen tcp-{{ $tcp.Port }}
 backend {{ $backend.Name }}
     mode {{ if $backend.SSLPassthrough }}tcp{{ else }}http{{ end }}
     balance {{ $backend.BalanceAlgorithm }}
+    tcp-request content set-var(txn.namespace) str("{{ $backend.Service.Namespace }}")
 {{- if ne $backend.Connection.TimeoutQueue "" }}
     timeout queue {{ $backend.Connection.TimeoutQueue }}
 {{- end }}


### PR DESCRIPTION
This PR adds a new variable containing the Namespace, that can be used later into logging or other parts.

An example: 

```yaml
http-log-format: |
  '{ "namespace": "%[var(txn.namespace),json(utf8s)]", "clientip": "%ci", "auth": "-", "timestamp": "%tr", "verb": "%HM", "request": "%HU", "httpversion": "%HV", "response": "%ST", "bytesraw": "%B", "requestsizeraw": "%U", "requesttimeraw": "%TR", "proxy-upstream-name": "%b", "backend-address": "%si", "backend-response-size-raw": "%ST", "backend-response-time-raw": "%Tr", "backend-response-raw": "%ST", "agent": "%[capture.req.hdr(2),json(utf8s)]", "referrer": "%[capture.req.hdr(0),json(utf8s)]", "forward-for": "%[capture.req.hdr(1),json(utf8s)]", "ingress-host": "%[capture.req.hdr(3),json(utf8s)]" }'

```