### PR TITLE
Fix duplication of ConfigFrontend snippets for DefaultBackend

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy-v07.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy-v07.tmpl
@@ -393,7 +393,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $hasBalance }}
+{{- if and $hasBalance (not $isDefault) }}
 {{- range $snippet := $ing.ConfigFrontend }}
     {{ $snippet }}
 {{- end }}


### PR DESCRIPTION
This fixes an issue where any frontend configuration is duplicated twice for the default backend.

Example for a `config-frontend` in the ConfigMap of `http-response add-header my-header` results in two headers `my-header` in the response from the default backend.

This is particularly bad when forcing http to https redirection using `config-frontend` we were seeing an infinite loop of redirects for unknown ingress endpoints rather than a 404.