### PR TITLE
Bind modsecurity backend to balance process

### DIFF
--- a/rootfs/etc/haproxy/template/haproxy-v07.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy-v07.tmpl
@@ -741,6 +741,9 @@ backend spoe-modsecurity
     mode tcp
     timeout connect 5s
     timeout server  5s
+{{- if gt $ing.Procs.Nbproc 1 }}
+    bind-process {{ $ing.Procs.BindprocBalance }}
+{{- end }}
 {{- range $i, $endpoint := split $cfg.ModSecurity "," }}
     server modsec-spoa{{ $i }} {{ $endpoint }}
 {{- end }}


### PR DESCRIPTION
The modsecurity backend is referenced by the spoe configuration file, so the automatic binding of that backend to the balance processes does not work when nbproc is declared. This change configures the modsecurity backend to the right processes.

v07 controller only.