### PR TITLE
Add support for Mod Security DetectionOnly Mode

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -1383,17 +1383,17 @@ See also [http-log](#log-format).
 | Configuration key | Scope     | Default | Since |
 |-------------------|-----------|---------|-------|
 | `waf`             | `Backend` |         |       |
-| `waf-mode`        | `Backend` |  `On`   | v0.9  |
+| `waf-mode`        | `Backend` | `deny`  | v0.9  |
 
 Defines which web application firewall (WAF) implementation should be used
 to validate requests. Currently the only supported value is `modsecurity`.
 
 This configuration has no effect if the ModSecurity endpoints are not configured.
 
-The `waf-mode` key defines wether the WAF should be `On` or in `DetectOnly` for that Backend. 
-If the WAF is in DetectOnly mode the requests are passed to ModSecurity and logged, but not denied.
+The `waf-mode` key defines wether the WAF should be `deny` or `detect` for that Backend. 
+If the WAF is in `detect` mode the requests are passed to ModSecurity and logged, but not denied.
 
-The default behavior here is `On` if `waf` is set to `modsecurity`.
+The default behavior here is `deny` if `waf` is set to `modsecurity`.
 
 See also:
 

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -221,6 +221,7 @@ The table below describes all supported configuration keys.
 | [`use-resolver`](#dns-resolvers)                     | resolver name                           | Backend |                    |
 | [`var-namespace`](#var-namespace)                    | [true\|false]                           | Host    | `false`            |
 | [`waf`](#waf)                                        | "modsecurity"                           | Backend |                    |
+| [`waf-mode`](#waf)                                   | [On\|DetectOnly]                        | Backend | `On` (if waf is set) |
 | `whitelist-source-range`                             | CIDR                                    | Backend |                    |
 
 ## Affinity
@@ -1382,11 +1383,17 @@ See also [http-log](#log-format).
 | Configuration key | Scope     | Default | Since |
 |-------------------|-----------|---------|-------|
 | `waf`             | `Backend` |         |       |
+| `waf-mode`        | `Backend` |  `On`   | v0.9  |
 
 Defines which web application firewall (WAF) implementation should be used
 to validate requests. Currently the only supported value is `modsecurity`.
 
 This configuration has no effect if the ModSecurity endpoints are not configured.
+
+The `waf-mode` key defines wether the WAF should be `On` or in `DetectOnly` for that Backend. 
+If the WAF is in DetectOnly mode the requests are passed to ModSecurity and logged, but not denied.
+
+The default behavior here is `On` if `waf` is set to `modsecurity`.
 
 See also:
 

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -737,15 +737,20 @@ func (c *updater) buildBackendWAF(d *backData) {
 				c.logger.Warn("ignoring invalid WAF module on %s: %s", waf.Source, waf.Value)
 				return nil
 			}
+			wafMode, foundWAFMode := values[ingtypes.BackWAFMode]
+			if !foundWAFMode {
+				return values
+			}
+			if wafMode.Value != "deny" && wafMode.Value != "detect" {
+				c.logger.Warn("ignoring invalid WAF mode '%s' on %s, using 'deny' instead", wafMode.Value, wafMode.Source)
+				wafMode.Value = "deny"
+			}
 			return values
 		},
 	)
 	for _, cfg := range config {
 		wafModule := cfg.Get(ingtypes.BackWAF).Value
 		wafMode := cfg.Get(ingtypes.BackWAFMode).Value
-		if wafMode != "On" && wafMode != "DetectOnly" {
-			wafMode = "On"
-		}
 		d.backend.WAF = append(d.backend.WAF, &hatypes.BackendConfigWAF{
 			Paths: cfg.Paths,
 			Config: hatypes.WAF{

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -727,23 +727,31 @@ func (c *updater) buildBackendTimeout(d *backData) {
 func (c *updater) buildBackendWAF(d *backData) {
 	config := d.mapper.GetBackendConfig(
 		d.backend,
-		[]string{ingtypes.BackWAF},
+		[]string{ingtypes.BackWAF, ingtypes.BackWAFMode},
 		func(path *hatypes.BackendPath, values map[string]*ConfigValue) map[string]*ConfigValue {
-			waf, found := values[ingtypes.BackWAF]
-			if !found {
+			waf, foundWAF := values[ingtypes.BackWAF]
+			if !foundWAF {
 				return nil
 			}
 			if waf.Value != "modsecurity" {
-				c.logger.Warn("ignoring invalid WAF mode on %s: %s", waf.Source, waf.Value)
+				c.logger.Warn("ignoring invalid WAF module on %s: %s", waf.Source, waf.Value)
 				return nil
 			}
 			return values
 		},
 	)
 	for _, cfg := range config {
-		d.backend.WAF = append(d.backend.WAF, &hatypes.BackendConfigStr{
-			Paths:  cfg.Paths,
-			Config: cfg.Get(ingtypes.BackWAF).Value,
+		wafModule := cfg.Get(ingtypes.BackWAF).Value
+		wafMode := cfg.Get(ingtypes.BackWAFMode).Value
+		if wafMode != "On" && wafMode != "DetectOnly" {
+			wafMode = "On"
+		}
+		d.backend.WAF = append(d.backend.WAF, &hatypes.BackendConfigWAF{
+			Paths: cfg.Paths,
+			Config: hatypes.WAF{
+				Module: wafModule,
+				Mode:   wafMode,
+			},
 		})
 	}
 }

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -1586,6 +1586,7 @@ func TestWAF(t *testing.T) {
 		expectedmode string
 		logging      string
 	}{
+		// 0
 		{
 			waf:          "",
 			wafmode:      "",
@@ -1593,32 +1594,44 @@ func TestWAF(t *testing.T) {
 			expectedmode: "",
 			logging:      "",
 		},
+		// 1
 		{
 			waf:          "none",
-			wafmode:      "On",
+			wafmode:      "deny",
 			expected:     "",
-			expectedmode: "On",
+			expectedmode: "",
 			logging:      "WARN ignoring invalid WAF module on ingress 'default/ing1': none",
 		},
+		// 2
 		{
 			waf:          "modsecurity",
 			wafmode:      "XXXXXX",
 			expected:     "modsecurity",
-			expectedmode: "On",
-			logging:      "",
+			expectedmode: "deny",
+			logging:      "WARN ignoring invalid WAF mode 'XXXXXX' on ingress 'default/ing1', using 'deny' instead",
 		},
+		// 3
 		{
 			waf:          "modsecurity",
-			wafmode:      "DetectOnly",
+			wafmode:      "detect",
 			expected:     "modsecurity",
-			expectedmode: "DetectOnly",
+			expectedmode: "detect",
 			logging:      "",
 		},
+		// 4
 		{
 			waf:          "modsecurity",
-			wafmode:      "On",
+			wafmode:      "deny",
 			expected:     "modsecurity",
-			expectedmode: "On",
+			expectedmode: "deny",
+			logging:      "",
+		},
+		// 5
+		{
+			waf:          "modsecurity",
+			wafmode:      "",
+			expected:     "modsecurity",
+			expectedmode: "deny",
 			logging:      "",
 		},
 	}
@@ -1631,24 +1644,25 @@ func TestWAF(t *testing.T) {
 		c := setup(t)
 		var ann map[string]map[string]string
 		var expected []*hatypes.BackendConfigWAF
-		if test.waf != "" {
-			ann = map[string]map[string]string{
-				"/": {
-					ingtypes.BackWAF:     test.waf,
-					ingtypes.BackWAFMode: test.wafmode,
-				},
-			}
-			expected = []*hatypes.BackendConfigWAF{
-				{
-					Paths: createBackendPaths("/"),
-					Config: hatypes.WAF{
-						Mode:   test.expectedmode,
-						Module: test.expected,
-					},
-				},
-			}
+		ann = map[string]map[string]string{
+			"/": {},
 		}
-		d := c.createBackendMappingData("default/app", source, map[string]string{}, ann, []string{})
+		if test.waf != "" {
+			ann["/"][ingtypes.BackWAF] = test.waf
+		}
+		if test.wafmode != "" {
+			ann["/"][ingtypes.BackWAFMode] = test.wafmode
+		}
+		expected = []*hatypes.BackendConfigWAF{
+			{
+				Paths: createBackendPaths("/"),
+				Config: hatypes.WAF{
+					Module: test.expected,
+					Mode:   test.expectedmode,
+				},
+			},
+		}
+		d := c.createBackendMappingData("default/app", source, map[string]string{ingtypes.BackWAFMode: "deny"}, ann, []string{})
 		c.createUpdater().buildBackendWAF(d)
 		c.compareObjects("WAF", i, d.backend.WAF, expected)
 		c.logger.CompareLogging(test.logging)

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -58,6 +58,7 @@ func createDefaults() map[string]string {
 		types.BackTimeoutServer:          "50s",
 		types.BackTimeoutServerFin:       "50s",
 		types.BackTimeoutTunnel:          "1h",
+		types.BackWAFMode:                "deny",
 		//
 		types.GlobalBindIPAddrHealthz:            "*",
 		types.GlobalBindIPAddrHTTP:               "*",

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -120,5 +120,6 @@ const (
 	BackTimeoutTunnel          = "timeout-tunnel"
 	BackUseResolver            = "use-resolver"
 	BackWAF                    = "waf"
+	BackWAFMode                = "waf-mode"
 	BackWhitelistSourceRange   = "whitelist-source-range"
 )

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2229,7 +2229,7 @@ func TestModSecurity(t *testing.T) {
 		},
 		{
 			waf:       "modsecurity",
-			wafmode:   "On",
+			wafmode:   "deny",
 			endpoints: []string{"10.0.0.101:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
@@ -2239,7 +2239,7 @@ func TestModSecurity(t *testing.T) {
 		},
 		{
 			waf:       "modsecurity",
-			wafmode:   "DetectOnly",
+			wafmode:   "detect",
 			endpoints: []string{"10.0.0.101:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf`,
@@ -2248,7 +2248,7 @@ func TestModSecurity(t *testing.T) {
 		},
 		{
 			waf:       "modsecurity",
-			wafmode:   "On",
+			wafmode:   "deny",
 			endpoints: []string{"10.0.0.101:12345", "10.0.0.102:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
@@ -2259,7 +2259,7 @@ func TestModSecurity(t *testing.T) {
 		},
 		{
 			waf:       "modsecurity",
-			wafmode:   "On",
+			wafmode:   "deny",
 			endpoints: []string{"10.0.0.101:12345"},
 			path:      "/sub",
 			backendExp: `

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2206,6 +2206,7 @@ frontend healthz
 func TestModSecurity(t *testing.T) {
 	testCases := []struct {
 		waf        string
+		wafmode    string
 		path       string
 		endpoints  []string
 		backendExp string
@@ -2213,12 +2214,14 @@ func TestModSecurity(t *testing.T) {
 	}{
 		{
 			waf:        "modsecurity",
+			wafmode:    "On",
 			endpoints:  []string{},
 			backendExp: ``,
 			modsecExp:  ``,
 		},
 		{
 			waf:        "",
+			wafmode:    "",
 			endpoints:  []string{"10.0.0.101:12345"},
 			backendExp: ``,
 			modsecExp: `
@@ -2226,6 +2229,7 @@ func TestModSecurity(t *testing.T) {
 		},
 		{
 			waf:       "modsecurity",
+			wafmode:   "On",
 			endpoints: []string{"10.0.0.101:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
@@ -2235,6 +2239,16 @@ func TestModSecurity(t *testing.T) {
 		},
 		{
 			waf:       "modsecurity",
+			wafmode:   "DetectOnly",
+			endpoints: []string{"10.0.0.101:12345"},
+			backendExp: `
+    filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf`,
+			modsecExp: `
+    server modsec-spoa0 10.0.0.101:12345`,
+		},
+		{
+			waf:       "modsecurity",
+			wafmode:   "On",
 			endpoints: []string{"10.0.0.101:12345", "10.0.0.102:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
@@ -2245,6 +2259,7 @@ func TestModSecurity(t *testing.T) {
 		},
 		{
 			waf:       "modsecurity",
+			wafmode:   "On",
 			endpoints: []string{"10.0.0.101:12345"},
 			path:      "/sub",
 			backendExp: `
@@ -2270,15 +2285,18 @@ func TestModSecurity(t *testing.T) {
 			test.path = "/"
 		}
 		h.AddPath(b, test.path)
-		b.WAF = []*hatypes.BackendConfigStr{
+		b.WAF = []*hatypes.BackendConfigWAF{
 			{
-				Paths:  hatypes.NewBackendPaths(b.FindHostPath("d1.local" + test.path)),
-				Config: test.waf,
+				Paths: hatypes.NewBackendPaths(b.FindHostPath("d1.local" + test.path)),
+				Config: hatypes.WAF{
+					Module: test.waf,
+					Mode:   test.wafmode,
+				},
 			},
 		}
 		if test.path != "/" {
 			h.AddPath(b, "/")
-			b.WAF = append(b.WAF, &hatypes.BackendConfigStr{
+			b.WAF = append(b.WAF, &hatypes.BackendConfigWAF{
 				Paths: hatypes.NewBackendPaths(b.FindHostPath("d1.local/")),
 			})
 		}

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -149,10 +149,10 @@ func (b *Backend) HasCorsEnabled() bool {
 	return false
 }
 
-// HasModsec ...
+// HasModsec is a method to verify if a Backend has ModSecurity Enabled
 func (b *Backend) HasModsec() bool {
 	for _, waf := range b.WAF {
-		if waf.Config == "modsecurity" {
+		if waf.Config.Module == "modsecurity" {
 			return true
 		}
 	}

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -286,3 +286,8 @@ func (b *BackendConfigHSTS) String() string {
 func (b *BackendConfigWhitelist) String() string {
 	return fmt.Sprintf("%+v", *b)
 }
+
+// String ...
+func (b *BackendConfigWAF) String() string {
+	return fmt.Sprintf("%+v", *b)
+}

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -393,7 +393,7 @@ type Backend struct {
 	MaxBodySize   []*BackendConfigInt
 	RewriteURL    []*BackendConfigStr
 	SSLRedirect   []*BackendConfigBool
-	WAF           []*BackendConfigStr
+	WAF           []*BackendConfigWAF
 	WhitelistHTTP []*BackendConfigWhitelist
 }
 
@@ -457,6 +457,12 @@ type BackendConfigAuth struct {
 type BackendConfigCors struct {
 	Paths  BackendPaths
 	Config Cors
+}
+
+// BackendConfigWAF defines Web Application Firewall Configurations
+type BackendConfigWAF struct {
+	Paths  BackendPaths
+	Config WAF
 }
 
 // BackendConfigHSTS ...
@@ -578,6 +584,14 @@ type HSTS struct {
 	MaxAge     int
 	Subdomains bool
 	Preload    bool
+}
+
+// WAF Defines the WAF Config structure for the Backend
+type WAF struct {
+	// Mode defines On or DetectionOnly
+	Mode string
+	// Which WAF Module should be used
+	Module string
 }
 
 // Userlist ...

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -354,7 +354,7 @@ backend {{ $backend.ID }}
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
 {{- $needACL := gt (len $backend.WAF) 1 }}
 {{- range $waf := $backend.WAF }}
-{{- if eq $waf.Config "modsecurity" }}
+{{- if eq $waf.Config.Mode "On" }}
     http-request deny if { var(txn.modsec.code) -m int gt 0 }
     {{- if $needACL }} { var(txn.pathID) {{ $waf.Paths.IDList }} }{{ end }}
 {{- end }}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -354,9 +354,9 @@ backend {{ $backend.ID }}
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
 {{- $needACL := gt (len $backend.WAF) 1 }}
 {{- range $waf := $backend.WAF }}
-{{- if eq $waf.Config.Mode "On" }}
+{{- if eq $waf.Config.Mode "deny" }}
     http-request deny if { var(txn.modsec.code) -m int gt 0 }
-    {{- if $needACL }} { var(txn.pathID) {{ $waf.Paths.IDList }} }{{ end }}
+        {{- if $needACL }} { var(txn.pathID) {{ $waf.Paths.IDList }} }{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@serpro.gov.br>

This PR adds support for a DetectionOnly mode in Mod Security for each backend.

The idea here is when specifying the annotation 'waf-mode: "DetectionOnly"' it will send the requests to the ModSecurity filter to generate the appropriate logging, but no action will be taken.

To keep the compability with following versions, the behavior here is: if there's a ``waf`` annotation and no ``waf-mode`` annotation, it will block bad requests.

To enable DetectionOnly mode user must create the ``waf-mode`` annotation with DetectionOnly as its value