### PR TITLE
Add forwardfor option - update

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -695,18 +695,26 @@ See also:
 |-------------------|-----------|---------|-------|
 | `forwardfor`      | `Global`  | `add`   |       |
 
-Define if `X-Forwarded-For` header should be added always, added if missing or
-ignored from incoming requests. Default is `add` which means HAProxy will itself
-generate a `X-Forwarded-For` header with client's IP address and remove this same
-header from incoming requests.
+Define how the `X-Forwarded-For` header should be handled by haproxy.
 
-Use `ignore` to skip any check. `ifmissing` should be used to add
-`X-Forwarded-For` with client's IP address only if this header is not defined.
-Only use `ignore` or `ifmissing` on trusted networks.
+Options:
+
+* `add`: haproxy should generate a `X-Forwarded-For` header with the source IP
+address. This is the default option and should be used on untrusted networks.
+If the request has a `XFF` header, its value is copied to
+`X-Original-Forwarded-For`.
+* `update`: Only on `v0.9` and above. haproxy should preserve any `X-Forwarded-For`
+header, if provided, updating with the source IP address, which should be a
+fronting TCP or HTTP proxy/load balancer.
+* `ignore`: do nothing - only send the `X-Forwarded-For` header if the client
+provided one, without updating its content.
+* `ifmissing`: add `X-Forwarded-For` header only if the incoming request
+doesn't provide one.
 
 See also:
 
 * http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-option%20forwardfor
+* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
 
 ---
 

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -220,7 +220,7 @@ func (c *updater) buildGlobalDNS(d *globalData) {
 }
 
 var (
-	forwardRegex = regexp.MustCompile(`^(add|ignore|ifmissing)$`)
+	forwardRegex = regexp.MustCompile(`^(add|update|ignore|ifmissing)$`)
 )
 
 func (c *updater) buildGlobalForwardFor(d *globalData) {

--- a/pkg/converters/ingress/annotations/global_test.go
+++ b/pkg/converters/ingress/annotations/global_test.go
@@ -190,6 +190,12 @@ func TestForwardFor(t *testing.T) {
 			expected: "ifmissing",
 			logging:  "",
 		},
+		// 5
+		{
+			conf:     "update",
+			expected: "update",
+			logging:  "",
+		},
 	}
 	for i, test := range testCases {
 		c := setup(t)

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -382,6 +382,8 @@ backend {{ $backend.ID }}
     http-request set-header X-Original-Forwarded-For %[hdr(x-forwarded-for)] if { hdr(x-forwarded-for) -m found }
     http-request del-header x-forwarded-for
     option forwardfor
+{{- else if eq $global.ForwardFor "update" }}
+    option forwardfor
 {{- else if eq $global.ForwardFor "ifmissing" }}
     option forwardfor if-none
 {{- end }}


### PR DESCRIPTION
Add the new option `update` to forwardfor global configuration key. This option updates any provided `X-Forwarded-For` header without removing the original content.