### PR TITLE
Tuning default thread number and reload strategy

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -19,7 +19,7 @@ The following command-line options are supported:
 | [`--max-old-config-files`](#max-old-config-files)       | num of files               | `0`                     |
 | [`--publish-service`](#publish-service)                 | namespace/servicename      |                         |
 | [`--rate-limit-update`](#rate-limit-update)             | uploads per second (float) | `0.5`                   |
-| [`--reload-strategy`](#reload-strategy)                 | [native\|reusesocket]      | `native`                |
+| [`--reload-strategy`](#reload-strategy)                 | [native\|reusesocket]      | `reusesocket`           |
 | [`--sort-backends`](#sort-backends)                     | [true\|false]              | `false`                 |  
 | [`--tcp-services-configmap`](#tcp-services-configmap)   | namespace/configmapname    | no tcp svc              |
 | [`--verify-hostname`](#verify-hostname)                 | [true\|false]              | `true`                  |
@@ -133,8 +133,8 @@ times per second.
 The `--reload-strategy` command-line argument is used to select which reload strategy
 HAProxy should use. The following options are available:
 
-* `native`: Uses native HAProxy reload option `-sf`. This is the default option.
-* `reusesocket`: (starting on v0.6) Uses HAProxy `-x` command-line option to pass the listening sockets between old and new HAProxy process, allowing hitless reloads.
+* `native`: Uses native HAProxy reload option `-sf`.
+* `reusesocket`: (starting on v0.6) Uses HAProxy `-x` command-line option to pass the listening sockets between old and new HAProxy process, allowing hitless reloads. This is the default option since v0.8.
 * `multibinder`: (deprecated on v0.6) Uses GitHub's [multibinder](https://github.com/github/multibinder). This [link](https://githubengineering.com/glb-part-2-haproxy-zero-downtime-zero-delay-reloads-with-multibinder/)
 describes how it works.
 

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -163,7 +163,7 @@ The table below describes all supported configuration keys.
 | [`modsecurity-timeout-idle`](#modsecurity)           | time with suffix                        | Global  | `30s`              |
 | [`modsecurity-timeout-processing`](#modsecurity)     | time with suffix                        | Global  | `1s`               |
 | [`nbproc-ssl`](#nbproc)                              | number of process                       | Global  | `0`                |
-| [`nbthread`](#nbthread)                              | number of threads                       | Global  | `1`                |
+| [`nbthread`](#nbthread)                              | number of threads                       | Global  | `2`                |
 | [`no-tls-redirect-locations`](#ssl-redirect)         | comma-separated list of URIs            | Global  | `/.well-known/acme-challenge` |
 | [`oauth`](#oauth)                                    | "oauth2_proxy"                          | Backend |                    |
 | [`oauth-headers`](#oauth)                            | `<header>:<var>,...`                    | Backend |                    |
@@ -916,7 +916,7 @@ See also:
 
 | Configuration key | Scope    | Default | Since |
 |-------------------|----------|---------|-------|
-| `nbthread`        | `Global` | `1`     |       |
+| `nbthread`        | `Global` | `2`     |       |
 
 Define the number of threads a single HAProxy process should use to all its
 processing. If using with [nbproc](#nbproc), every single HAProxy process will

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -184,8 +184,8 @@ func (hc *HAProxyController) UpdateIngressStatus(*extensions.Ingress) []api.Load
 // ConfigureFlags allow to configure more flags before the parsing of
 // command line arguments
 func (hc *HAProxyController) ConfigureFlags(flags *pflag.FlagSet) {
-	hc.reloadStrategy = flags.String("reload-strategy", "native",
-		`Name of the reload strategy. Options are: native (default) or reusesocket`)
+	hc.reloadStrategy = flags.String("reload-strategy", "reusesocket",
+		`Name of the reload strategy. Options are: native or reusesocket (default)`)
 	hc.maxOldConfigFiles = flags.Int("max-old-config-files", 0,
 		`Maximum old haproxy timestamped config files to allow before being cleaned up. A value <= 0 indicates a single non-timestamped config file will be used`)
 	hc.validateConfig = flags.Bool("validate-config", false,

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -79,7 +79,7 @@ func createDefaults() map[string]string {
 		types.GlobalModsecurityTimeoutIdle:       "30s",
 		types.GlobalModsecurityTimeoutProcessing: "1s",
 		types.GlobalNbprocBalance:                "1",
-		types.GlobalNbthread:                     "1",
+		types.GlobalNbthread:                     "2",
 		types.GlobalNoTLSRedirectLocations:       "/.well-known/acme-challenge",
 		types.GlobalSSLCiphers:                   defaultSSLCiphers,
 		types.GlobalSSLCipherSuites:              defaultSSLCipherSuites,


### PR DESCRIPTION
Upgrading the default thread number to 2 (two) and reload strategy to reusesocket (hitless reloads, haproxy's `-x`).

This should be merged to v0.8.