### PR TITLE
Improve sorting of internal state

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -258,8 +258,13 @@ func (hc *HAProxyController) SyncIngress(item interface{}) error {
 			ingress = append(ingress, ing)
 		}
 	}
-	sort.SliceStable(ingress, func(i, j int) bool {
-		return ingress[i].CreationTimestamp.Before(&ingress[j].CreationTimestamp)
+	sort.Slice(ingress, func(i, j int) bool {
+		i1 := ingress[i]
+		i2 := ingress[j]
+		if i1.CreationTimestamp != i2.CreationTimestamp {
+			return i1.CreationTimestamp.Before(&i2.CreationTimestamp)
+		}
+		return i1.Namespace+"/"+i1.Name < i2.Namespace+"/"+i2.Name
 	})
 	var globalConfig map[string]string
 	if hc.configMap != nil {

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -198,6 +198,9 @@ func (c *config) AddUserlist(name string, users []hatypes.User) *hatypes.Userlis
 		Name:  name,
 		Users: users,
 	}
+	sort.Slice(users, func(i, j int) bool {
+		return users[i].Name < users[j].Name
+	})
 	c.userlists = append(c.userlists, userlist)
 	sort.Slice(c.userlists, func(i, j int) bool {
 		return c.userlists[i].Name < c.userlists[j].Name


### PR DESCRIPTION
Configuration change is mostly performed on diff'ing old and new internal state, because of that all internal slices should be sorted.

This change improves two scenarios:

* Order of ingress with the same creation timestamp wasn't idempotent, added a fallback to namespace/name
* Users of a userlist wasn't sorted