### PR TITLE
Add configmap snippet for defaults.

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,6 +408,7 @@ The following parameters are supported:
 ||[`bind-ip-addr-stats`](#bind-ip-addr)|IP address|`*`|
 ||[`bind-ip-addr-tcp`](#bind-ip-addr)|IP address|`*`|
 ||[`config-frontend`](#configuration-snippet)|multiline HAProxy frontend config||
+|`[1]`|[`config-defaults`](#configuration-snippet)|multiline HAProxy config for the defaults section||
 ||[`config-global`](#configuration-snippet)|multiline HAProxy global config||
 ||[`cookie-key`](#cookie-key)|secret key|`Ingress`|
 ||[`dns-accepted-payload-size`](#dns-resolvers)|number|`8192`|
@@ -517,6 +518,11 @@ Examples - configmap:
 ```
 
 ```yaml
+    config-defaults: |
+      option redispatch
+```
+
+```yaml
     config-frontend: |
       capture request header X-User-Id len 32
 ```
@@ -533,6 +539,7 @@ Ingress annotation:
 Global configmap options:
 
 * `config-global`: Add configuration snippet to the end of the global section.
+* `config-defaults`: Add configuration snippet to the end of the defaults section.
 * `config-frontend`: Add configuration snippet to all frontend sections.
 
 Annotation option:

--- a/pkg/controller/config.go
+++ b/pkg/controller/config.go
@@ -75,6 +75,7 @@ func newControllerConfig(ingressConfig *ingress.Configuration, haproxyController
 	cfg.createDNSResolvers()
 	cfg.createProcs()
 	return &types.ControllerConfig{
+		ConfigDefaults:      stringToArray(cfg.haproxyConfig.ConfigDefaults),
 		ConfigGlobal:        stringToArray(cfg.haproxyConfig.ConfigGlobal),
 		ConfigFrontend:      stringToArray(cfg.haproxyConfig.ConfigFrontend),
 		Userlists:           cfg.userlists,
@@ -138,6 +139,7 @@ func newHAProxyConfig(haproxyController *HAProxyController) *types.HAProxyConfig
 		ModSecTimeoutIdle:      "30s",
 		ModSecTimeoutProc:      "1s",
 		BackendCheckInterval:   "2s",
+		ConfigDefaults:         "",
 		ConfigGlobal:           "",
 		ConfigFrontend:         "",
 		Forwardfor:             "add",

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -111,5 +111,6 @@ func (c *updater) buildGlobalModSecurity(d *globalData) {
 func (c *updater) buildGlobalCustomConfig(d *globalData) {
 	if d.config.ConfigGlobal != "" {
 		d.global.CustomConfig = strings.Split(strings.TrimRight(d.config.ConfigGlobal, "\n"), "\n")
+		d.global.CustomDefaults = strings.Split(strings.TrimRight(d.config.ConfigGlobals.ConfigDefaults, "\n"), "\n")
 	}
 }

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -28,9 +28,9 @@ const (
 func createDefaults() *types.Config {
 	return &types.Config{
 		ConfigDefaults: types.ConfigDefaults{
-			BalanceAlgorithm: "roundrobin",
-			CookieKey:        "Ingress",
-			HSTS:             true,
+			BalanceAlgorithm:      "roundrobin",
+			CookieKey:             "Ingress",
+			HSTS:                  true,
 			HSTSIncludeSubdomains: false,
 			HSTSMaxAge:            "15768000",
 			HSTSPreload:           false,
@@ -55,6 +55,7 @@ func createDefaults() *types.Config {
 			BindIPAddrTCP:                "*",
 			ConfigFrontend:               "",
 			ConfigGlobal:                 "",
+			ConfigDefaults:               "",
 			DNSAcceptedPayloadSize:       8192,
 			DNSClusterDomain:             "cluster.local",
 			DNSHoldObsolete:              "0s",

--- a/pkg/converters/ingress/types/config.go
+++ b/pkg/converters/ingress/types/config.go
@@ -45,6 +45,7 @@ type ConfigGlobals struct {
 	BindIPAddrHTTP               string `json:"bind-ip-addr-http"`
 	BindIPAddrStats              string `json:"bind-ip-addr-stats"`
 	BindIPAddrTCP                string `json:"bind-ip-addr-tcp"`
+	ConfigDefaults               string `json:"config-defaults"`
 	ConfigFrontend               string `json:"config-frontend"`
 	ConfigGlobal                 string `json:"config-global"`
 	DNSAcceptedPayloadSize       int    `json:"dns-accepted-payload-size"`

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -28,6 +28,7 @@ type Global struct {
 	LoadServerState bool
 	StatsSocket     string
 	CustomConfig    []string
+	CustomDefaults  []string
 }
 
 // ProcsConfig ...

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -35,6 +35,7 @@ type (
 	// ControllerConfig has ingress generated and some transformations
 	// compatible with HAProxy
 	ControllerConfig struct {
+		ConfigDefaults      []string
 		ConfigGlobal        []string
 		ConfigFrontend      []string
 		Userlists           map[string]Userlist
@@ -85,6 +86,7 @@ type (
 		ModSecTimeoutIdle      string `json:"modsecurity-timeout-idle"`
 		ModSecTimeoutProc      string `json:"modsecurity-timeout-processing"`
 		BackendCheckInterval   string `json:"backend-check-interval"`
+		ConfigDefaults         string `json:"config-defaults"`
 		ConfigGlobal           string `json:"config-global"`
 		ConfigFrontend         string `json:"config-frontend"`
 		Forwardfor             string `json:"forwardfor"`

--- a/rootfs/etc/haproxy/template/haproxy-v07.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy-v07.tmpl
@@ -67,6 +67,9 @@ defaults
     timeout server-fin      {{ $cfg.TimeoutServerFin }}
     timeout tunnel          {{ $cfg.TimeoutTunnel }}
     timeout http-keep-alive {{ $cfg.TimeoutKeepAlive }}
+{{- range $snippet := $ing.ConfigDefaults }}
+    {{ $snippet }}
+{{- end }}
 {{- if ne (len $ing.DNSResolvers) 0 }}
 
 ######

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -92,6 +92,9 @@ defaults
 {{- if $global.Timeout.Tunnel }}
     timeout tunnel          {{ $global.Timeout.Tunnel }}
 {{- end }}
+{{- range $snippet := $global.CustomDefaults }}
+    {{ $snippet }}
+{{- end }}
 
   # # # # # # # # # # # # # # # # # # #
 # #


### PR DESCRIPTION
Allows additional values to be specified in the HAProxy "defaults" section by putting them in a multi-line snippet in the configmap.