### PR TITLE
Disable HTTP Basic Auth on CORS pre-flight OPTIONS request

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy-v07.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy-v07.tmpl
@@ -459,7 +459,7 @@ frontend http{{ if and $hasSSL (not $hasBalance) }}s{{ end }}front-{{ if $isShar
 {{- $listName := $location.Userlist.ListName }}
 {{- if ne $listName "" }}
 {{- $realm := $location.Userlist.Realm }}
-    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if {{ $server.ACLLabel }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
+    http-request auth {{ if ne $realm "" }}realm "{{ $realm }}" {{ end }}if {{- if $location.CORS.CorsEnabled }}!METH_OPTIONS{{ end }} {{ $server.ACLLabel }}{{ $location.HAMatchPath }} !{ http_auth({{ $listName }}) }
 {{- end }}
 {{- end }}
 {{- end }}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -191,7 +191,7 @@ backend {{ $backend.ID }}
 {{- if $backend.Userlist.Name }}
     http-request auth
         {{- if $backend.Userlist.Realm }} realm "{{ $backend.Userlist.Realm }}"{{ end }}
-        {{- "" }} if !{ http_auth({{ $backend.Userlist.Name }}) }
+        {{- "" }} if {{- if and $backend.Cors.Enabled }}!METH_OPTIONS{{ end }} !{ http_auth({{ $backend.Userlist.Name }}) }
 {{- end }}
 
 {{- /*------------------------------------*/}}


### PR DESCRIPTION
> port of https://github.com/jcmoraisjr/haproxy-ingress/pull/354 to master

When CORS is enabled on a k8s ingress definition that also has Basic Auth, the connection from a browser fails because the browser (correctly) does not send the Basic Auth credentials on the pre-flight OPTIONS request.

Example annotations to recreate:

```yaml
    ingress.kubernetes.io/auth-realm: Authentication Required
    ingress.kubernetes.io/auth-secret: somesecret
    ingress.kubernetes.io/auth-type: basic
    ingress.kubernetes.io/cors-allow-credentials: "true"
    ingress.kubernetes.io/cors-allow-methods: POST,PUT,GET,DELETE
    ingress.kubernetes.io/cors-allow-origin: '*'
    ingress.kubernetes.io/enable-cors: "true"
```

This PR suggests updating the http-request auth rule to be disabled for OPTIONS requests when CORS is enabled on a backend definition. This would make haproxy consistent with the behaviour in nginx ingresses (we are evaluating a switch from nginx to haproxy to benefit from features only currently available in haproxy).

Questions from PR 354 moved to discussion here:

> What kind of features did you find on haproxy you didn't on nginx?

Hitless reload is the key feature driving us to adopt haproxy.

> Which issues you have found testing on master?

Swapping the image from the `0.7` branch to one built with this PR, I see this error processing the CORS config:

```
E0710 22:10:00.594793       8 controller.go:350] unexpected failure restarting the backend: 
template: haproxy-v07.tmpl:727:12: executing "CORS" at <$cors.CorsExportHead...>: can't evaluate field CorsExportHeaders in type *cors.CorsConfig
```

Related to these lines of the config template:
https://github.com/jcmoraisjr/haproxy-ingress/blob/d85fa4e4889ec10a49cb1965efbbe3ef78d35c4b/rootfs/etc/haproxy/template/haproxy-v07.tmpl#L727-L729