### PR TITLE
Enable redispatch even when drain-support is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ The following parameters are supported:
 ||[`dns-resolvers`](#dns-resolvers)|multiline resolver=ip[:port]|``|
 ||[`dns-timeout-retry`](#dns-resolvers)|time with suffix|`1s`|
 ||[`drain-support`](#drain-support)|[true\|false]|`false`|
+||[`drain-support-redispatch`](#drain-support)|[true\|false]|`true`|
 ||[`dynamic-scaling`](#dynamic-scaling)|[true\|false]|`false`|
 ||[`forwardfor`](#forwardfor)|[add\|ignore\|ifmissing]|`add`|
 ||[`healthz-port`](#healthz-port)|port number|`10253`|
@@ -968,6 +969,9 @@ Set to true if you wish to use HAProxy's drain support for pods that are NotRead
 k8s readiness check) or are in the process of terminating. This option only makes sense with
 cookie affinity configured as it allows persistent traffic to be directed to pods that are in a
 not ready or terminating state.
+
+By default, sessions will be redispatched on a failed upstream connection once the target pod is terminated.
+You can control this behavior by setting `drain-support-redispatch` flag to `false` to instead return a 503 failure.
 
 ## Command-line
 

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -164,6 +164,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		HTTPSLogFormat:         "",
 		TCPLogFormat:           "",
 		DrainSupport:           false,
+		DrainSupportRedispatch: true,
 		DNSResolvers:           "",
 		DNSTimeoutRetry:        "1s",
 		DNSHoldObsolete:        "0s",

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -75,6 +75,7 @@ func (c *updater) UpdateGlobalConfig(global *hatypes.Global, config *ingtypes.Co
 	global.Syslog.Tag = config.SyslogTag
 	global.MaxConn = config.MaxConnections
 	global.DrainSupport = config.DrainSupport
+	global.DrainSupportRedispatch = config.DrainSupportRedispatch
 	global.LoadServerState = config.LoadServerState
 	global.StatsSocket = "/var/run/haproxy-stats.sock"
 	c.buildGlobalProc(data)

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -62,6 +62,7 @@ func createDefaults() *types.Config {
 			DNSResolvers:                 "",
 			DNSTimeoutRetry:              "1s",
 			DrainSupport:                 false,
+			DrainSupportRedispatch:       true,
 			DynamicScaling:               false,
 			Forwardfor:                   "add",
 			HealthzPort:                  10253,

--- a/pkg/converters/ingress/types/config.go
+++ b/pkg/converters/ingress/types/config.go
@@ -54,6 +54,7 @@ type ConfigGlobals struct {
 	DNSResolvers                 string `json:"dns-resolvers"`
 	DNSTimeoutRetry              string `json:"dns-timeout-retry"`
 	DrainSupport                 bool   `json:"drain-support"`
+	DrainSupportRedispatch       bool   `json:"drain-support-redispatch"`
 	DynamicScaling               bool   `json:"dynamic-scaling"`
 	Forwardfor                   string `json:"forwardfor"`
 	HealthzPort                  int    `json:"healthz-port"`

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -18,16 +18,17 @@ package types
 
 // Global ...
 type Global struct {
-	Procs           ProcsConfig
-	Syslog          SyslogConfig
-	MaxConn         int
-	Timeout         TimeoutConfig
-	SSL             SSLConfig
-	ModSecurity     ModSecurityConfig
-	DrainSupport    bool
-	LoadServerState bool
-	StatsSocket     string
-	CustomConfig    []string
+	Procs                  ProcsConfig
+	Syslog                 SyslogConfig
+	MaxConn                int
+	Timeout                TimeoutConfig
+	SSL                    SSLConfig
+	ModSecurity            ModSecurityConfig
+	DrainSupport           bool
+	DrainSupportRedispatch bool
+	LoadServerState        bool
+	StatsSocket            string
+	CustomConfig           []string
 }
 
 // ProcsConfig ...

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -111,6 +111,7 @@ type (
 		HTTPSLogFormat         string `json:"https-log-format"`
 		TCPLogFormat           string `json:"tcp-log-format"`
 		DrainSupport           bool   `json:"drain-support"`
+		DrainSupportRedispatch bool   `json:"drain-support-redispatch"`
 		DNSResolvers           string `json:"dns-resolvers"`
 		DNSTimeoutRetry        string `json:"dns-timeout-retry"`
 		DNSHoldObsolete        string `json:"dns-hold-obsolete"`

--- a/rootfs/etc/haproxy/template/haproxy-v07.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy-v07.tmpl
@@ -52,9 +52,8 @@ defaults
     maxconn {{ $cfg.MaxConn }}
 {{- if $cfg.DrainSupport }}
     option persist
-{{- else }}
-    option redispatch
 {{- end }}
+    option redispatch
     option dontlognull
     option http-server-close
     option http-keep-alive

--- a/rootfs/etc/haproxy/template/haproxy-v07.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy-v07.tmpl
@@ -52,8 +52,12 @@ defaults
     maxconn {{ $cfg.MaxConn }}
 {{- if $cfg.DrainSupport }}
     option persist
-{{- end }}
+    {{- if $cfg.DrainSupportRedispatch }}
     option redispatch
+    {{- end }}
+{{- else }}
+    option redispatch
+{{- end }}
     option dontlognull
     option http-server-close
     option http-keep-alive

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -65,9 +65,8 @@ defaults
     maxconn {{ $global.MaxConn }}
 {{- if $global.DrainSupport }}
     option persist
-{{- else }}
-    option redispatch
 {{- end }}
+    option redispatch
     option dontlognull
     option http-server-close
     option http-keep-alive

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -65,8 +65,12 @@ defaults
     maxconn {{ $global.MaxConn }}
 {{- if $global.DrainSupport }}
     option persist
-{{- end }}
+    {{- if $global.DrainSupportRedispatch }}
     option redispatch
+    {{- end }}
+{{- else }}
+    option redispatch
+{{- end }}
     option dontlognull
     option http-server-close
     option http-keep-alive


### PR DESCRIPTION
This fixes an issue where drain-support would lock a cookie affinity to a backend pod, even after it was terminated. Enabling `redispatch` as per haproxy doc recommendations fixes this to redispatch the session once the target pod is finally shutdown.

Without this change, haproxy returns a 503 status until a new session is started by the user.

Reference from haproxy: https://cbonte.github.io/haproxy-dconv/1.7/configuration.html#4-option%20persist