### PR TITLE
Remove Basic Auth challenge for pre-flight OPTIONS request when CORS is enabled

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -424,7 +424,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- $listName := $location.Userlist.ListName }}
 {{- if ne $listName "" }}
 {{- $realm := $location.Userlist.Realm }}
-    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if {{ $server.ACLLabel }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
+    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if {{if and $server.CORS $server.CORS.CorsEnabled }}!METH_OPTIONS{{ end }} {{ $server.ACLLabel }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
 {{- end }}
 {{- end }}
 {{- end }}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -424,7 +424,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- $listName := $location.Userlist.ListName }}
 {{- if ne $listName "" }}
 {{- $realm := $location.Userlist.Realm }}
-    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if {{if and $server.CORS $server.CORS.CorsEnabled }}!METH_OPTIONS{{ end }} {{ $server.ACLLabel }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
+    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if {{if and $server.CORS $location.CORS.CorsEnabled }}!METH_OPTIONS{{ end }} {{ $server.ACLLabel }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
 {{- end }}
 {{- end }}
 {{- end }}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -424,7 +424,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- $listName := $location.Userlist.ListName }}
 {{- if ne $listName "" }}
 {{- $realm := $location.Userlist.Realm }}
-    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if {{if and $server.CORS $location.CORS.CorsEnabled }}!METH_OPTIONS{{ end }} {{ $server.ACLLabel }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
+    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if {{if and $location.CORS.CorsEnabled }}!METH_OPTIONS{{ end }} {{ $server.ACLLabel }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
When CORS is enabled on a k8s ingress definition that also has Basic Auth, the connection from a browser fails because the browser (correctly) does not send the Basic Auth credentials on the pre-flight `OPTIONS` request.

Example annotations to recreate:
```yaml
    ingress.kubernetes.io/auth-realm: Authentication Required
    ingress.kubernetes.io/auth-secret: somesecret
    ingress.kubernetes.io/auth-type: basic
    ingress.kubernetes.io/cors-allow-credentials: "true"
    ingress.kubernetes.io/cors-allow-methods: POST,PUT,GET,DELETE
    ingress.kubernetes.io/cors-allow-origin: '*'
    ingress.kubernetes.io/enable-cors: "true"
```

This PR suggests updating the `http-request auth` rule to be disabled for `OPTIONS` requests when CORS is enabled on a backend definition. This would make haproxy consistent with the behaviour in nginx ingresses (we are evaluating a switch from nginx to haproxy to benefit from features only currently available in haproxy).

I did look at creating a PR to the master branch, but hit some unrelated issues testing the master branch with CORS. For our needs it would be great to be able to get this change into an upcoming 0.7 release so we avoid being on a long lived fork getting to production ready 0.8. So I'm kicking off the discussion here against the 0.7 release. However, if you think it's more expedient to work on the 0.8 PR first, let me know and I can raise a separate PR now to discuss there.