### PR TITLE
Change dynamic update default values

### DIFF
--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -29,7 +29,8 @@ func createDefaults() map[string]string {
 		types.HostTimeoutClient:    "50s",
 		types.HostTimeoutClientFin: "50s",
 		//
-		types.BackBackendServerSlotsInc: "32",
+		types.BackBackendServerSlotsInc: "1",
+		types.BackSlotsMinFree:          "6",
 		types.BackBalanceAlgorithm:      "roundrobin",
 		types.BackCorsAllowHeaders:      "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization",
 		types.BackCorsAllowMethods:      "GET, PUT, POST, DELETE, PATCH, OPTIONS",


### PR DESCRIPTION
Change SlotsInc to 1 which in fact disables it. Change SlotsMinFree to 6. These default values will leave 6 free slots per backend after each HAProxy reload, despite the number of replicas.

This should be merged to v0.8.