### PR TITLE
Fix port retrieval for terminatingPod with named targetPort.

### DIFF
--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -1297,13 +1297,14 @@ func (ic *GenericController) getEndpoints(
 		// For each pod associated with this service that is in the terminating state, add it to the output in the draining state
 		// This will allow persistent traffic to be sent to the server during the termination grace period.
 		for _, tp := range terminatingPods {
-			ep := fmt.Sprintf("%v:%v", tp.Status.PodIP, servicePort.TargetPort.IntValue())
+			targetPort := determineTerminatingPodTargetPort(&tp, servicePort, proto)
+			ep := fmt.Sprintf("%v:%v", tp.Status.PodIP, targetPort)
 			if _, exists := adus[ep]; exists {
 				continue
 			}
 			ups := ingress.Endpoint{
 				Address:     tp.Status.PodIP,
-				Port:        fmt.Sprintf("%v", servicePort.TargetPort.IntValue()),
+				Port:        fmt.Sprintf("%v", targetPort),
 				Draining:    true,
 				MaxFails:    hz.MaxFails,
 				FailTimeout: hz.FailTimeout,
@@ -1322,6 +1323,37 @@ func (ic *GenericController) getEndpoints(
 
 	glog.V(3).Infof("endpoints found: %v", upsServers)
 	return upsServers
+}
+
+func determineTerminatingPodTargetPort(tp *apiv1.Pod, servicePort *apiv1.ServicePort, proto apiv1.Protocol) int32 {
+	// Use the int value of the target port by default
+	targetPort := int32(servicePort.TargetPort.IntValue())
+	// If the target port value is a string and the int value can't be computed,
+	// then look it up by iterating through the pod's containers looking for the match
+	if targetPort <= 0 {
+		portStr := servicePort.TargetPort.String()
+		glog.V(4).Infof("Searching for %v on %v", portStr, tp.Name)
+		for _, tpc := range tp.Spec.Containers {
+			for _, tpcPort := range tpc.Ports {
+				if !reflect.DeepEqual(tpcPort.Protocol, proto) {
+					continue
+				}
+				if portStr == tpcPort.Name {
+					targetPort = tpcPort.ContainerPort
+					glog.V(4).Infof("Found port match for %v on container %v port %v", portStr, tpc.Name, tpcPort)
+					break
+				}
+			}
+		}
+	}
+	// If we still couldn't find a target port by looking through the containers port definitions
+	// then use the port value from the service as a fallback.
+	if targetPort <= 0 {
+		targetPort = servicePort.Port
+		glog.Warningf("Using targetPort of %v for terminating pod %v since we were unable to find the named port %v on %v",
+			targetPort, tp.Name, servicePort.TargetPort.String(), tp)
+	}
+	return targetPort
 }
 
 func addIngressEndpoint(addresses []apiv1.EndpointAddress,


### PR DESCRIPTION
Discovered a bug where services with a named targetPort would end up with the port set to 0 in the haproxy config when drain support is on and the pod is terminating. This is because the port could not be converted to an int and instead needs to be retrieved by name from the pod's containers' ports.

I put this into release-0.6 figuring it could be merged up through that, release-0.7 and master to cover any bugfix releases for the release 0.6 and 0.7 branches. However, if you prefer, I can just re-target this to master.