### PR TITLE
Add dynamic-scaling false option

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -656,6 +656,8 @@ running HAProxy via a Unix socket (`true`) whenever possible. Despite the config
 the config files will stay in sync with in memory config. The default value was `false`
 up to v0.7 if not declared, changed to `true` since v0.8.
 
+`dynamic-scaling` is ignored if the backend uses [DNS resolver](#dns-resolvers).
+
 If `true` HAProxy Ingress will create at least `backend-server-slots-increment`
 servers on each backend and update them via a Unix socket without reloading HAProxy.
 Unused servers will stay in a disabled state. If the change cannot be made via socket,

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -40,6 +40,7 @@ func createDefaults() map[string]string {
 		types.BackCorsAllowMethods:       "GET, PUT, POST, DELETE, PATCH, OPTIONS",
 		types.BackCorsAllowOrigin:        "*",
 		types.BackCorsMaxAge:             "86400",
+		types.BackDynamicScaling:         "true",
 		types.BackHealthCheckInterval:    "2s",
 		types.BackHSTS:                   "true",
 		types.BackHSTSIncludeSubdomains:  "false",

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -79,6 +79,7 @@ func TestDynUpdate(t *testing.T) {
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.Dynamic.BlockSize = 8
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
@@ -94,7 +95,7 @@ func TestDynUpdate(t *testing.T) {
 				"srv008:127.0.0.1:1023:0",
 			},
 			dynamic: false,
-			logging: `INFO-V(2) added endpoints`,
+			logging: `INFO-V(2) added endpoints on backend 'default_app_8080'`,
 		},
 		// 6
 		{
@@ -105,6 +106,7 @@ func TestDynUpdate(t *testing.T) {
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
 			},
 			expected: []string{
@@ -127,6 +129,7 @@ set server default_app_8080/srv001 weight 0
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				ep := b.AcquireEndpoint("172.17.0.2", 8080, "")
 				ep.Weight = 2
 			},
@@ -150,6 +153,7 @@ set server default_app_8080/srv001 weight 2
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
 			},
@@ -174,6 +178,7 @@ set server default_app_8080/srv001 weight 1
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
 			},
@@ -204,6 +209,7 @@ set server default_app_8080/srv001 weight 1
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.AcquireEndpoint("172.17.0.5", 8080, "")
 				b.AcquireEndpoint("172.17.0.7", 8080, "")
 			},
@@ -256,7 +262,7 @@ INFO-V(2) disabled endpoint '172.17.0.9:8080' on backend/server 'default_app_808
 				b.AcquireEndpoint("172.17.0.4", 8080, "")
 			},
 			doconfig2: func(c *testConfig) {
-				c.config.AcquireBackend("default", "app", "8080")
+				c.config.AcquireBackend("default", "app", "8080").Dynamic.DynUpdate = true
 			},
 			expected: []string{
 				"srv001:127.0.0.1:1023:0",
@@ -290,6 +296,7 @@ INFO-V(2) disabled endpoint '172.17.0.4:8080' on backend/server 'default_app_808
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.Dynamic.MinFreeSlots = 4
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
@@ -305,7 +312,7 @@ INFO-V(2) disabled endpoint '172.17.0.4:8080' on backend/server 'default_app_808
 				"srv007:127.0.0.1:1023:0",
 			},
 			dynamic: false,
-			logging: `INFO-V(2) added endpoints`,
+			logging: `INFO-V(2) added endpoints on backend 'default_app_8080'`,
 		},
 		// 13
 		{
@@ -317,6 +324,7 @@ INFO-V(2) disabled endpoint '172.17.0.4:8080' on backend/server 'default_app_808
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.Dynamic.MinFreeSlots = 4
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
@@ -344,9 +352,11 @@ set server default_app_8080/srv002 weight 1
 			},
 			doconfig2: func(c *testConfig) {
 				b1 := c.config.AcquireBackend("default", "default_backend", "8080")
+				b1.Dynamic.DynUpdate = true
 				b1.Dynamic.MinFreeSlots = 1
 				c.config.ConfigDefaultBackend(b1)
 				b2 := c.config.AcquireBackend("default", "app", "8080")
+				b2.Dynamic.DynUpdate = true
 				b2.AcquireEndpoint("172.17.0.2", 8080, "")
 				b2.AcquireEndpoint("172.17.0.3", 8080, "")
 			},
@@ -356,12 +366,12 @@ set server default_app_8080/srv002 weight 1
 			},
 			dynamic: false,
 			cmd:     ``,
-			logging: `INFO-V(2) added endpoints`,
+			logging: `INFO-V(2) added endpoints on backend 'default_app_8080'`,
 		},
 		// 15
 		{
 			doconfig2: func(c *testConfig) {
-				c.config.AcquireBackend("default", "app", "8080")
+				c.config.AcquireBackend("default", "app", "8080").Dynamic.DynUpdate = true
 			},
 			expected: []string{
 				"srv001:127.0.0.1:1023:0",
@@ -374,6 +384,7 @@ set server default_app_8080/srv002 weight 1
 		{
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.Dynamic.BlockSize = 4
 			},
 			expected: []string{
@@ -395,6 +406,7 @@ set server default_app_8080/srv002 weight 1
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.AcquireEndpoint("172.17.0.2", 8080, "").Label = "green"
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
 			},
@@ -418,6 +430,7 @@ set server default_app_8080/srv002 weight 1`,
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.AcquireEndpoint("172.17.0.2", 8080, "").Label = "green"
 				b.AcquireEndpoint("172.17.0.4", 8080, "").Label = "green"
 			},
@@ -436,6 +449,7 @@ set server default_app_8080/srv002 weight 1`,
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.AcquireEndpoint("172.17.0.2", 8080, "").Label = "green"
 			},
 			expected: []string{
@@ -453,6 +467,7 @@ set server default_app_8080/srv002 weight 1`,
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = true
 				b.AcquireEndpoint("172.17.0.2", 8080, "").Label = "green"
 				b.AcquireEndpoint("172.17.0.4", 8080, "").Label = "green"
 			},
@@ -461,6 +476,44 @@ set server default_app_8080/srv002 weight 1`,
 				"srv002:172.17.0.4:8080:1",
 			},
 			dynamic: false,
+		},
+		// 21
+		{
+			doconfig1: func(c *testConfig) {
+				b := c.config.AcquireBackend("default", "app", "8080")
+				b.AcquireEndpoint("172.17.0.2", 8080, "")
+				b.AcquireEndpoint("172.17.0.3", 8080, "")
+			},
+			doconfig2: func(c *testConfig) {
+				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = false
+				b.Dynamic.MinFreeSlots = 4
+				b.AcquireEndpoint("172.17.0.3", 8080, "")
+			},
+			expected: []string{
+				"srv001:172.17.0.3:8080:1",
+			},
+			dynamic: false,
+			logging: `INFO-V(2) backend 'default_app_8080' changed and its dynamic-scaling is 'false'`,
+		},
+		// 22
+		{
+			doconfig1: func(c *testConfig) {
+				b := c.config.AcquireBackend("default", "app", "8080")
+				b.AcquireEndpoint("172.17.0.2", 8080, "")
+				b.Dynamic.DynUpdate = false
+				b.Dynamic.MinFreeSlots = 4
+			},
+			doconfig2: func(c *testConfig) {
+				b := c.config.AcquireBackend("default", "app", "8080")
+				b.Dynamic.DynUpdate = false
+				b.Dynamic.MinFreeSlots = 4
+				b.AcquireEndpoint("172.17.0.2", 8080, "")
+			},
+			expected: []string{
+				"srv001:172.17.0.2:8080:1",
+			},
+			dynamic: true,
 		},
 	}
 	for i, test := range testCases {

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -677,7 +677,6 @@ defaults
     timeout tunnel          1h
 backend default_empty_8080
     mode http
-    server srv001 127.0.0.1:1023 disabled weight 0
 backend _error404
     mode http
     errorfile 400 /usr/local/etc/haproxy/errors/404.http


### PR DESCRIPTION
Dynamic update was always running despite `dynamic-scaling` configuration. The current behaviour doesn't change, its default value was `true` since v0.8 and will continue to be.

This should be merged to v0.8.