### PR TITLE
Sort ingress using creation timestamp

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -259,7 +259,7 @@ func (hc *HAProxyController) SyncIngress(item interface{}) error {
 		}
 	}
 	sort.SliceStable(ingress, func(i, j int) bool {
-		return ingress[i].ResourceVersion < ingress[j].ResourceVersion
+		return ingress[i].CreationTimestamp.Before(&ingress[j].CreationTimestamp)
 	})
 	var globalConfig map[string]string
 	if hc.configMap != nil {


### PR DESCRIPTION
Ingress objects can overlap each other configurations - two or more ingress can compose a single domain/hostname with distinct backend/service configurations. This is fine.

HAProxy Ingress does its best to merge objects and configurations in order to make a consistent state. However if conflicting configuration is used to the same entity, a warning is logged and one of the configurations should be used.

Before the current change, the ResourceVersion was being used to sort ingress objects, which means that the object updated earlier wins. This could sound good but the ResourceVersion is unique to the whole object, which means an old configuration of a just updated object would be overridden by a conflicting configuration of another object, changing the cluster status in a wrong way. This is even worse: status updates change the ResourceVersion, which will randomly change the precedente of conflicting configurations.

Note that this change can potentially impact only clusters with conflicting configurations, which is a status that should be avoided. There is no impact if the controller log doesn't complain about conflicts.