### PR TITLE
Improve fronting proxy config

### DIFF
--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -156,15 +156,20 @@ func (c *updater) buildGlobalHealthz(d *globalData) {
 }
 
 func (c *updater) buildGlobalHTTPStoHTTP(d *globalData) {
-	port := d.mapper.Get(ingtypes.GlobalHTTPStoHTTPPort).Int()
-	if port > 0 {
-		d.global.Bind.ToHTTPBindIP = d.mapper.Get(ingtypes.GlobalBindIPAddrHTTP).Value
-		d.global.Bind.ToHTTPPort = port
-		// Socket ID should be a high number to avoid colision
-		// between the same socket ID from distinct frontends
-		// TODO match socket and frontend ID in the backend
-		d.global.Bind.ToHTTPSocketID = 10011
+	port := d.mapper.Get(ingtypes.GlobalFrontingProxyPort).Int()
+	if port == 0 {
+		port = d.mapper.Get(ingtypes.GlobalHTTPStoHTTPPort).Int()
 	}
+	if port == 0 {
+		return
+	}
+	// TODO Change all `ToHTTP` naming to `FrontingProxy`
+	d.global.Bind.ToHTTPBindIP = d.mapper.Get(ingtypes.GlobalBindIPAddrHTTP).Value
+	d.global.Bind.ToHTTPPort = port
+	// Socket ID should be a high number to avoid colision
+	// between the same socket ID from distinct frontends
+	// TODO match socket and frontend ID in the backend
+	d.global.Bind.ToHTTPSocketID = 10011
 }
 
 func (c *updater) buildGlobalModSecurity(d *globalData) {

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -35,6 +35,7 @@ const (
 	GlobalDrainSupport                 = "drain-support"
 	GlobalDrainSupportRedispatch       = "drain-support-redispatch"
 	GlobalForwardfor                   = "forwardfor"
+	GlobalFrontingProxyPort            = "fronting-proxy-port"
 	GlobalHealthzPort                  = "healthz-port"
 	GlobalHTTPLogFormat                = "http-log-format"
 	GlobalHTTPPort                     = "http-port"

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -235,7 +235,7 @@ func (c *config) BuildFrontendGroup() error {
 		HTTPSRedirMap:     fgroupMaps.AddMap(c.mapsDir + "/_global_https_redir.map"),
 		SSLPassthroughMap: fgroupMaps.AddMap(c.mapsDir + "/_global_sslpassthrough.map"),
 	}
-	if c.global.Bind.ToHTTPPort > 0 {
+	if c.global.Bind.HasFrontingProxy() {
 		bind := hatypes.NewFrontendBind(nil)
 		bind.Socket = fmt.Sprintf("%s:%d", c.global.Bind.ToHTTPBindIP, c.global.Bind.ToHTTPPort)
 		bind.ID = c.global.Bind.ToHTTPSocketID
@@ -349,7 +349,7 @@ func (c *config) BuildFrontendGroup() error {
 						maxBodySizes[base] = maxBodySize
 					}
 				}
-				if !hasSSLRedirect {
+				if !hasSSLRedirect || c.global.Bind.HasFrontingProxy() {
 					fgroup.HTTPFrontsMap.AppendHostname(base, back)
 				}
 				var ns string

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -724,82 +724,195 @@ empty/ default_empty_8080`)
 }
 
 func TestInstanceToHTTPSocket(t *testing.T) {
-	c := setup(t)
-	defer c.teardown()
-
-	var h *hatypes.Host
-	var b *hatypes.Backend
-
-	b = c.config.AcquireBackend("d1", "app", "8080")
-	h = c.config.AcquireHost("d1.local")
-	h.AddPath(b, "/")
-	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	b.HSTS = []*hatypes.BackendConfigHSTS{
+	testCases := []struct {
+		toHTTPPort       int
+		domain           string
+		expectedFront    string
+		expectedMap      string
+		expectedRegexMap string
+		expectedACL      string
+		expectedSetvar   string
+	}{
+		// 0
 		{
-			Paths: hatypes.NewBackendPaths(b.FindHostPath("d1.local/")),
-			Config: hatypes.HSTS{
-				Enabled:    true,
-				MaxAge:     15768000,
-				Subdomains: true,
-				Preload:    true,
-			},
+			toHTTPPort: 8000,
+			domain:     "d1.local",
+			expectedFront: `
+    mode http
+    bind :80
+    bind :8000 id 11
+    acl fronting-proxy so_id 11
+    http-request redirect scheme https if fronting-proxy !{ hdr(X-Forwarded-Proto) https }
+    http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
+    http-request redirect scheme https if !fronting-proxy { var(req.base),map_beg(/etc/haproxy/maps/_global_https_redir.map,_nomatch) yes }
+    http-request set-header X-Forwarded-Proto http if !fronting-proxy
+    http-request del-header X-SSL-Client-CN if !fronting-proxy
+    http-request del-header X-SSL-Client-DN if !fronting-proxy
+    http-request del-header X-SSL-Client-SHA1 if !fronting-proxy
+    http-request del-header X-SSL-Client-Cert if !fronting-proxy
+    http-request set-var(req.backend) var(req.base),map_beg(/etc/haproxy/maps/_global_http_front.map,_nomatch)
+    use_backend %[var(req.backend)] unless { var(req.backend) _nomatch }`,
+			expectedMap: "d1.local/ d1_app_8080",
+			expectedACL: `
+    acl tls-has-crt ssl_c_used
+    acl tls-need-crt ssl_fc_sni -i -f /etc/haproxy/maps/_front001_no_crt.list
+    acl tls-host-need-crt var(req.host) -i -f /etc/haproxy/maps/_front001_no_crt.list
+    acl tls-has-invalid-crt ssl_c_ca_err gt 0
+    acl tls-has-invalid-crt ssl_c_err gt 0
+    acl tls-check-crt ssl_fc_sni -i -f /etc/haproxy/maps/_front001_inv_crt.list`,
+			expectedSetvar: `
+    http-request set-var(req.snibase) ssl_fc_sni,concat(path),lower,regsub(:[0-9]+/,/)
+    http-request set-var(req.snibackend) var(req.snibase),map_beg(/etc/haproxy/maps/_front001_sni.map,_nomatch)
+    http-request set-var(req.snibackend) var(req.base),map_beg(/etc/haproxy/maps/_front001_sni.map,_nomatch) if { var(req.snibackend) _nomatch } !tls-has-crt !tls-host-need-crt
+    http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_no_crt_redir.map,_internal) if !tls-has-crt tls-need-crt
+    http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_inv_crt_redir.map,_internal) if tls-has-invalid-crt tls-check-crt`,
+		},
+		// 1
+		{
+			toHTTPPort: 8000,
+			domain:     "*.d1.local",
+			expectedFront: `
+    mode http
+    bind :80
+    bind :8000 id 11
+    acl fronting-proxy so_id 11
+    http-request redirect scheme https if fronting-proxy !{ hdr(X-Forwarded-Proto) https }
+    http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
+    http-request set-var(req.redir) var(req.base),map_beg(/etc/haproxy/maps/_global_https_redir.map,_nomatch) if !fronting-proxy
+    http-request redirect scheme https if !fronting-proxy { var(req.redir) yes }
+    http-request redirect scheme https if !fronting-proxy { var(req.redir) _nomatch } { var(req.base),map_reg(/etc/haproxy/maps/_global_https_redir_regex.map,_nomatch) yes }
+    http-request set-header X-Forwarded-Proto http if !fronting-proxy
+    http-request del-header X-SSL-Client-CN if !fronting-proxy
+    http-request del-header X-SSL-Client-DN if !fronting-proxy
+    http-request del-header X-SSL-Client-SHA1 if !fronting-proxy
+    http-request del-header X-SSL-Client-Cert if !fronting-proxy
+    http-request set-var(req.backend) var(req.base),map_beg(/etc/haproxy/maps/_global_http_front.map,_nomatch)
+    http-request set-var(req.backend) var(req.base),map_reg(/etc/haproxy/maps/_global_http_front_regex.map,_nomatch) if { var(req.backend) _nomatch }
+    use_backend %[var(req.backend)] unless { var(req.backend) _nomatch }`,
+			expectedRegexMap: `^[^.]+\.d1\.local/ d1_app_8080`,
+			expectedACL: `
+    acl tls-has-crt ssl_c_used
+    acl tls-need-crt ssl_fc_sni -i -f /etc/haproxy/maps/_front001_no_crt.list
+    acl tls-need-crt ssl_fc_sni -i -m reg -f /etc/haproxy/maps/_front001_no_crt_regex.list
+    acl tls-host-need-crt var(req.host) -i -f /etc/haproxy/maps/_front001_no_crt.list
+    acl tls-host-need-crt var(req.host) -i -m reg -f /etc/haproxy/maps/_front001_no_crt_regex.list
+    acl tls-has-invalid-crt ssl_c_ca_err gt 0
+    acl tls-has-invalid-crt ssl_c_err gt 0
+    acl tls-check-crt ssl_fc_sni -i -f /etc/haproxy/maps/_front001_inv_crt.list
+    acl tls-check-crt ssl_fc_sni -i -m reg -f /etc/haproxy/maps/_front001_inv_crt_regex.list`,
+			expectedSetvar: `
+    http-request set-var(req.snibase) ssl_fc_sni,concat(path),lower,regsub(:[0-9]+/,/)
+    http-request set-var(req.snibackend) var(req.snibase),map_beg(/etc/haproxy/maps/_front001_sni.map,_nomatch)
+    http-request set-var(req.snibackend) var(req.snibase),map_reg(/etc/haproxy/maps/_front001_sni_regex.map,_nomatch) if { var(req.snibackend) _nomatch }
+    http-request set-var(req.snibackend) var(req.base),map_beg(/etc/haproxy/maps/_front001_sni.map,_nomatch) if { var(req.snibackend) _nomatch } !tls-has-crt !tls-host-need-crt
+    http-request set-var(req.snibackend) var(req.base),map_reg(/etc/haproxy/maps/_front001_sni_regex.map,_nomatch) if { var(req.snibackend) _nomatch } !tls-has-crt !tls-host-need-crt
+    http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_no_crt_redir.map,_internal) if !tls-has-crt tls-need-crt
+    http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_inv_crt_redir.map,_internal) if tls-has-invalid-crt tls-check-crt`,
+		},
+		// 2
+		{
+			toHTTPPort: 80,
+			domain:     "d1.local",
+			expectedFront: `
+    mode http
+    bind :80
+    acl fronting-proxy hdr(X-Forwarded-Proto) -m found
+    http-request redirect scheme https if fronting-proxy !{ hdr(X-Forwarded-Proto) https }
+    http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
+    http-request redirect scheme https if !fronting-proxy { var(req.base),map_beg(/etc/haproxy/maps/_global_https_redir.map,_nomatch) yes }
+    http-request set-header X-Forwarded-Proto http if !fronting-proxy
+    http-request del-header X-SSL-Client-CN if !fronting-proxy
+    http-request del-header X-SSL-Client-DN if !fronting-proxy
+    http-request del-header X-SSL-Client-SHA1 if !fronting-proxy
+    http-request del-header X-SSL-Client-Cert if !fronting-proxy
+    http-request set-var(req.backend) var(req.base),map_beg(/etc/haproxy/maps/_global_http_front.map,_nomatch)
+    use_backend %[var(req.backend)] unless { var(req.backend) _nomatch }`,
+			expectedMap: "d1.local/ d1_app_8080",
+			expectedACL: `
+    acl tls-has-crt ssl_c_used
+    acl tls-need-crt ssl_fc_sni -i -f /etc/haproxy/maps/_front001_no_crt.list
+    acl tls-host-need-crt var(req.host) -i -f /etc/haproxy/maps/_front001_no_crt.list
+    acl tls-has-invalid-crt ssl_c_ca_err gt 0
+    acl tls-has-invalid-crt ssl_c_err gt 0
+    acl tls-check-crt ssl_fc_sni -i -f /etc/haproxy/maps/_front001_inv_crt.list`,
+			expectedSetvar: `
+    http-request set-var(req.snibase) ssl_fc_sni,concat(path),lower,regsub(:[0-9]+/,/)
+    http-request set-var(req.snibackend) var(req.snibase),map_beg(/etc/haproxy/maps/_front001_sni.map,_nomatch)
+    http-request set-var(req.snibackend) var(req.base),map_beg(/etc/haproxy/maps/_front001_sni.map,_nomatch) if { var(req.snibackend) _nomatch } !tls-has-crt !tls-host-need-crt
+    http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_no_crt_redir.map,_internal) if !tls-has-crt tls-need-crt
+    http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_inv_crt_redir.map,_internal) if tls-has-invalid-crt tls-check-crt`,
 		},
 	}
-	h.TLS.CAHash = "1"
-	h.TLS.CAFilename = "/var/haproxy/ssl/ca.pem"
-	c.config.Global().Bind.ToHTTPPort = 8000
-	c.config.Global().Bind.ToHTTPSocketID = 11
+	for _, test := range testCases {
+		c := setup(t)
 
-	c.Update()
-	c.checkConfig(`
+		var h *hatypes.Host
+		var b *hatypes.Backend
+
+		b = c.config.AcquireBackend("d1", "app", "8080")
+		h = c.config.AcquireHost(test.domain)
+		h.AddPath(b, "/")
+		b.Endpoints = []*hatypes.Endpoint{endpointS1}
+		b.HSTS = []*hatypes.BackendConfigHSTS{
+			{
+				Paths: hatypes.NewBackendPaths(b.FindHostPath(test.domain + "/")),
+				Config: hatypes.HSTS{
+					Enabled:    true,
+					MaxAge:     15768000,
+					Subdomains: true,
+					Preload:    true,
+				},
+			},
+		}
+		h.TLS.CAHash = "1"
+		h.TLS.CAFilename = "/var/haproxy/ssl/ca.pem"
+		c.config.Global().Bind.ToHTTPPort = test.toHTTPPort
+		c.config.Global().Bind.ToHTTPSocketID = 11
+
+		c.Update()
+		c.checkConfig(`
 <<global>>
 <<defaults>>
 backend d1_app_8080
     mode http
     acl https-request ssl_fc
-    acl https-request so_id 11
+    acl https-request var(txn.proto) https
     acl local-offload ssl_fc
+    http-request set-var(txn.proto) hdr(X-Forwarded-Proto)
     http-request set-header X-SSL-Client-CN   %{+Q}[ssl_c_s_dn(cn)]   if local-offload
     http-request set-header X-SSL-Client-DN   %{+Q}[ssl_c_s_dn]       if local-offload
     http-request set-header X-SSL-Client-SHA1 %{+Q}[ssl_c_sha1,hex]   if local-offload
     http-response set-header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload" if https-request
     server s1 172.17.0.11:8080 weight 100
 <<backends-default>>
-<<frontend-http>>
+frontend _front_http` + test.expectedFront + `
     default_backend _error404
 frontend _front001
     mode http
     bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front001_bind_crt.list ca-ignore-err all crt-ignore-err all
-    bind :8000 id 11
-    acl local-offload ssl_fc
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
     http-request set-var(req.hostbackend) var(req.base),map_beg(/etc/haproxy/maps/_front001_host.map,_nomatch)
     http-request set-var(req.host) hdr(host),lower,regsub(:[0-9]+$,)
     http-request set-header X-Forwarded-Proto https
-    http-request del-header X-SSL-Client-CN if local-offload
-    http-request del-header X-SSL-Client-DN if local-offload
-    http-request del-header X-SSL-Client-SHA1 if local-offload
-    http-request del-header X-SSL-Client-Cert if local-offload
-    acl tls-has-crt ssl_c_used
-    acl tls-need-crt ssl_fc_sni -i -f /etc/haproxy/maps/_front001_no_crt.list
-    acl tls-host-need-crt var(req.host) -i -f /etc/haproxy/maps/_front001_no_crt.list
-    acl tls-has-invalid-crt ssl_c_ca_err gt 0
-    acl tls-has-invalid-crt ssl_c_err gt 0
-    acl tls-check-crt ssl_fc_sni -i -f /etc/haproxy/maps/_front001_inv_crt.list
-    http-request set-var(req.snibase) ssl_fc_sni,concat(path),lower,regsub(:[0-9]+/,/) if local-offload
-    http-request set-var(req.snibackend) var(req.snibase),map_beg(/etc/haproxy/maps/_front001_sni.map,_nomatch) if local-offload
-    http-request set-var(req.snibackend) var(req.base),map_beg(/etc/haproxy/maps/_front001_sni.map,_nomatch) if local-offload { var(req.snibackend) _nomatch } !tls-has-crt !tls-host-need-crt
-    http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_no_crt_redir.map,_internal) if local-offload !tls-has-crt tls-need-crt
-    http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_inv_crt_redir.map,_internal) if local-offload tls-has-invalid-crt tls-check-crt
+    http-request del-header X-SSL-Client-CN
+    http-request del-header X-SSL-Client-DN
+    http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-Cert` + test.expectedACL + test.expectedSetvar + `
     use_backend _error421 if { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
     use_backend _error496 if { var(req.tls_nocrt_redir) _internal }
     use_backend _error495 if { var(req.tls_invalidcrt_redir) _internal }
     use_backend %[var(req.hostbackend)] unless { var(req.hostbackend) _nomatch }
-    use_backend %[var(req.snibackend)] if local-offload !{ var(req.snibackend) _nomatch }
+    use_backend %[var(req.snibackend)] unless { var(req.snibackend) _nomatch }
     default_backend _error404
 <<support>>
 `)
-	c.logger.CompareLogging(defaultLogging)
+		c.checkMap("_global_http_front.map", test.expectedMap)
+		if test.expectedRegexMap != "" {
+			c.checkMap("_global_http_front_regex.map", test.expectedRegexMap)
+		}
+		c.logger.CompareLogging(defaultLogging)
+		c.teardown()
+	}
 }
 
 func TestInstanceTCPBackend(t *testing.T) {

--- a/pkg/haproxy/types/global.go
+++ b/pkg/haproxy/types/global.go
@@ -35,3 +35,13 @@ func (dns *DNSNameserver) String() string {
 func (u *Userlist) String() string {
 	return fmt.Sprintf("%+v", *u)
 }
+
+// ShareHTTPPort ...
+func (b GlobalBindConfig) ShareHTTPPort() bool {
+	return b.HasFrontingProxy() && b.HTTPBindIP == b.ToHTTPBindIP && b.HTTPPort == b.ToHTTPPort
+}
+
+// HasFrontingProxy ...
+func (b GlobalBindConfig) HasFrontingProxy() bool {
+	return b.ToHTTPPort > 0
+}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -285,15 +285,20 @@ backend {{ $backend.ID }}
 {{- else }}{{/*** if $backend.ModeTCP ***/}}
 
 {{- /*------------------------------------*/}}
+{{- $hasFrontingProxy := $global.Bind.ToHTTPSocketID }}
 {{- if $backend.HSTS }}
     acl https-request ssl_fc
-{{- $hasHTTPSocket := $global.Bind.ToHTTPSocketID }}
-{{- if $hasHTTPSocket }}
-    acl https-request so_id {{ $global.Bind.ToHTTPSocketID }}
+{{- if $hasFrontingProxy }}
+    acl https-request var(txn.proto) https
 {{- end }}
 {{- end }}
-{{- if or $backend.TLS.HasTLSAuth }}
+{{- if $backend.TLS.HasTLSAuth }}
     acl local-offload ssl_fc
+{{- end }}
+
+{{- /*------------------------------------*/}}
+{{- if and $hasFrontingProxy $backend.HSTS }}
+    http-request set-var(txn.proto) hdr(X-Forwarded-Proto)
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -675,13 +680,33 @@ listen _front__tls
     server _default_server{{ $fgroup.DefaultBind.Name }} {{ $fgroup.DefaultBind.Socket }} send-proxy-v2
 {{- end }}
 
+{{- $hasFrontingProxy := $global.Bind.ToHTTPSocketID }}
+
   # # # # # # # # # # # # # # # # # # #
 # #
-#     HTTP frontend
+#     HTTP{{ if $hasFrontingProxy }} & Fronting Proxy{{ end }} frontend
 #
 frontend _front_http
     mode http
+{{- $frontingBind := $fgroup.ToHTTPBind }}
+{{- $hasPlainHTTPSocket := not $global.Bind.ShareHTTPPort }}
+{{- if $hasPlainHTTPSocket }}
     bind {{ $global.Bind.HTTPBindIP }}:{{ $global.Bind.HTTPPort }}{{ if $global.Bind.AcceptProxy }} accept-proxy{{ end }}
+{{- end }}
+{{- if $frontingBind.Socket }}
+    bind {{ $frontingBind.Socket }}
+        {{- if and $hasPlainHTTPSocket $frontingBind.ID }} id {{ $frontingBind.ID }}{{ end }}
+        {{- if $frontingBind.AcceptProxy }} accept-proxy{{ end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
+{{- if $hasFrontingProxy }}
+{{- if $hasPlainHTTPSocket }}
+    acl fronting-proxy so_id {{ $global.Bind.ToHTTPSocketID }}
+{{- else }}
+    acl fronting-proxy hdr(X-Forwarded-Proto) -m found
+{{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- if $global.Syslog.Endpoint }}
@@ -693,17 +718,30 @@ frontend _front_http
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $hasFrontingProxy }}
+    http-request redirect scheme https if
+        {{- "" }} fronting-proxy !{ hdr(X-Forwarded-Proto) https }
+{{- end }}
+
+{{- /*------------------------------------*/}}
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
 
 {{- /*------------------------------------*/}}
 {{- if $fgroup.HTTPSRedirMap.HasRegex }}
     http-request set-var(req.redir)
         {{- "" }} var(req.base),map_beg({{ $fgroup.HTTPSRedirMap.MatchFile }},_nomatch)
-    http-request redirect scheme https if { var(req.redir) yes }
-    http-request redirect scheme https if { var(req.redir) _nomatch }
+        {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
+    http-request redirect scheme https if
+        {{- if $hasFrontingProxy }} !fronting-proxy{{ end }}
+        {{- "" }} { var(req.redir) yes }
+    http-request redirect scheme https if
+        {{- if $hasFrontingProxy }} !fronting-proxy{{ end }}
+        {{- "" }} { var(req.redir) _nomatch }
         {{- "" }} { var(req.base),map_reg({{ $fgroup.HTTPSRedirMap.RegexFile }},_nomatch) yes }
 {{- else }}
-    http-request redirect scheme https if { var(req.base),map_beg({{ $fgroup.HTTPSRedirMap.MatchFile }},_nomatch) yes }
+    http-request redirect scheme https if
+        {{- if $hasFrontingProxy }} !fronting-proxy{{ end }}
+        {{- "" }} { var(req.base),map_beg({{ $fgroup.HTTPSRedirMap.MatchFile }},_nomatch) yes }
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -720,10 +758,15 @@ frontend _front_http
 
 {{- /*------------------------------------*/}}
     http-request set-header X-Forwarded-Proto http
+        {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-CN
+        {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-DN
+        {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-SHA1
+        {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-Cert
+        {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
 
 {{- /*------------------------------------*/}}
     http-request set-var(req.backend) var(req.base),map_beg({{ $fgroup.HTTPFrontsMap.MatchFile }},_nomatch)
@@ -745,7 +788,7 @@ frontend _front_http
 
   # # # # # # # # # # # # # # # # # # #
 # #
-#     HTTPS frontends
+#     HTTPS frontend
 #
 {{- range $frontend := $frontends }}
 frontend {{ $frontend.Name }}
@@ -760,18 +803,6 @@ frontend {{ $frontend.Name }}
         {{- "" }} ssl alpn {{ $bind.ALPN }}
         {{- "" }} crt-list {{ $bind.CrtList.MatchFile }}
         {{- "" }} ca-ignore-err all crt-ignore-err all
-{{- end }}
-{{- $bind := $fgroup.ToHTTPBind }}
-{{- if $bind.Socket }}
-    bind {{ $bind.Socket }}
-        {{- if $bind.ID }} id {{ $bind.ID }}{{ end }}
-        {{- if $bind.AcceptProxy }} accept-proxy{{ end }}
-{{- end }}
-
-{{- /*------------------------------------*/}}
-{{- $hasHTTPSocket := $global.Bind.ToHTTPSocketID }}
-{{- if $hasHTTPSocket }}
-    acl local-offload ssl_fc
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -834,13 +865,9 @@ frontend {{ $frontend.Name }}
 {{- /*------------------------------------*/}}
     http-request set-header X-Forwarded-Proto https
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-CN
-        {{- if $hasHTTPSocket }} if local-offload{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-DN
-        {{- if $hasHTTPSocket }} if local-offload{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-SHA1
-        {{- if $hasHTTPSocket }} if local-offload{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-Cert
-        {{- if $hasHTTPSocket }} if local-offload{{ end }}
 
 {{- /*------------------------------------*/}}
 {{- if $frontend.HasMaxBody }}
@@ -868,66 +895,53 @@ frontend {{ $frontend.Name }}
     acl tls-check-crt ssl_fc_sni -i -m reg -f {{ $frontend.TLSInvalidCrtErrorList.RegexFile }}
 {{- end }}
     http-request set-var(req.snibase) ssl_fc_sni,concat(path),lower,regsub(:[0-9]+/,/)
-        {{- if $hasHTTPSocket }} if local-offload{{ end }}
 {{- if $frontend.SNIBackendsMap.HasRegex }}
     http-request set-var(req.snibackend) var(req.snibase)
         {{- "" }},map_beg({{ $frontend.SNIBackendsMap.MatchFile }},_nomatch)
-        {{- if $hasHTTPSocket }} if local-offload{{ end }}
     http-request set-var(req.snibackend) var(req.snibase)
         {{- "" }},map_reg({{ $frontend.SNIBackendsMap.RegexFile }},_nomatch)
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} { var(req.snibackend) _nomatch }
+        {{- "" }} if { var(req.snibackend) _nomatch }
     http-request set-var(req.snibackend) var(req.base)
         {{- "" }},map_beg({{ $frontend.SNIBackendsMap.MatchFile }},_nomatch)
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} { var(req.snibackend) _nomatch }
+        {{- "" }} if { var(req.snibackend) _nomatch }
         {{- "" }} !tls-has-crt !tls-host-need-crt
     http-request set-var(req.snibackend) var(req.base)
         {{- "" }},map_reg({{ $frontend.SNIBackendsMap.RegexFile }},_nomatch)
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} { var(req.snibackend) _nomatch }
+        {{- "" }} if { var(req.snibackend) _nomatch }
         {{- "" }} !tls-has-crt !tls-host-need-crt
 {{- else }}
     http-request set-var(req.snibackend) var(req.snibase)
         {{- "" }},map_beg({{ $frontend.SNIBackendsMap.MatchFile }},_nomatch)
-        {{- if $hasHTTPSocket }} if local-offload{{ end }}
     http-request set-var(req.snibackend) var(req.base)
         {{- "" }},map_beg({{ $frontend.SNIBackendsMap.MatchFile }},_nomatch)
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} { var(req.snibackend) _nomatch }
+        {{- "" }} if { var(req.snibackend) _nomatch }
         {{- "" }} !tls-has-crt !tls-host-need-crt
 {{- end }}
 {{- if $mandatory }}
     http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower
         {{- "" }},map({{ $frontend.TLSNoCrtErrorPagesMap.MatchFile }},_internal)
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} !tls-has-crt tls-need-crt
+        {{- "" }} if !tls-has-crt tls-need-crt
 {{- if $frontend.TLSNoCrtErrorPagesMap.HasRegex }}
     http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower
         {{- "" }},map_reg({{ $frontend.TLSNoCrtErrorPagesMap.RegexFile }},_internal)
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} { var(req.tls_nocrt_redir) _internal }
+        {{- "" }} if { var(req.tls_nocrt_redir) _internal }
 {{- end }}
 {{- end }}
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower
         {{- "" }},map({{ $frontend.TLSInvalidCrtErrorPagesMap.MatchFile }},_internal)
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} tls-has-invalid-crt tls-check-crt
+        {{- "" }} if tls-has-invalid-crt tls-check-crt
 {{- if $frontend.TLSInvalidCrtErrorPagesMap.HasRegex }}
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower
         {{- "" }},map_reg({{ $frontend.TLSInvalidCrtErrorPagesMap.RegexFile }},_internal)
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} { var(req.tls_invalidcrt_redir) _internal }
+        {{- "" }} if { var(req.tls_invalidcrt_redir) _internal }
 {{- end }}
 {{- if and $mandatory $frontend.HasNoCrtErrorPage }}
     http-request redirect location %[var(req.tls_nocrt_redir)] code 303
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} { var(req.tls_nocrt_redir) -m found } !{ var(req.tls_nocrt_redir) _internal }
+        {{- "" }} if { var(req.tls_nocrt_redir) -m found } !{ var(req.tls_nocrt_redir) _internal }
 {{- end }}
 {{- if $frontend.HasInvalidErrorPage }}
     http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303
-        {{- "" }} if{{ if $hasHTTPSocket }} local-offload{{ end }}
-        {{- "" }} { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
+        {{- "" }} if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
 {{- end }}
 {{- end }}
 
@@ -956,8 +970,7 @@ frontend {{ $frontend.Name }}
     use_backend %[var(req.hostbackend)] unless { var(req.hostbackend) _nomatch }
 {{- if $frontend.HasTLSAuth }}
     use_backend %[var(req.snibackend)]
-        {{- if $hasHTTPSocket }} if local-offload !{ var(req.snibackend) _nomatch }
-        {{- else }} unless { var(req.snibackend) _nomatch }{{ end }}
+       {{- "" }} unless { var(req.snibackend) _nomatch }
 {{- end }}
 {{- template "defaultbackend" map $cfg }}
 {{- end }}


### PR DESCRIPTION
Fixes https redirect scheme and port sharing with http-port, which defaults to 80. Name changed from `https-to-http-port` to `fronting-proxy-port` which better represents the functionality. The old name is now an alias to the new one.

The implementation was moved from https frontend to http due to some advantages:

* Easier to share the same http port without side effect
* There is less `if`s in the http frontend if compared to the https one

Missing var-namespace and max-body-size implementations which wasn't in the http frontend.

Should be merged to v0.8.

Related with #401