### PR TITLE
Add cross-namespace command-line option

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -137,7 +137,7 @@ func (hc *HAProxyController) startServices() {
 
 func (hc *HAProxyController) createDefaultSSLFile(cache convtypes.Cache) (tlsFile convtypes.File) {
 	if hc.cfg.DefaultSSLCertificate != "" {
-		tlsFile, err := cache.GetTLSSecretPath(hc.cfg.DefaultSSLCertificate)
+		tlsFile, err := cache.GetTLSSecretPath("", hc.cfg.DefaultSSLCertificate)
 		if err == nil {
 			return tlsFile
 		}

--- a/pkg/converters/configmap/tcpservices.go
+++ b/pkg/converters/configmap/tcpservices.go
@@ -84,7 +84,7 @@ func (c *tcpSvcConverter) Sync(tcpservices map[string]string) {
 		}
 		var crtfile convtypes.File
 		if svc.secret != "" {
-			crtfile, err = c.cache.GetTLSSecretPath(svc.secret)
+			crtfile, err = c.cache.GetTLSSecretPath("", svc.secret)
 			if err != nil {
 				c.logger.Warn("skipping TCP service on public port %d: %v", publicport, err)
 				continue

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -54,6 +54,13 @@ func NewCacheMock() *CacheMock {
 	}
 }
 
+func (c *CacheMock) buildSecretName(defaultNamespace, secretName string) string {
+	if defaultNamespace == "" || strings.Index(secretName, "/") >= 0 {
+		return secretName
+	}
+	return defaultNamespace + "/" + secretName
+}
+
 // GetService ...
 func (c *CacheMock) GetService(serviceName string) (*api.Service, error) {
 	sname := strings.Split(serviceName, "/")
@@ -94,27 +101,29 @@ func (c *CacheMock) GetPod(podName string) (*api.Pod, error) {
 }
 
 // GetTLSSecretPath ...
-func (c *CacheMock) GetTLSSecretPath(secretName string) (convtypes.File, error) {
-	if path, found := c.SecretTLSPath[secretName]; found {
+func (c *CacheMock) GetTLSSecretPath(defaultNamespace, secretName string) (convtypes.File, error) {
+	fullname := c.buildSecretName(defaultNamespace, secretName)
+	if path, found := c.SecretTLSPath[fullname]; found {
 		return convtypes.File{
 			Filename: path,
 			SHA1Hash: fmt.Sprintf("%x", sha1.Sum([]byte(path))),
 		}, nil
 	}
-	return convtypes.File{}, fmt.Errorf("secret not found: '%s'", secretName)
+	return convtypes.File{}, fmt.Errorf("secret not found: '%s'", fullname)
 }
 
 // GetCASecretPath ...
-func (c *CacheMock) GetCASecretPath(secretName string) (ca, crl convtypes.File, err error) {
-	if path, found := c.SecretCAPath[secretName]; found {
+func (c *CacheMock) GetCASecretPath(defaultNamespace, secretName string) (ca, crl convtypes.File, err error) {
+	fullname := c.buildSecretName(defaultNamespace, secretName)
+	if path, found := c.SecretCAPath[fullname]; found {
 		ca = convtypes.File{
 			Filename: path,
 			SHA1Hash: fmt.Sprintf("%x", sha1.Sum([]byte(path))),
 		}
 	} else {
-		return ca, crl, fmt.Errorf("secret not found: '%s'", secretName)
+		return ca, crl, fmt.Errorf("secret not found: '%s'", fullname)
 	}
-	if path, found := c.SecretCRLPath[secretName]; found {
+	if path, found := c.SecretCRLPath[fullname]; found {
 		crl = convtypes.File{
 			Filename: path,
 			SHA1Hash: fmt.Sprintf("%x", sha1.Sum([]byte(path))),
@@ -124,23 +133,25 @@ func (c *CacheMock) GetCASecretPath(secretName string) (ca, crl convtypes.File, 
 }
 
 // GetDHSecretPath ...
-func (c *CacheMock) GetDHSecretPath(secretName string) (convtypes.File, error) {
-	if path, found := c.SecretDHPath[secretName]; found {
+func (c *CacheMock) GetDHSecretPath(defaultNamespace, secretName string) (convtypes.File, error) {
+	fullname := c.buildSecretName(defaultNamespace, secretName)
+	if path, found := c.SecretDHPath[fullname]; found {
 		return convtypes.File{
 			Filename: path,
 			SHA1Hash: fmt.Sprintf("%x", sha1.Sum([]byte(path))),
 		}, nil
 	}
-	return convtypes.File{}, fmt.Errorf("secret not found: '%s'", secretName)
+	return convtypes.File{}, fmt.Errorf("secret not found: '%s'", fullname)
 }
 
 // GetSecretContent ...
-func (c *CacheMock) GetSecretContent(secretName, keyName string) ([]byte, error) {
-	if content, found := c.SecretContent[secretName]; found {
+func (c *CacheMock) GetSecretContent(defaultNamespace, secretName, keyName string) ([]byte, error) {
+	fullname := c.buildSecretName(defaultNamespace, secretName)
+	if content, found := c.SecretContent[fullname]; found {
 		if val, found := content[keyName]; found {
 			return val, nil
 		}
-		return nil, fmt.Errorf("secret '%s' does not have file/key '%s'", secretName, keyName)
+		return nil, fmt.Errorf("secret '%s' does not have file/key '%s'", fullname, keyName)
 	}
-	return nil, fmt.Errorf("secret not found: '%s'", secretName)
+	return nil, fmt.Errorf("secret not found: '%s'", fullname)
 }

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -80,11 +80,14 @@ func (c *updater) buildBackendAuthHTTP(d *backData) {
 				c.logger.Error("missing secret name on basic authentication on %v", authType.Source)
 				return nil
 			}
-			secretName := ingutils.FullQualifiedName(authSecret.Source.Namespace, authSecret.Value)
+			secretName := authSecret.Value
+			if strings.Index(secretName, "/") < 0 {
+				secretName = authSecret.Source.Namespace + "/" + secretName
+			}
 			listName := strings.Replace(secretName, "/", "_", 1)
 			userlist := c.haproxy.FindUserlist(listName)
 			if userlist == nil {
-				userb, err := c.cache.GetSecretContent(secretName, "auth")
+				userb, err := c.cache.GetSecretContent(authSecret.Source.Namespace, authSecret.Value, "auth")
 				if err != nil {
 					c.logger.Error("error reading basic authentication on %v: %v", authSecret.Source, err)
 					return nil
@@ -594,7 +597,7 @@ func (c *updater) buildBackendProtocol(d *backData) {
 		return
 	}
 	if crt := d.mapper.Get(ingtypes.BackSecureCrtSecret); crt.Value != "" {
-		if crtFile, err := c.cache.GetTLSSecretPath(crt.Source.Namespace + "/" + crt.Value); err == nil {
+		if crtFile, err := c.cache.GetTLSSecretPath(crt.Source.Namespace, crt.Value); err == nil {
 			d.backend.Server.CrtFilename = crtFile.Filename
 			d.backend.Server.CrtHash = crtFile.SHA1Hash
 		} else {
@@ -602,7 +605,7 @@ func (c *updater) buildBackendProtocol(d *backData) {
 		}
 	}
 	if ca := d.mapper.Get(ingtypes.BackSecureVerifyCASecret); ca.Value != "" {
-		if caFile, crlFile, err := c.cache.GetCASecretPath(ca.Source.Namespace + "/" + ca.Value); err == nil {
+		if caFile, crlFile, err := c.cache.GetCASecretPath(ca.Source.Namespace, ca.Value); err == nil {
 			d.backend.Server.CAFilename = caFile.Filename
 			d.backend.Server.CAHash = caFile.SHA1Hash
 			d.backend.Server.CRLFilename = crlFile.Filename

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -97,7 +97,7 @@ func (c *updater) buildGlobalStats(d *globalData) {
 	d.global.Stats.BindIP = d.mapper.Get(ingtypes.GlobalBindIPAddrStats).Value
 	d.global.Stats.Port = d.mapper.Get(ingtypes.GlobalStatsPort).Int()
 	if tlsSecret := d.mapper.Get(ingtypes.GlobalStatsSSLCert).Value; tlsSecret != "" {
-		if tls, err := c.cache.GetTLSSecretPath(tlsSecret); err == nil {
+		if tls, err := c.cache.GetTLSSecretPath("", tlsSecret); err == nil {
 			d.global.Stats.TLSFilename = tls.Filename
 			d.global.Stats.TLSHash = tls.SHA1Hash
 		} else {
@@ -138,7 +138,7 @@ func (c *updater) buildGlobalSSL(d *globalData) {
 	ssl.BackendCipherSuites = d.mapper.Get(ingtypes.BackSSLCipherSuitesBackend).Value
 	ssl.BackendOptions = d.mapper.Get(ingtypes.BackSSLOptionsBackend).Value
 	if sslDHParam := d.mapper.Get(ingtypes.GlobalSSLDHParam).Value; sslDHParam != "" {
-		if dhFile, err := c.cache.GetDHSecretPath(sslDHParam); err == nil {
+		if dhFile, err := c.cache.GetDHSecretPath("", sslDHParam); err == nil {
 			ssl.DHParam.Filename = dhFile.Filename
 		} else {
 			c.logger.Error("error reading DH params: %v", err)

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -29,7 +29,7 @@ func (c *updater) buildHostAuthTLS(d *hostData) {
 	if verify.Value == "off" {
 		return
 	}
-	if cafile, crlfile, err := c.cache.GetCASecretPath(tlsSecret.Value); err == nil {
+	if cafile, crlfile, err := c.cache.GetCASecretPath(tlsSecret.Source.Namespace, tlsSecret.Value); err == nil {
 		d.host.TLS.CAFilename = cafile.Filename
 		d.host.TLS.CAHash = cafile.SHA1Hash
 		d.host.TLS.CRLFilename = crlfile.Filename

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -450,7 +450,7 @@ func TestSyncTLSSecretNotFound(t *testing.T) {
     tlsfilename: /tls/tls-default.pem`)
 
 	c.logger.CompareLogging(`
-WARN using default certificate due to an error reading secret 'default/ing-tls': secret not found: 'default/ing-tls'`)
+WARN using default certificate due to an error reading secret 'ing-tls' on ingress 'default/echo': secret not found: 'default/ing-tls'`)
 }
 
 func TestSyncTLSCustom(t *testing.T) {
@@ -580,7 +580,7 @@ func TestSyncInvalidTLS(t *testing.T) {
     tlsfilename: /tls/tls-default.pem`)
 
 	c.logger.CompareLogging(`
-WARN using default certificate due to an error reading secret 'default/tls-invalid': secret not found: 'default/tls-invalid'`)
+WARN using default certificate due to an error reading secret 'tls-invalid' on ingress 'default/echo': secret not found: 'default/tls-invalid'`)
 }
 
 func TestSyncRootPathDefault(t *testing.T) {

--- a/pkg/converters/ingress/utils/utils.go
+++ b/pkg/converters/ingress/utils/utils.go
@@ -16,16 +16,6 @@ limitations under the License.
 
 package utils
 
-import (
-	"fmt"
-)
-
-// FullQualifiedName ...
-func FullQualifiedName(namespace, name string) string {
-	// TODO cross namespace
-	return fmt.Sprintf("%s/%s", namespace, name)
-}
-
 // GCD calculates the Greatest Common Divisor between a and b
 func GCD(a, b int) int {
 	for b != 0 {

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -26,10 +26,10 @@ type Cache interface {
 	GetEndpoints(service *api.Service) (*api.Endpoints, error)
 	GetTerminatingPods(service *api.Service) ([]*api.Pod, error)
 	GetPod(podName string) (*api.Pod, error)
-	GetTLSSecretPath(secretName string) (File, error)
-	GetCASecretPath(secretName string) (ca, crl File, err error)
-	GetDHSecretPath(secretName string) (File, error)
-	GetSecretContent(secretName, keyName string) ([]byte, error)
+	GetTLSSecretPath(defaultNamespace, secretName string) (File, error)
+	GetCASecretPath(defaultNamespace, secretName string) (ca, crl File, err error)
+	GetDHSecretPath(defaultNamespace, secretName string) (File, error)
+	GetSecretContent(defaultNamespace, secretName, keyName string) ([]byte, error)
 }
 
 // File ...


### PR DESCRIPTION
`--allow-cross-namespace` command-line option wasn't ported to the v0.8 controller. It defaults to `false` which blocks the reading of any secret from one namespace to populate configurations of another namespace.

Should be merged to v0.8

related with #429 