### PR TITLE
Add TLS ALPN extension advertisement

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,7 @@ The following parameters are supported:
 ||[`timeout-server-fin`](#timeout)|time with suffix|`50s`|
 ||[`timeout-stop`](#timeout)|time with suffix|no timeout|
 ||[`timeout-tunnel`](#timeout)|time with suffix|`1h`|
+|`[0]`|[`tls-alpn`](#tls-alpn)|TLS ALPN advertisement|`h2,http/1.1`|
 ||[`use-proxy-protocol`](#use-proxy-protocol)|[true\|false]|`false`|
 
 ### balance-algorithm
@@ -930,6 +931,13 @@ Define timeout configurations:
 Reference:
 
 * `timeout-stop` - http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#3.1-hard-stop-after
+
+### tls-alpn
+
+Defines the TLS ALPN extension advertisement. The default value is `h2,http/1.1` which enables
+HTTP/2 on the client side.
+
+* http://cbonte.github.io/haproxy-dconv/1.8/configuration.html#5.1-alpn
 
 ### use-proxy-protocol
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -111,6 +111,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 			DefaultMaxSize: 2048,
 			SecretName:     "",
 		},
+		TLSALPN:                "h2,http/1.1",
 		NbprocBalance:          1,
 		NbprocSSL:              0,
 		Nbthread:               1,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -58,6 +58,7 @@ type (
 		SSLCiphers             string `json:"ssl-ciphers"`
 		SSLOptions             string `json:"ssl-options"`
 		SSLDHParam             `json:",squash"`
+		TLSALPN                string `json:"tls-alpn"`
 		NbprocBalance          int    `json:"nbproc-balance"`
 		NbprocSSL              int    `json:"nbproc-ssl"`
 		Nbthread               int    `json:"nbthread"`

--- a/rootfs/etc/haproxy/template/haproxy-v07.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy-v07.tmpl
@@ -332,7 +332,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
     bind unix@/var/run/haproxy-http-{{ $singleserver.HostnameSocket }}.sock accept-proxy
 {{- end }}
 {{- if $hasSSL }}
-    bind unix@/var/run/haproxy-https{{ if not $isShared }}-{{ $singleserver.HostnameSocket }}{{ end }}.sock ssl alpn h2,http/1.1 crt {{ if $isShared }}/ingress-controller/ssl/shared-frontend/{{ else }}{{ $singleserver.SSLCertificate }}{{ end }}{{ if $isCACert }} ca-file {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
+    bind unix@/var/run/haproxy-https{{ if not $isShared }}-{{ $singleserver.HostnameSocket }}{{ end }}.sock ssl alpn {{ $cfg.TLSALPN }} crt {{ if $isShared }}/ingress-controller/ssl/shared-frontend/{{ else }}{{ $singleserver.SSLCertificate }}{{ end }}{{ if $isCACert }} ca-file {{ $singleserver.CertificateAuth.AuthSSLCert.CAFileName }} verify optional ca-ignore-err all crt-ignore-err all{{ end }} accept-proxy
 {{- end }}
 {{- if gt $ing.Procs.Nbproc 1 }}
 {{- if and $hasBalance (not $hasSSL) }}


### PR DESCRIPTION
ALPN advertisement configuration is used to choose the HTTP protocol version. By default h2 is used if the client has support, falling back to http/1.1 otherwise. This configmap option could be used if h2 has any issue with some clients.