### PR TITLE
Add initial-weight config key

### DIFF
--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -335,7 +335,7 @@ func TestBlueGreen(t *testing.T) {
 			for _, targetRef := range strings.Split(targets, ",") {
 				targetWeight := strings.Split(targetRef, "=")
 				target := targetRef
-				weight := 1
+				weight := 100
 				if len(targetWeight) == 2 {
 					target = targetWeight[0]
 					if w, err := strconv.ParseInt(targetWeight[1], 10, 0); err == nil {
@@ -379,35 +379,35 @@ func TestBlueGreen(t *testing.T) {
 		{
 			ann:        buildAnn("", ""),
 			endpoints:  buildEndpoints("pod0101-01"),
-			expWeights: []int{1},
+			expWeights: []int{100},
 			expLogging: "",
 		},
 		// 1
 		{
 			ann:        buildAnn("", "err"),
 			endpoints:  buildEndpoints("pod0101-01"),
-			expWeights: []int{1},
+			expWeights: []int{100},
 			expLogging: "",
 		},
 		// 2
 		{
 			ann:        buildAnn("err", ""),
 			endpoints:  buildEndpoints("pod0101-01"),
-			expWeights: []int{1},
+			expWeights: []int{100},
 			expLogging: "ERROR blue/green config on ingress 'default/ing1' has an invalid weight format: err",
 		},
 		// 3
 		{
 			ann:        buildAnn("v=1=xx", ""),
 			endpoints:  buildEndpoints("pod0101-01"),
-			expWeights: []int{1},
+			expWeights: []int{100},
 			expLogging: "ERROR blue/green config on ingress 'default/ing1' has an invalid weight value: strconv.ParseInt: parsing \"xx\": invalid syntax",
 		},
 		// 4
 		{
 			ann:        buildAnn("v=1=1.5", ""),
 			endpoints:  buildEndpoints("pod0101-01"),
-			expWeights: []int{1},
+			expWeights: []int{100},
 			expLogging: "ERROR blue/green config on ingress 'default/ing1' has an invalid weight value: strconv.ParseInt: parsing \"1.5\": invalid syntax",
 		},
 		// 5
@@ -421,49 +421,49 @@ func TestBlueGreen(t *testing.T) {
 		{
 			ann:        buildAnn("v=1=260", ""),
 			endpoints:  buildEndpoints("pod0101-01"),
-			expWeights: []int{1},
+			expWeights: []int{100},
 			expLogging: "WARN invalid weight '260' on ingress 'default/ing1', using '256' instead",
 		},
 		// 7
 		{
 			ann:        buildAnn("v=1=10", "err"),
 			endpoints:  buildEndpoints("pod0101-01"),
-			expWeights: []int{1},
+			expWeights: []int{100},
 			expLogging: "WARN unsupported blue/green mode 'err' on ingress 'default/ing1', falling back to 'deploy'",
 		},
 		// 8
 		{
 			ann:        buildAnn("v=1=10", ""),
 			endpoints:  buildEndpoints("pod0101-01"),
-			expWeights: []int{1},
+			expWeights: []int{100},
 			expLogging: "",
 		},
 		// 9
 		{
 			ann:        buildAnn("", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01"),
-			expWeights: []int{1, 1},
+			expWeights: []int{100, 100},
 			expLogging: "",
 		},
 		// 10
 		{
 			ann:        buildAnn("v=1=50,v=2=50", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01"),
-			expWeights: []int{1, 1},
+			expWeights: []int{100, 100},
 			expLogging: "",
 		},
 		// 11
 		{
 			ann:        buildAnn("v=1=50,v=2=25", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01"),
-			expWeights: []int{2, 1},
+			expWeights: []int{200, 100},
 			expLogging: "",
 		},
 		// 12
 		{
 			ann:        buildAnn("v=1=50,v=2=25", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01,pod0102-02"),
-			expWeights: []int{4, 1, 1},
+			expWeights: []int{256, 64, 64},
 			expLogging: "",
 		},
 		// 13
@@ -477,21 +477,21 @@ func TestBlueGreen(t *testing.T) {
 		{
 			ann:        buildAnn("v=1=50,v=2=25", ""),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01,pod0102-02"),
-			expWeights: []int{4, 1, 1},
+			expWeights: []int{256, 64, 64},
 			expLogging: "",
 		},
 		// 15
 		{
 			ann:        buildAnn("v=1=500,v=2=2", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01"),
-			expWeights: []int{128, 1},
+			expWeights: []int{256, 2},
 			expLogging: "WARN invalid weight '500' on ingress 'default/ing1', using '256' instead",
 		},
 		// 16
 		{
 			ann:        buildAnn("v=1=60,v=2=3", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01,pod0102-02,pod0102-03,pod0102-04"),
-			expWeights: []int{80, 1, 1, 1, 1},
+			expWeights: []int{256, 3, 3, 3, 3},
 			expLogging: "",
 		},
 		// 17
@@ -505,7 +505,7 @@ func TestBlueGreen(t *testing.T) {
 		{
 			ann:        buildAnn("v=1=50,v=2=25", "deploy"),
 			endpoints:  buildEndpoints(",pod0102-01"),
-			expWeights: []int{0, 1},
+			expWeights: []int{0, 100},
 			expLogging: `
 WARN endpoint '172.17.0.11:8080' on ingress 'default/ing1' was removed from balance: endpoint does not reference a pod
 INFO-V(3) blue/green balance label 'v=1' on ingress 'default/ing1' does not reference any endpoint`,
@@ -514,7 +514,7 @@ INFO-V(3) blue/green balance label 'v=1' on ingress 'default/ing1' does not refe
 		{
 			ann:        buildAnn("v=1=50,v=non=25", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01"),
-			expWeights: []int{1, 0},
+			expWeights: []int{100, 0},
 			expLogging: "INFO-V(3) blue/green balance label 'v=non' on ingress 'default/ing1' does not reference any endpoint",
 		},
 		// 20
@@ -528,14 +528,14 @@ INFO-V(3) blue/green balance label 'v=1' on ingress 'default/ing1' does not refe
 		{
 			ann:        buildAnn("v=1=50,non=2=25", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01"),
-			expWeights: []int{1, 0},
+			expWeights: []int{100, 0},
 			expLogging: "INFO-V(3) blue/green balance label 'non=2' on ingress 'default/ing1' does not reference any endpoint",
 		},
 		// 22
 		{
 			ann:        buildAnn("v=1=50,v=2=25", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-non"),
-			expWeights: []int{1, 0},
+			expWeights: []int{100, 0},
 			expLogging: `
 WARN endpoint '172.17.0.11:8080' on ingress 'default/ing1' was removed from balance: pod not found: 'pod0102-non'
 INFO-V(3) blue/green balance label 'v=2' on ingress 'default/ing1' does not reference any endpoint`,
@@ -553,14 +553,14 @@ INFO-V(3) blue/green balance label 'v=2' on ingress 'default/ing1' does not refe
 		{
 			ann:        buildAnn("v=1=50,v=2=25,v=3=25", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01,pod0102-02,pod0103-01"),
-			expWeights: []int{4, 1, 1, 2},
+			expWeights: []int{256, 64, 64, 128},
 			expLogging: "",
 		},
 		// 25
 		{
 			ann:        buildAnn("v=1=50,v=2=0,v=3=25", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0102-01,pod0102-02,pod0103-01"),
-			expWeights: []int{2, 0, 0, 1},
+			expWeights: []int{200, 0, 0, 100},
 			expLogging: "",
 		},
 		// 26
@@ -591,7 +591,7 @@ INFO-V(3) blue/green balance label 'v=3' on ingress 'default/ing1' does not refe
 		{
 			ann:        buildAnn("v=1=50,v=2=50", "deploy"),
 			endpoints:  buildEndpoints("pod0101-01,pod0101-02,pod0102-01,pod0102-02=0"),
-			expWeights: []int{1, 1, 2, 0},
+			expWeights: []int{100, 100, 200, 0},
 			expLogging: "",
 		},
 		//
@@ -684,7 +684,7 @@ INFO-V(3) blue/green balance label 'v=3' on ingress 'default/ing1' does not refe
 	for i, test := range testCase {
 		c := setup(t)
 		c.cache.PodList = pods
-		d := c.createBackendData("default/app", source, test.ann, map[string]string{})
+		d := c.createBackendData("default/app", source, test.ann, map[string]string{ingtypes.BackInitialWeight: "100"})
 		d.backend.Endpoints = test.endpoints
 		u := c.createUpdater()
 		u.buildBackendBlueGreenBalance(d)

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -46,6 +46,7 @@ func createDefaults() map[string]string {
 		types.BackHSTSIncludeSubdomains:  "false",
 		types.BackHSTSMaxAge:             "15768000",
 		types.BackHSTSPreload:            "false",
+		types.BackInitialWeight:          "1",
 		types.BackSessionCookieDynamic:   "true",
 		types.BackSSLRedirect:            "true",
 		types.BackSSLCipherSuitesBackend: defaultSSLCipherSuites,

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -232,6 +232,7 @@ func (c *converter) addBackend(source *annotations.Source, hostpath, fullSvcName
 			Type:      "service",
 		}, hostpath, ann)
 		c.backendAnnotations[backend] = mapper
+		backend.Server.InitialWeight = mapper.Get(ingtypes.BackInitialWeight).Int()
 	}
 	// Merging Ingress annotations
 	conflict := mapper.AddAnnotations(source, hostpath, ann)

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -1153,7 +1153,9 @@ var defaultBackendConfig = `
 
 func (c *testConfig) SyncDef(config map[string]string, ing ...*extensions.Ingress) {
 	defaultConfig := func() map[string]string {
-		return map[string]string{}
+		return map[string]string{
+			ingtypes.BackInitialWeight: "100",
+		}
 	}
 	conv := NewIngressConverter(
 		&ingtypes.ConverterOptions{

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -87,6 +87,7 @@ const (
 	BackHSTSIncludeSubdomains  = "hsts-include-subdomains"
 	BackHSTSMaxAge             = "hsts-max-age"
 	BackHSTSPreload            = "hsts-preload"
+	BackInitialWeight          = "initial-weight"
 	BackLimitConnections       = "limit-connections"
 	BackLimitRPS               = "limit-rps"
 	BackLimitWhitelist         = "limit-whitelist"

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -169,6 +169,7 @@ func createBackend(namespace, name, port string) *hatypes.Backend {
 		Namespace: namespace,
 		Name:      name,
 		Port:      port,
+		Server:    hatypes.ServerConfig{InitialWeight: 1},
 		Endpoints: []*hatypes.Endpoint{},
 	}
 }

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -87,12 +87,12 @@ func TestDynUpdate(t *testing.T) {
 			expected: []string{
 				"srv001:172.17.0.2:8080:1",
 				"srv002:172.17.0.3:8080:1",
-				"srv003:127.0.0.1:1023:0",
-				"srv004:127.0.0.1:1023:0",
-				"srv005:127.0.0.1:1023:0",
-				"srv006:127.0.0.1:1023:0",
-				"srv007:127.0.0.1:1023:0",
-				"srv008:127.0.0.1:1023:0",
+				"srv003:127.0.0.1:1023:1",
+				"srv004:127.0.0.1:1023:1",
+				"srv005:127.0.0.1:1023:1",
+				"srv006:127.0.0.1:1023:1",
+				"srv007:127.0.0.1:1023:1",
+				"srv008:127.0.0.1:1023:1",
 			},
 			dynamic: false,
 			logging: `INFO-V(2) added endpoints on backend 'default_app_8080'`,
@@ -110,7 +110,7 @@ func TestDynUpdate(t *testing.T) {
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
 			},
 			expected: []string{
-				"srv001:127.0.0.1:1023:0",
+				"srv001:127.0.0.1:1023:1",
 				"srv002:172.17.0.3:8080:1",
 			},
 			dynamic: true,
@@ -214,14 +214,14 @@ set server default_app_8080/srv001 weight 1
 				b.AcquireEndpoint("172.17.0.7", 8080, "")
 			},
 			expected: []string{
-				"srv001:127.0.0.1:1023:0",
-				"srv002:127.0.0.1:1023:0",
-				"srv003:127.0.0.1:1023:0",
+				"srv001:127.0.0.1:1023:1",
+				"srv002:127.0.0.1:1023:1",
+				"srv003:127.0.0.1:1023:1",
 				"srv004:172.17.0.5:8080:1",
-				"srv005:127.0.0.1:1023:0",
+				"srv005:127.0.0.1:1023:1",
 				"srv006:172.17.0.7:8080:1",
-				"srv007:127.0.0.1:1023:0",
-				"srv008:127.0.0.1:1023:0",
+				"srv007:127.0.0.1:1023:1",
+				"srv008:127.0.0.1:1023:1",
 			},
 			dynamic: true,
 			cmd: `
@@ -265,9 +265,9 @@ INFO-V(2) disabled endpoint '172.17.0.9:8080' on backend/server 'default_app_808
 				c.config.AcquireBackend("default", "app", "8080").Dynamic.DynUpdate = true
 			},
 			expected: []string{
-				"srv001:127.0.0.1:1023:0",
-				"srv002:127.0.0.1:1023:0",
-				"srv003:127.0.0.1:1023:0",
+				"srv001:127.0.0.1:1023:1",
+				"srv002:127.0.0.1:1023:1",
+				"srv003:127.0.0.1:1023:1",
 			},
 			dynamic: true,
 			cmd: `
@@ -306,10 +306,10 @@ INFO-V(2) disabled endpoint '172.17.0.4:8080' on backend/server 'default_app_808
 				"srv001:172.17.0.2:8080:1",
 				"srv002:172.17.0.3:8080:1",
 				"srv003:172.17.0.4:8080:1",
-				"srv004:127.0.0.1:1023:0",
-				"srv005:127.0.0.1:1023:0",
-				"srv006:127.0.0.1:1023:0",
-				"srv007:127.0.0.1:1023:0",
+				"srv004:127.0.0.1:1023:1",
+				"srv005:127.0.0.1:1023:1",
+				"srv006:127.0.0.1:1023:1",
+				"srv007:127.0.0.1:1023:1",
 			},
 			dynamic: false,
 			logging: `INFO-V(2) added endpoints on backend 'default_app_8080'`,
@@ -332,7 +332,7 @@ INFO-V(2) disabled endpoint '172.17.0.4:8080' on backend/server 'default_app_808
 			expected: []string{
 				"srv001:172.17.0.2:8080:1",
 				"srv002:172.17.0.3:8080:1",
-				"srv003:127.0.0.1:1023:0",
+				"srv003:127.0.0.1:1023:1",
 			},
 			dynamic: true,
 			cmd: `
@@ -374,7 +374,7 @@ set server default_app_8080/srv002 weight 1
 				c.config.AcquireBackend("default", "app", "8080").Dynamic.DynUpdate = true
 			},
 			expected: []string{
-				"srv001:127.0.0.1:1023:0",
+				"srv001:127.0.0.1:1023:1",
 			},
 			dynamic: false,
 			cmd:     ``,
@@ -388,10 +388,10 @@ set server default_app_8080/srv002 weight 1
 				b.Dynamic.BlockSize = 4
 			},
 			expected: []string{
-				"srv001:127.0.0.1:1023:0",
-				"srv002:127.0.0.1:1023:0",
-				"srv003:127.0.0.1:1023:0",
-				"srv004:127.0.0.1:1023:0",
+				"srv001:127.0.0.1:1023:1",
+				"srv002:127.0.0.1:1023:1",
+				"srv003:127.0.0.1:1023:1",
+				"srv004:127.0.0.1:1023:1",
 			},
 			dynamic: false,
 			cmd:     ``,
@@ -454,7 +454,7 @@ set server default_app_8080/srv002 weight 1`,
 			},
 			expected: []string{
 				"srv001:172.17.0.2:8080:1",
-				"srv002:127.0.0.1:1023:0",
+				"srv002:127.0.0.1:1023:1",
 			},
 			dynamic: false,
 		},

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1995,10 +1995,10 @@ resolvers k8s
     timeout retry         2s
 backend d1_app_8080
     mode http
-    server-template srv 2 app.d1.svc.cluster.local:8080 resolvers k8s resolve-prefer ipv4 init-addr none
+    server-template srv 2 app.d1.svc.cluster.local:8080 resolvers k8s resolve-prefer ipv4 init-addr none weight 1
 backend d2_app_http
     mode http
-    server-template srv 2 _http._tcp.app.d2.svc.cluster.local resolvers k8s resolve-prefer ipv4 init-addr none
+    server-template srv 2 _http._tcp.app.d2.svc.cluster.local resolvers k8s resolve-prefer ipv4 init-addr none weight 1
 <<backends-default>>
 <<frontends-default>>
 <<support>>

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -52,7 +52,6 @@ func (b *Backend) AcquireEndpoint(ip string, port int, targetRef string) *Endpoi
 func (b *Backend) AddEmptyEndpoint() *Endpoint {
 	endpoint := b.addEndpoint("127.0.0.1", 1023, "")
 	endpoint.Enabled = false
-	endpoint.Weight = 0
 	return endpoint
 }
 
@@ -64,7 +63,7 @@ func (b *Backend) addEndpoint(ip string, port int, targetRef string) *Endpoint {
 		Target:    fmt.Sprintf("%s:%d", ip, port),
 		Enabled:   true,
 		TargetRef: targetRef,
-		Weight:    1,
+		Weight:    b.Server.InitialWeight,
 	}
 	b.Endpoints = append(b.Endpoints, endpoint)
 	return endpoint

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -513,20 +513,21 @@ type OAuthConfig struct {
 
 // ServerConfig ...
 type ServerConfig struct {
-	CAFilename   string
-	CAHash       string
-	Ciphers      string // TLS up to 1.2
-	CipherSuites string // TLS 1.3
-	CRLFilename  string
-	CRLHash      string
-	CrtFilename  string
-	CrtHash      string
-	MaxConn      int
-	MaxQueue     int
-	Options      string
-	Protocol     string
-	Secure       bool
-	SendProxy    string
+	CAFilename    string
+	CAHash        string
+	Ciphers       string // TLS up to 1.2
+	CipherSuites  string // TLS 1.3
+	CRLFilename   string
+	CRLHash       string
+	CrtFilename   string
+	CrtHash       string
+	InitialWeight int
+	MaxConn       int
+	MaxQueue      int
+	Options       string
+	Protocol      string
+	Secure        bool
+	SendProxy     string
 }
 
 // BackendTimeoutConfig ...

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -495,6 +495,7 @@ backend {{ $backend.ID }}
         {{- $backend.Name }}.{{ $backend.Namespace }}.svc.{{ $global.DNS.ClusterDomain }}
         {{- if $portIsNumber }}:{{ $backend.Port }}{{ end }}
         {{- "" }} resolvers {{ $backend.Resolver }} resolve-prefer ipv4 init-addr none
+        {{- "" }} weight {{ $backend.Server.InitialWeight }}
         {{- template "backend" map $backend }}
 {{- else }}
 {{- /* Iterate twice because header takes precedence */}}


### PR DESCRIPTION
The `initial-weight` configuration key defines the static weight configuration of each backend server, which will define the initial weight configuration. The initial weight configuration is used on agent-check: an agent can change the weight of a server defining a percentage value of the initial weight.

Without this option, servers always start with weight 1 (one) and empty slots start with weight 0 (zero). If trying to update the weight via agent, in the former, the weight cannot be downgraded without removing the server from the balance, and the upgrade is always at least duplicating the weight. In the latter the weight cannot be changed. Iow weight via agent cannot be used.

Should be back ported to v0.8.

Related with #442 