### PR TITLE
Fix permission of frontend certs dir

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -381,7 +381,7 @@ func (cfg *haConfig) createFrontendCertsDir() error {
 	if err := os.RemoveAll(certsDir); err != nil {
 		return err
 	}
-	if err := os.MkdirAll(certsDir, 700); err != nil {
+	if err := os.MkdirAll(certsDir, 0700); err != nil {
 		return err
 	}
 	defaultCertFile := cfg.haDefaultServer.SSLCertificate


### PR DESCRIPTION
`os.Mkdir` receives the directory permission as a three groups of three bits number. Usually such notation is used as an octal number which, in Go, starts with a zero that was missing here.