### PR TITLE
New ingress converter and haproxy types (part 4)

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -23,8 +23,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/utils"
+	ingutils "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/utils"
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
 )
 
 func (c *updater) buildBackendAffinity(d *backData) {
@@ -63,7 +64,7 @@ func (c *updater) buildBackendAuthHTTP(d *backData) {
 		c.logger.Error("missing secret name on basic authentication on %v", d.ann.Source)
 		return
 	}
-	secretName := utils.FullQualifiedName(d.ann.Source.Namespace, d.ann.AuthSecret)
+	secretName := ingutils.FullQualifiedName(d.ann.Source.Namespace, d.ann.AuthSecret)
 	listName := strings.Replace(secretName, "/", "_", 1)
 	userlist := c.haproxy.FindUserlist(listName)
 	if userlist == nil {
@@ -225,7 +226,7 @@ func (c *updater) buildBackendBlueGreen(d *backData) {
 			continue
 		}
 		if lcmCount > 0 {
-			lcmCount = utils.LCM(lcmCount, count)
+			lcmCount = ingutils.LCM(lcmCount, count)
 		} else {
 			lcmCount = count
 		}
@@ -243,7 +244,7 @@ func (c *updater) buildBackendBlueGreen(d *backData) {
 		}
 		groupWeight := dw.weight * lcmCount / count
 		if gcdGroupWeight > 0 {
-			gcdGroupWeight = utils.GCD(gcdGroupWeight, groupWeight)
+			gcdGroupWeight = ingutils.GCD(gcdGroupWeight, groupWeight)
 		} else {
 			gcdGroupWeight = groupWeight
 		}
@@ -400,7 +401,7 @@ func (c *updater) buildWhitelist(d *backData) {
 		return
 	}
 	var cidrlist []string
-	for _, cidr := range strings.Split(d.ann.WhitelistSourceRange, ",") {
+	for _, cidr := range utils.Split(d.ann.WhitelistSourceRange, ",") {
 		if _, _, err := net.ParseCIDR(cidr); err != nil {
 			c.logger.Warn("skipping invalid cidr '%s' in whitelist config on %v", cidr, d.ann.Source)
 		} else {

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -727,11 +727,16 @@ func TestWhitelist(t *testing.T) {
 		},
 		// 1
 		{
+			cidrlist: "10.0.0.0/8, 192.168.0.0/16",
+			expected: []string{"10.0.0.0/8", "192.168.0.0/16"},
+		},
+		// 2
+		{
 			cidrlist: "10.0.0.0/8,192.168.0/16",
 			expected: []string{"10.0.0.0/8"},
 			logging:  `WARN skipping invalid cidr '192.168.0/16' in whitelist config on ingress 'default/app'`,
 		},
-		// 2
+		// 3
 		{
 			cidrlist: "10.0.0/8,192.168.0/16",
 			expected: []string{},

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
 )
 
 func (c *updater) buildGlobalProc(d *globalData) {
@@ -104,7 +106,7 @@ func (c *updater) buildGlobalSSL(d *globalData) {
 }
 
 func (c *updater) buildGlobalModSecurity(d *globalData) {
-	d.global.ModSecurity.Endpoints = strings.Split(d.config.ModsecurityEndpoints, ",")
+	d.global.ModSecurity.Endpoints = utils.Split(d.config.ModsecurityEndpoints, ",")
 	d.global.ModSecurity.Timeout.Hello = d.config.ModsecurityTimeoutHello
 	d.global.ModSecurity.Timeout.Idle = d.config.ModsecurityTimeoutIdle
 	d.global.ModSecurity.Timeout.Processing = d.config.ModsecurityTimeoutProcessing

--- a/pkg/converters/ingress/annotations/global_test.go
+++ b/pkg/converters/ingress/annotations/global_test.go
@@ -17,10 +17,45 @@ limitations under the License.
 package annotations
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
 )
+
+func TestModSecurity(t *testing.T) {
+	testCases := []struct {
+		endpoints string
+		expected  []string
+	}{
+		// 0
+		{
+			endpoints: "",
+			expected:  []string{},
+		},
+		// 1
+		{
+			endpoints: "127.0.0.1:12345",
+			expected:  []string{"127.0.0.1:12345"},
+		},
+		// 2
+		{
+			endpoints: "10.0.0.1:12345, 10.0.0.2:12345",
+			expected:  []string{"10.0.0.1:12345", "10.0.0.2:12345"},
+		},
+	}
+	for i, test := range testCases {
+		c := setup(t)
+		config := &types.Config{}
+		config.ModsecurityEndpoints = test.endpoints
+		d := c.createGlobalData(config)
+		c.createUpdater().buildGlobalModSecurity(d)
+		if !reflect.DeepEqual(test.expected, d.global.ModSecurity.Endpoints) {
+			t.Errorf("endpoints differ on %d - expected: %v - actual: %v", i, test.expected, d.global.ModSecurity.Endpoints)
+		}
+		c.teardown()
+	}
+}
 
 func TestForwardFor(t *testing.T) {
 	testCases := []struct {

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -134,11 +134,10 @@ func (i *instance) Update() {
 	}
 	updated := i.dynconfig.Update()
 	i.clearConfig()
-	if err := i.check(); err != nil {
-		i.logger.Error("error validating config file:\n%v", err)
-		return
-	}
 	if updated {
+		if err := i.check(); err != nil {
+			i.logger.Error("error validating config file:\n%v", err)
+		}
 		i.logger.Info("HAProxy updated without needing to reload")
 		return
 	}

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1616,7 +1616,6 @@ var endpointS41h = &hatypes.Endpoint{
 }
 
 var defaultLogging = `
-INFO (test) check was skipped
 INFO (test) reload was skipped
 INFO HAProxy successfully reloaded`
 

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -901,10 +901,9 @@ listen _front__tls
     mode tcp
     bind :443
     tcp-request inspect-delay 5s
+    tcp-request content set-var(req.sslpassback) req.ssl_sni,lower,map(/etc/haproxy/maps/_global_sslpassthrough.map,_nomatch)
     tcp-request content accept if { req.ssl_hello_type 1 }
-    ## ssl-passthrough
-    tcp-request content set-var(req.backend) req.ssl_sni,lower,map(/etc/haproxy/maps/_global_sslpassthrough.map,_nomatch)
-    use_backend %[var(req.backend)] unless { var(req.backend) _nomatch }
+    use_backend %[var(req.sslpassback)] unless { var(req.sslpassback) _nomatch }
     # TODO default backend
 frontend _front_http
     mode http

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -18,11 +18,27 @@ package utils
 
 import (
 	"fmt"
-	"github.com/golang/glog"
-	"github.com/mitchellh/mapstructure"
 	"net"
 	"strconv"
+	"strings"
+
+	"github.com/golang/glog"
+	"github.com/mitchellh/mapstructure"
 )
+
+// Split returns a slice of substrings from s, separated by sep.
+// If s is empty, Split returns an empty slice.
+// Split will also TrimSpace() all resulting substrings.
+func Split(s, sep string) []string {
+	if s == "" {
+		return []string{}
+	}
+	out := strings.Split(s, sep)
+	for i := range out {
+		out[i] = strings.TrimSpace(out[i])
+	}
+	return out
+}
 
 // MergeMap copy keys from a `data` map to a `resultTo` tagged object
 func MergeMap(data map[string]string, resultTo interface{}) error {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -664,14 +664,14 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 
+{{- if $global.ModSecurity.Endpoints }}
+
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # #
 # #   SUPPORT
 # #
 #
-
-{{- if $global.ModSecurity.Endpoints }}
 
   # # # # # # # # # # # # # # # # # # #
 # #

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -387,17 +387,26 @@ listen _front__tls
 
 {{- /*------------------------------------*/}}
     tcp-request inspect-delay 5s
+
+{{- /*------------------------------------*/}}
+{{- if $fgroup.HasSSLPassthrough }}
+    tcp-request content set-var(req.sslpassback)
+        {{- "" }} req.ssl_sni,lower,map({{ $fgroup.SSLPassthroughMap.MatchFile }},_nomatch)
+{{- end }}
+{{- if $fgroup.SSLPassthroughMap.HasRegex }}
+{{- /*** TODO map_reg() running on every request ***/}}
+    tcp-request content set-var(req.sslpassregback)
+        {{- "" }} req.ssl_sni,lower,map_reg({{ $fgroup.SSLPassthroughMap.RegexFile }},_nomatch)
+        {{- "" }} if { var(req.sslpassback) _nomatch }
+{{- end }}
+
+{{- /*------------------------------------*/}}
     tcp-request content accept if { req.ssl_hello_type 1 }
 
 {{- /*------------------------------------*/}}
 {{- if $fgroup.HasSSLPassthrough }}
-    ## ssl-passthrough
-    tcp-request content set-var(req.backend)
-        {{- "" }} req.ssl_sni,lower,map({{ $fgroup.SSLPassthroughMap.MatchFile }},_nomatch)
-    use_backend %[var(req.backend)] unless { var(req.backend) _nomatch }
+    use_backend %[var(req.sslpassback)] unless { var(req.sslpassback) _nomatch }
 {{- end }}
-
-{{- /*------------------------------------*/}}
 {{- range $frontend := $frontends }}
 {{- range $bind := $frontend.Binds }}
     ## {{ $frontend.Name }}/{{ $bind.Name }}
@@ -408,14 +417,7 @@ listen _front__tls
 
 {{- /*------------------------------------*/}}
 {{- if $fgroup.SSLPassthroughMap.HasRegex }}
-    ## ssl-passthrough wildcard
-{{- /*** TODO is map_reg() converter running on every request? ***/}}
-    tcp-request content set-var(req.backend)
-        {{- "" }} req.ssl_sni,lower,map_reg({{ $fgroup.SSLPassthroughMap.RegexFile }},_nomatch)
-        {{- "" }} if { var(req.backend) _nomatch }
-
-{{- /*------------------------------------*/}}
-    use_backend %[var(req.backend)] unless { var(req.backend) _nomatch }
+    use_backend %[var(req.sslpassback)] unless { var(req.sslpassback) _nomatch }
 {{- end }}
 {{- range $frontend := $frontends }}
 {{- range $bind := $frontend.Binds }}


### PR DESCRIPTION
Some small fixes before snapshot.2:

* [x] Fix ssl-passthrough routing - fixes #341 
* [x] Fix template parsing without modsec endpoints
* [x] Fix backward compatibility parsing of whitelist
* [x] Skip double checking config file

Related with #339 

Implements #274 
