### PR TITLE
Add CRL Support in the TLS Secret for Client Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ in-memory parsed template.
 |`/etc/haproxy/template`|`haproxy.tmpl`|[haproxy.tmpl](/rootfs/etc/haproxy/template/haproxy.tmpl)|
 |`/etc/haproxy/modsecurity`|`spoe-modsecurity.tmpl`|[spoe-modsecurity.tmpl](/rootfs/etc/haproxy/modsecurity/spoe-modsecurity.tmpl)|
 
-All templates support [Sprig](http://masterminds.github.io/sprig/) template library. 
-This library provides a group of commonly used template functions to work with dictionaries, 
+All templates support [Sprig](http://masterminds.github.io/sprig/) template library.
+This library provides a group of commonly used template functions to work with dictionaries,
 lists, math etc.
 
 ## Annotations
@@ -173,7 +173,7 @@ The following annotations are supported:
 
 * `ingress.kubernetes.io/auth-tls-cert-header`: if true HAProxy will add `X-SSL-Client-Cert` http header with a base64 encoding of the X509 certificate provided by the client. Default is to not provide the client certificate.
 * `ingress.kubernetes.io/auth-tls-error-page`: optional URL of the page to redirect the user if he doesn't provide a certificate or the certificate is invalid.
-* `ingress.kubernetes.io/auth-tls-secret`: mandatory secret name with `ca.crt` key providing all certificate authority bundles used to validate client certificates.
+* `ingress.kubernetes.io/auth-tls-secret`: mandatory secret name with `ca.crt` key providing all certificate authority bundles used to validate client certificates, an optional `ca.crl` key can also provide a CRL in PEM format for the server to verify against.
 * `ingress.kubernetes.io/auth-tls-verify-client`: optional configuration of Client Verification behavior. Supported values are `off`, `on`, `optional` and `optional_no_ca`. The default value is `on` if a valid secret is provided, `off` otherwise.
 
 See also client cert [example](/examples/auth/client-certs).

--- a/pkg/common/ingress/controller/backend_ssl.go
+++ b/pkg/common/ingress/controller/backend_ssl.go
@@ -111,7 +111,8 @@ func (ic *GenericController) getPemCertificate(secret *apiv1.Secret) (*ingress.S
 		}
 
 	} else if ca != nil {
-		s, err = ssl.AddCertAuth(nsSecName, ca)
+		crl, _ := secret.Data["ca.crl"]
+		s, err = ssl.AddCertAuth(nsSecName, ca, crl)
 
 		if err != nil {
 			return nil, fmt.Errorf("unexpected error creating pem file: %v", err)

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -859,6 +859,7 @@ func (ic GenericController) GetAuthCertificate(name string) (*resolver.AuthSSLCe
 		Secret:      name,
 		CrtFileName: cert.PemFileName,
 		CAFileName:  cert.CAFileName,
+		CRLFileName: cert.CRLFileName,
 		PemSHA:      cert.PemSHA,
 	}, nil
 }

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -233,6 +233,10 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 	if err != nil {
 		glog.Fatalf("Failed to mkdir cacerts directory: %v", err)
 	}
+	err = os.MkdirAll(ingress.DefaultCrlDirectory, 0655)
+	if err != nil {
+		glog.Fatalf("Failed to mkdir crl directory: %v", err)
+	}
 
 	if *forceIsolation && *allowCrossNamespace {
 		glog.Fatal("Cannot use --allow-cross-namespace if --force-namespace-isolation is true")

--- a/pkg/common/ingress/resolver/main.go
+++ b/pkg/common/ingress/resolver/main.go
@@ -61,6 +61,8 @@ type AuthSSLCert struct {
 	CrtFileName string `json:"crtFilename"`
 	// CAFileName contains the path to the secrets 'ca.crt'
 	CAFileName string `json:"caFilename"`
+	// CRLFileName contains the path to the secrets 'ca.crl'
+	CRLFileName string `json:"crlFileName"`
 	// PemSHA contains the SHA1 hash of the 'ca.crt' or combinations of (tls.crt, tls.key, tls.crt) depending on certs in secret
 	PemSHA string `json:"pemSha"`
 }

--- a/pkg/common/ingress/sort_ingress.go
+++ b/pkg/common/ingress/sort_ingress.go
@@ -30,6 +30,8 @@ type SSLCert struct {
 	Certificate       *x509.Certificate `json:"certificate,omitempty"`
 	// CAFileName contains the path to the file with the root certificate
 	CAFileName string `json:"caFileName"`
+	// CRLFileName containst the path to the CA CRL file
+	CRLFileName string `json:"crlFileName"`
 	// PemFileName contains the path to the file with the certificate and key concatenated
 	PemFileName string `json:"pemFileName"`
 	// PemSHA contains the sha1 of the pem file.

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -60,6 +60,7 @@ var (
 	// certificate and key.
 	DefaultSSLDirectory     = "/ingress-controller/ssl"
 	DefaultCACertsDirectory = "/ingress-controller/cacerts"
+	DefaultCrlDirectory     = "/ingress-controller/crl"
 )
 
 // Controller holds the methods to handle an Ingress backend

--- a/pkg/common/net/ssl/ssl.go
+++ b/pkg/common/net/ssl/ssl.go
@@ -31,6 +31,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/golang/glog"
@@ -247,8 +248,7 @@ func parseSANExtension(value []byte) (dnsNames, emailAddresses []string, ipAddre
 
 // AddCertAuth creates a .pem file with the specified CAs to be used in Cert Authentication
 // If it's already exists, it's clobbered.
-func AddCertAuth(name string, ca []byte) (*ingress.SSLCert, error) {
-
+func AddCertAuth(name string, ca, crl []byte) (*ingress.SSLCert, error) {
 	caName := fmt.Sprintf("ca-%v.pem", name)
 	caFileName := fmt.Sprintf("%v/%v", ingress.DefaultCACertsDirectory, caName)
 
@@ -271,11 +271,45 @@ func AddCertAuth(name string, ca []byte) (*ingress.SSLCert, error) {
 		return nil, fmt.Errorf("could not write CA file %v: %v", caFileName, err)
 	}
 
+	var crlFileName string
+	var PemSHA string
+
+	if len(crl) > 0 {
+		crlName := fmt.Sprintf("ca-%v-crl.pem", name)
+		crlFileName = fmt.Sprintf("%v/%v", ingress.DefaultCrlDirectory, crlName)
+
+		pemCrlBlock, _ := pem.Decode(crl)
+		if pemCrlBlock == nil {
+			return nil, fmt.Errorf("CRL file %v provided contains invalid data, and must be created only with PEM formatted CRL", name)
+		}
+
+		_, err := x509.ParseCRL(pemCrlBlock.Bytes)
+		if err != nil {
+			return nil, err
+		}
+
+		err = ioutil.WriteFile(crlFileName, crl, 0644)
+		if err != nil {
+			return nil, fmt.Errorf("could not write CRL file: %v: %v", crlFileName, err)
+		}
+
+		// Concatenate the CA and CRL file SHAs together for the PemSHA
+		filenameSHAs := []string{
+			file.SHA1(caFileName),
+			file.SHA1(crlFileName),
+		}
+		PemSHA = strings.Join(filenameSHAs, "")
+	} else {
+		// Only use the CA filename for a PemSHA
+		PemSHA = file.SHA1(caFileName)
+	}
+
 	glog.V(3).Infof("Created CA Certificate for Authentication: %v", caFileName)
 	return &ingress.SSLCert{
 		CAFileName:  caFileName,
+		CRLFileName: crlFileName,
 		PemFileName: caFileName,
-		PemSHA:      file.SHA1(caFileName),
+		PemSHA:      PemSHA,
 	}, nil
 }
 

--- a/rootfs/etc/haproxy/template/haproxy-v07.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy-v07.tmpl
@@ -188,6 +188,7 @@ backend {{ $backend.Name }}
     {{- if $backend.Secure.IsSecure }} ssl
         {{- if ne $clcert.CrtFileName "" }} crt {{ $clcert.CrtFileName }}{{ end }}
         {{- if ne $cacert.CAFileName "" }} verify required ca-file {{ $cacert.CAFileName }}
+          {{- if ne $cacert.CRLFileName "" }} crl-file {{ $cacert.CRLFileName }}{{ end }}
         {{- else }} verify none{{ end }}
     {{- end }}
     {{- if eq $backend.Proxy.ProxyProtocol "v1" }} send-proxy


### PR DESCRIPTION
Added an additional check for ca.crl in the TLS secret, and storing the
provided PEM file separately allowing the HAproxy server to verify a
client certificate being used has not been revoked.