### PR TITLE
bump haproxy to 2.1 to get prometheus exporter

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM haproxy:1.8.20-alpine
+FROM haproxytech/haproxy-alpine:2.1
 RUN apk --no-cache add socat openssl lua5.3 lua-socket
 
 # dumb-init kindly manages SIGCHLD from forked HAProxy processes

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -748,6 +748,9 @@ frontend {{ $frontend.Name }}
 listen stats
     mode http
     bind :1936{{ if gt $global.Procs.Nbproc 1 }} process 1{{ end }}
+    option http-use-htx
+    http-request use-service prometheus-exporter if {path /metrics}
+    stats refresh 10s
     stats enable
     stats uri /
     no log


### PR DESCRIPTION
Haproxy is now able to expose its metrics to prometheus. It's a very useful feature.