### PR TITLE
Add var-namespace annotation

### DIFF
--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -130,6 +130,7 @@ func (c *updater) UpdateHostConfig(host *hatypes.Host, mapper *Mapper) {
 	host.RootRedirect = mapper.Get(ingtypes.HostAppRoot).Value
 	host.Alias.AliasName = mapper.Get(ingtypes.HostServerAlias).Value
 	host.Alias.AliasRegex = mapper.Get(ingtypes.HostServerAliasRegex).Value
+	host.VarNamespace = mapper.Get(ingtypes.HostVarNamespace).Bool()
 	c.buildHostAuthTLS(data)
 	c.buildHostSSLPassthrough(data)
 	c.buildHostTimeout(data)

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -28,6 +28,7 @@ const (
 	HostSSLPassthroughHTTPPort = "ssl-passthrough-http-port"
 	HostTimeoutClient          = "timeout-client"
 	HostTimeoutClientFin       = "timeout-client-fin"
+	HostVarNamespace           = "var-namespace"
 )
 
 var (
@@ -43,6 +44,7 @@ var (
 		HostSSLPassthroughHTTPPort: {},
 		HostTimeoutClient:          {},
 		HostTimeoutClientFin:       {},
+		HostVarNamespace:           {},
 	}
 )
 


### PR DESCRIPTION
A HAProxy var txn.namespace can be configured with the k8s namespace owner of the service which is the target of the request. This can be used on http logs. var-namespace is a boolean annotation that defaults to false, which means txn.namespace shouldn't be created.

This change only defines the annotation. The haproxy entity was already implemented.