### PR TITLE
Add --wait-before-shutdown flag to wait defined time when SIGTERM received

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,7 @@ The following command-line arguments are supported:
 
 ||Name|Type|Default|
 |---|---|---|---|
+||[`termination-grace-period`](#termination-grace-period)|seconds as integer|`0`|
 ||[`allow-cross-namespace`](#allow-cross-namespace)|[true\|false]|`false`|
 ||[`default-backend-service`](#default-backend-service)|namespace/servicename|(mandatory)|
 ||[`default-ssl-certificate`](#default-ssl-certificate)|namespace/secretname|(mandatory)|
@@ -999,6 +1000,11 @@ The following command-line arguments are supported:
 ||[`tcp-services-configmap`](#tcp-services-configmap)|namespace/configmapname|no tcp svc|
 ||[`verify-hostname`](#verify-hostname)|[true\|false]|`true`|
 ||[`watch-namespace`](#watch-namespace)|namespace|all namespaces|
+
+### termination-grace-period
+If argument `--termination-grace-period` is defined, controller will wait defined time in seconds
+before it starts shutting down components when SIGTERM was received. By default, it's 0, which means
+the controller starts shutting down itself right after signal was sent.
 
 ### allow-cross-namespace
 

--- a/README.md
+++ b/README.md
@@ -986,7 +986,6 @@ The following command-line arguments are supported:
 
 ||Name|Type|Default|
 |---|---|---|---|
-||[`termination-grace-period`](#termination-grace-period)|seconds as integer|`0`|
 ||[`allow-cross-namespace`](#allow-cross-namespace)|[true\|false]|`false`|
 ||[`default-backend-service`](#default-backend-service)|namespace/servicename|(mandatory)|
 ||[`default-ssl-certificate`](#default-ssl-certificate)|namespace/secretname|(mandatory)|
@@ -999,12 +998,8 @@ The following command-line arguments are supported:
 ||[`sort-backends`](#sort-backends)|[true\|false]|`false`|
 ||[`tcp-services-configmap`](#tcp-services-configmap)|namespace/configmapname|no tcp svc|
 ||[`verify-hostname`](#verify-hostname)|[true\|false]|`true`|
+||[`wait-before-shutdown`](#wait-before-shutdown)|seconds as integer|`0`|
 ||[`watch-namespace`](#watch-namespace)|namespace|all namespaces|
-
-### termination-grace-period
-If argument `--termination-grace-period` is defined, controller will wait defined time in seconds
-before it starts shutting down components when SIGTERM was received. By default, it's 0, which means
-the controller starts shutting down itself right after signal was sent.
 
 ### allow-cross-namespace
 
@@ -1139,6 +1134,12 @@ match the hostname are discarded and a warning is logged into the ingress contro
 
 Use `--verify-hostname=false` argument to bypass this validation. If used, HAProxy will provide
 the certificate declared in the `secretName` ignoring if the certificate is or is not valid.
+
+### wait-before-shutdown
+
+If argument `--wait-before-shutdown` is defined, controller will wait defined time in seconds
+before it starts shutting down components when SIGTERM was received. By default, it's 0, which means
+the controller starts shutting down itself right after signal was sent.
 
 ### watch-namespace
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -130,7 +130,7 @@ type Configuration struct {
 	ConfigMapName  string
 
 	ForceNamespaceIsolation bool
-	TerminationGracePeriod  int
+	WaitBeforeShutdown      int
 	AllowCrossNamespace     bool
 	DisableNodeList         bool
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -130,6 +130,7 @@ type Configuration struct {
 	ConfigMapName  string
 
 	ForceNamespaceIsolation bool
+	TerminationGracePeriod  int
 	AllowCrossNamespace     bool
 	DisableNodeList         bool
 

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -102,7 +102,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		configmaps or the default backend service located in a different namespace than the specified
 		in the flag --watch-namespace.`)
 
-		terminationGracePeriod = flags.Int("termination-grace-period", 0, `Define time controller waits until it shuts down " +
+		waitBeforeShutdown = flags.Int("wait-before-shutdown", 0, `Define time controller waits until it shuts down " +
 			"when SIGTERM signal was received`)
 
 		allowCrossNamespace = flags.Bool("allow-cross-namespace", false,
@@ -260,7 +260,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		PublishService:          *publishSvc,
 		Backend:                 backend,
 		ForceNamespaceIsolation: *forceIsolation,
-		TerminationGracePeriod:  *terminationGracePeriod,
+		WaitBeforeShutdown:      *waitBeforeShutdown,
 		AllowCrossNamespace:     *allowCrossNamespace,
 		DisableNodeList:         *disableNodeList,
 		UpdateStatusOnShutdown:  *updateStatusOnShutdown,

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -102,8 +102,8 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		configmaps or the default backend service located in a different namespace than the specified
 		in the flag --watch-namespace.`)
 
-		waitBeforeShutdown = flags.Int("wait-before-shutdown", 0, `Define time controller waits until it shuts down " +
-			"when SIGTERM signal was received`)
+		waitBeforeShutdown = flags.Int("wait-before-shutdown", 0, `Define time controller waits until it shuts down
+		when SIGTERM signal was received`)
 
 		allowCrossNamespace = flags.Bool("allow-cross-namespace", false,
 			`Defines if the ingress controller can reference resources of another namespaces.

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -102,6 +102,9 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		configmaps or the default backend service located in a different namespace than the specified
 		in the flag --watch-namespace.`)
 
+		terminationGracePeriod = flags.Int("termination-grace-period", 0, `Define time controller waits until it shuts down " +
+			"when SIGTERM signal was received`)
+
 		allowCrossNamespace = flags.Bool("allow-cross-namespace", false,
 			`Defines if the ingress controller can reference resources of another namespaces.
 		Cannot be used if force-namespace-isolation is true`)
@@ -257,6 +260,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		PublishService:          *publishSvc,
 		Backend:                 backend,
 		ForceNamespaceIsolation: *forceIsolation,
+		TerminationGracePeriod:  *terminationGracePeriod,
 		AllowCrossNamespace:     *allowCrossNamespace,
 		DisableNodeList:         *disableNodeList,
 		UpdateStatusOnShutdown:  *updateStatusOnShutdown,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -168,9 +168,11 @@ func (hc *HAProxyController) CreateX509CertsDir(bindName string, certs []string)
 
 // Stop shutdown the controller process
 func (hc *HAProxyController) Stop() error {
-	waitBeforeShutdown := time.Duration(hc.cfg.WaitBeforeShutdown) * time.Second
-	glog.Infof("Waiting %v before stopping components", waitBeforeShutdown)
-	time.Sleep(waitBeforeShutdown)
+	if hc.cfg.WaitBeforeShutdown > 0 {
+		waitBeforeShutdown := time.Duration(hc.cfg.WaitBeforeShutdown) * time.Second
+		glog.Infof("Waiting %v before stopping components", waitBeforeShutdown)
+		time.Sleep(waitBeforeShutdown)
+	}
 	err := hc.controller.Stop()
 	return err
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -168,9 +168,9 @@ func (hc *HAProxyController) CreateX509CertsDir(bindName string, certs []string)
 
 // Stop shutdown the controller process
 func (hc *HAProxyController) Stop() error {
-	terminationGracePeriod := time.Duration(hc.cfg.TerminationGracePeriod) * time.Second
-	glog.Infof("Waiting %v before stopping components", terminationGracePeriod)
-	time.Sleep(terminationGracePeriod)
+	waitBeforeShutdown := time.Duration(hc.cfg.WaitBeforeShutdown) * time.Second
+	glog.Infof("Waiting %v before stopping components", waitBeforeShutdown)
+	time.Sleep(waitBeforeShutdown)
 	err := hc.controller.Stop()
 	return err
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -168,6 +168,9 @@ func (hc *HAProxyController) CreateX509CertsDir(bindName string, certs []string)
 
 // Stop shutdown the controller process
 func (hc *HAProxyController) Stop() error {
+	terminationGracePeriod := time.Duration(hc.cfg.TerminationGracePeriod) * time.Second
+	glog.Infof("Waiting %v before stopping components", terminationGracePeriod)
+	time.Sleep(terminationGracePeriod)
 	err := hc.controller.Stop()
 	return err
 }


### PR DESCRIPTION
I've encountered a case, when deploying haproxy ingress controller with helm chart and some changes in Deployment object (which already had terminationGracePeriodSeconds as 4 minutes), my controller's Pods once received SIGTERM, shut down themselves almost immediately, causing the connections to be broken.
I'd like to propose a parameter of --terminate-grace-period defined as integer of seconds, which causes the Stop function to wait defined time before it shuts down the controller's components. Thanks to this, if terminationGracePeriodSeconds and --terminate-grace-period are defined, long living connections might have a chance to complete, while the Pod is taken of out Service's endpoints, so no new requests are coming.