### PR TITLE
Upgrade to HAProxy 1.8.20

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM haproxy:1.8.19-alpine
+FROM haproxy:1.8.20-alpine
 RUN apk --no-cache add socat openssl lua5.3 lua-socket
 
 # dumb-init kindly manages SIGCHLD from forked HAProxy processes

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -14,9 +14,6 @@
 
 FROM haproxy:1.8.19-alpine
 RUN apk --no-cache add socat openssl lua5.3 lua-socket
-## this `--upgrade add libssl/libcrypto` is a temporary upgrade
-## to fix a SIGSEGV starting HAProxy using some new CA bundles
-RUN apk --no-cache --upgrade add libssl1.1 libcrypto1.1
 
 # dumb-init kindly manages SIGCHLD from forked HAProxy processes
 ARG DUMB_INIT_SHA256=81231da1cd074fdc81af62789fead8641ef3f24b6b07366a1c34e5b059faf363


### PR DESCRIPTION
Upgrade to HAProxy 1.8.20.

This PR also remove a temporary upgrade of libssl and libcrypto from 1.1.1a to 1.1.1b - the Alpine base image has already the 1.1.1b version. 1.1.1a causes HAProxy to emit SIGSEGV and fail to start or check a valid configuration with some new certificate authority bundles.