### PR TITLE
Kubernetes version 1.16 removed several deprecated APIs

### DIFF
--- a/docs/haproxy-ingress.yaml
+++ b/docs/haproxy-ingress.yaml
@@ -132,7 +132,7 @@ subjects:
     kind: User
     name: ingress-controller
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -175,7 +175,7 @@ metadata:
   name: haproxy-ingress
   namespace: ingress-controller
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:


### PR DESCRIPTION
Kubernetes version 1.16 has removed several deprecated APIs that you'll likely recognize and may use on a daily basis