### PR TITLE
Fix overlapping configs on shared frontend

### DIFF
--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -501,6 +501,12 @@ func (cfg *haConfig) newHAProxyLocations(server *ingress.Server) ([]*types.HAPro
 			otherPaths = otherPaths + " " + location.Path
 			haLocation.HAMatchPath = " { path -m beg " + haLocation.Path + " }"
 			haLocation.HAMatchTxnPath = " { var(txn.path) -m beg " + haLocation.Path + " }"
+			for _, loc := range locations {
+				if loc.Path != haLocation.Path && strings.HasPrefix(loc.Path, haLocation.Path) {
+					haLocation.HAMatchPath = haLocation.HAMatchPath + " !{ path -m beg " + loc.Path + " }"
+					haLocation.HAMatchTxnPath = haLocation.HAMatchTxnPath + " !{ var(txn.path) -m beg " + loc.Path + " }"
+				}
+			}
 		}
 		haLocations[i] = &haLocation
 	}

--- a/rootfs/etc/haproxy/template/haproxy-v07.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy-v07.tmpl
@@ -533,9 +533,9 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- $rewriteTarget := $location.Rewrite.Target }}
 {{- if ne $rewriteTarget "" }}
 {{- if eq $rewriteTarget "/" }}
-    reqrep ^([^\ :]*)\ {{ $location.Path }}/?(.*$) \1\ {{ $rewriteTarget }}\2 if {{ if $location.SSLRedirect }}from-https {{ end }}{{ $server.ACLLabel }} { var(txn.path) -m beg {{ $location.Path }} }
+    reqrep ^([^\ :]*)\ {{ $location.Path }}/?(.*$) \1\ {{ $rewriteTarget }}\2 if {{ if $location.SSLRedirect }}from-https {{ end }}{{ $server.ACLLabel }}{{ $location.HAMatchTxnPath }}
 {{- else }}
-    reqrep ^([^\ :]*)\ {{ $location.Path }}(.*$) \1\ {{ $rewriteTarget }}{{ if hasSuffix $location.Path "/" }}/{{ end }}\2 if {{ if $location.SSLRedirect }}from-https {{ end }}{{ $server.ACLLabel }} { var(txn.path) -m beg {{ $location.Path }} }
+    reqrep ^([^\ :]*)\ {{ $location.Path }}(.*$) \1\ {{ $rewriteTarget }}{{ if hasSuffix $location.Path "/" }}/{{ end }}\2 if {{ if $location.SSLRedirect }}from-https {{ end }}{{ $server.ACLLabel }}{{ $location.HAMatchTxnPath }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -596,7 +596,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- range $server := $servers }}
 {{- range $location := $server.Locations }}
 {{- if ne $location.Proxy.BodySize "" }}
-    use_backend error413 if {{ $server.ACLLabel }} { var(txn.path) -m beg {{ $location.Path }} } { req.body_size gt {{ sizeSuffix $location.Proxy.BodySize }} }
+    use_backend error413 if {{ $server.ACLLabel }}{{ $location.HAMatchTxnPath }} { req.body_size gt {{ sizeSuffix $location.Proxy.BodySize }} }
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
An overlap happens whenever a `/path` of a domain has a configuration, eg whitelist or body-size limit, and a `/path/sub` doesn’t have such configuration. Most of match is made with path_beg which will also match the subpath uri. This change adds a `!{ subpath }` acl to fix this behavior.