### PR TITLE
add ip+port bind support for http/https/fronting-proxy

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -104,6 +104,9 @@ The table below describes all supported configuration keys.
 | [`backend-protocol`](#backend-protocol)              | [h1\|h2\|h1-ssl\|h2-ssl]                | Backend |                    |
 | [`backend-server-slots-increment`](#dynamic-scaling) | number of slots                         | Backend | `32`               |
 | [`balance-algorithm`](#balance-algorithm)            | algorithm name                          | Backend | `roundrobin`       |
+| [`bind-fronting-proxy`](#bind)                       | ip + port                               | Global  |                    |
+| [`bind-http`](#bind)                                 | ip + port                               | Global  |                    |
+| [`bind-https`](#bind)                                | ip + port                               | Global  |                    |
 | [`bind-ip-addr-healthz`](#bind-ip-addr)              | IP address                              | Global  | `*`                |
 | [`bind-ip-addr-http`](#bind-ip-addr)                 | IP address                              | Global  | `*`                |
 | [`bind-ip-addr-stats`](#bind-ip-addr)                | IP address                              | Global  | `*`                |
@@ -381,6 +384,49 @@ See also:
 
 ---
 
+## Bind
+
+| Configuration key      | Scope    | Default | Since |
+|------------------------|----------|---------|-------|
+| `bind-fronting-proxy`  | `Global` |         | v0.8  |
+| `bind-http`            | `Global` |         | v0.8  |
+| `bind-https`           | `Global` |         | v0.8  |
+
+Configures listening IP and port for HTTP/s incoming requests. These
+configuration keys have backward compatibility with [Bind IP addr](#bind-ip-addr),
+[Bind port](#bind-port) and [Fronting proxy](#fronting-proxy-port) keys.
+The bind configuration keys in this section have precedente if declared.
+
+Any HAProxy supported option can be used, this will be copied verbatim to the
+bind keyword. See HAProxy
+[bind keyword doc](#http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-bind).
+
+Configuration examples:
+
+* `bind-http: ":::80"` and `bind-https: ":::443"`: Listen all IPv6 addresses
+* `bind-http: ":80,:::80"` and `bind-https:  ":443,:::443"`: Listen all IPv4 and IPv6 addresses
+* `bind-https: ":443,:8443"`: accept https connections on `443` and also `8443` port numbers
+
+{{% alert title="Note" %}}
+`bind-fronting-proxy` and `bind-http` can share the same port number, provided
+that the whole configuration key match, not only the port number.
+See [Fronting proxy](#fronting-proxy-port) doc.
+{{% /alert %}}
+
+{{% alert title="Warning" color="warning" %}}
+Special care should be taken on port number overlap, nether haproxy itself nor
+haproxy-ingress will warn if the same port number is used in more than one
+configuration key.
+{{% /alert %}}
+
+See also:
+
+* http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-bind
+* [Bind IP addr](#bind-ip-addr)
+* [Bind port](#bind-port)
+
+---
+
 ## Bind IP addr
 
 | Configuration key      | Scope    | Default | Since |
@@ -400,6 +446,7 @@ Define listening IPv4/IPv6 address on public HAProxy frontends.
 See also:
 
 * http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-bind
+* [Bind](#bind)
 
 ---
 
@@ -418,6 +465,7 @@ See also:
 See also:
 
 * http://cbonte.github.io/haproxy-dconv/1.9/configuration.html#4-monitor-uri (`healthz-port`)
+* [Bind](#bind)
 
 ---
 
@@ -760,6 +808,10 @@ the fronting proxy should connect to the same port number defined in
 between the load balancer and HAProxy which changes the connecting port number.
 This limitation doesn't exist on v0.8 or above.
 {{% /alert %}}
+
+See also:
+
+* [Bind](#bind)
 
 ---
 

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -28,11 +28,21 @@ import (
 
 func (c *updater) buildGlobalBind(d *globalData) {
 	d.global.Bind.AcceptProxy = d.mapper.Get(ingtypes.GlobalUseProxyProtocol).Bool()
-	d.global.Bind.HTTPBindIP = d.mapper.Get(ingtypes.GlobalBindIPAddrHTTP).Value
-	d.global.Bind.HTTPSBindIP = d.global.Bind.HTTPBindIP
 	d.global.Bind.TCPBindIP = d.mapper.Get(ingtypes.GlobalBindIPAddrTCP).Value
-	d.global.Bind.HTTPPort = d.mapper.Get(ingtypes.GlobalHTTPPort).Int()
-	d.global.Bind.HTTPSPort = d.mapper.Get(ingtypes.GlobalHTTPSPort).Int()
+	if bindHTTP := d.mapper.Get(ingtypes.GlobalBindHTTP).Value; bindHTTP != "" {
+		d.global.Bind.HTTPBind = bindHTTP
+	} else {
+		ip := d.mapper.Get(ingtypes.GlobalBindIPAddrHTTP).Value
+		port := d.mapper.Get(ingtypes.GlobalHTTPPort).Int()
+		d.global.Bind.HTTPBind = fmt.Sprintf("%s:%d", ip, port)
+	}
+	if bindHTTPS := d.mapper.Get(ingtypes.GlobalBindHTTPS).Value; bindHTTPS != "" {
+		d.global.Bind.HTTPSBind = bindHTTPS
+	} else {
+		ip := d.mapper.Get(ingtypes.GlobalBindIPAddrHTTP).Value
+		port := d.mapper.Get(ingtypes.GlobalHTTPSPort).Int()
+		d.global.Bind.HTTPSBind = fmt.Sprintf("%s:%d", ip, port)
+	}
 }
 
 func (c *updater) buildGlobalProc(d *globalData) {
@@ -156,20 +166,23 @@ func (c *updater) buildGlobalHealthz(d *globalData) {
 }
 
 func (c *updater) buildGlobalHTTPStoHTTP(d *globalData) {
-	port := d.mapper.Get(ingtypes.GlobalFrontingProxyPort).Int()
-	if port == 0 {
-		port = d.mapper.Get(ingtypes.GlobalHTTPStoHTTPPort).Int()
-	}
-	if port == 0 {
-		return
+	bind := d.mapper.Get(ingtypes.GlobalBindFrontingProxy).Value
+	if bind == "" {
+		port := d.mapper.Get(ingtypes.GlobalFrontingProxyPort).Int()
+		if port == 0 {
+			port = d.mapper.Get(ingtypes.GlobalHTTPStoHTTPPort).Int()
+		}
+		if port == 0 {
+			return
+		}
+		bind = fmt.Sprintf("%s:%d", d.mapper.Get(ingtypes.GlobalBindIPAddrHTTP).Value, port)
 	}
 	// TODO Change all `ToHTTP` naming to `FrontingProxy`
-	d.global.Bind.ToHTTPBindIP = d.mapper.Get(ingtypes.GlobalBindIPAddrHTTP).Value
-	d.global.Bind.ToHTTPPort = port
+	d.global.Bind.FrontingBind = bind
 	// Socket ID should be a high number to avoid colision
 	// between the same socket ID from distinct frontends
 	// TODO match socket and frontend ID in the backend
-	d.global.Bind.ToHTTPSocketID = 10011
+	d.global.Bind.FrontingSockID = 10011
 }
 
 func (c *updater) buildGlobalModSecurity(d *globalData) {

--- a/pkg/converters/ingress/annotations/global_test.go
+++ b/pkg/converters/ingress/annotations/global_test.go
@@ -23,6 +23,75 @@ import (
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 )
 
+func TestBind(t *testing.T) {
+	testCases := []struct {
+		ann      map[string]string
+		expected hatypes.GlobalBindConfig
+	}{
+		// 0
+		{
+			ann: map[string]string{},
+			expected: hatypes.GlobalBindConfig{
+				HTTPBind:  "*:80",
+				HTTPSBind: "*:443",
+			},
+		},
+		// 1
+		{
+			ann: map[string]string{
+				ingtypes.GlobalBindHTTP: ":80,:8080",
+			},
+			expected: hatypes.GlobalBindConfig{
+				HTTPBind:  ":80,:8080",
+				HTTPSBind: "*:443",
+			},
+		},
+		// 2
+		{
+			ann: map[string]string{
+				ingtypes.GlobalBindHTTPS: ":443,:8443",
+			},
+			expected: hatypes.GlobalBindConfig{
+				HTTPBind:  "*:80",
+				HTTPSBind: ":443,:8443",
+			},
+		},
+		// 3
+		{
+			ann: map[string]string{
+				ingtypes.GlobalBindIPAddrHTTP: "127.0.0.1",
+			},
+			expected: hatypes.GlobalBindConfig{
+				HTTPBind:  "127.0.0.1:80",
+				HTTPSBind: "127.0.0.1:443",
+			},
+		},
+		// 4
+		{
+			ann: map[string]string{
+				ingtypes.GlobalHTTPPort:  "8080",
+				ingtypes.GlobalHTTPSPort: "8443",
+			},
+			expected: hatypes.GlobalBindConfig{
+				HTTPBind:  "*:8080",
+				HTTPSBind: "*:8443",
+			},
+		},
+	}
+	for i, test := range testCases {
+		c := setup(t)
+		d := c.createGlobalData(map[string]string{
+			ingtypes.GlobalHTTPPort:       "80",
+			ingtypes.GlobalHTTPSPort:      "443",
+			ingtypes.GlobalBindIPAddrHTTP: "*",
+		})
+		d.mapper.AddAnnotations(nil, "-", test.ann)
+		c.createUpdater().buildGlobalBind(d)
+		c.compareObjects("bind", i, d.global.Bind, test.expected)
+		c.teardown()
+	}
+}
+
 func TestModSecurity(t *testing.T) {
 	testCases := []struct {
 		endpoints string
@@ -203,6 +272,61 @@ func TestForwardFor(t *testing.T) {
 		c.createUpdater().buildGlobalForwardFor(d)
 		c.compareObjects("forward-for", i, d.global.ForwardFor, test.expected)
 		c.logger.CompareLogging(test.logging)
+		c.teardown()
+	}
+}
+
+func TestFrontingProxy(t *testing.T) {
+	testCases := []struct {
+		ann      map[string]string
+		expected hatypes.GlobalBindConfig
+	}{
+		// 0
+		{
+			ann: map[string]string{
+				ingtypes.GlobalHTTPStoHTTPPort: "8000",
+			},
+			expected: hatypes.GlobalBindConfig{
+				FrontingBind: ":8000",
+			},
+		},
+		// 1
+		{
+			ann: map[string]string{
+				ingtypes.GlobalFrontingProxyPort: "9000",
+			},
+			expected: hatypes.GlobalBindConfig{
+				FrontingBind: ":9000",
+			},
+		},
+		// 2
+		{
+			ann: map[string]string{
+				ingtypes.GlobalHTTPStoHTTPPort:   "9000",
+				ingtypes.GlobalBindFrontingProxy: ":7000",
+			},
+			expected: hatypes.GlobalBindConfig{
+				FrontingBind: ":7000",
+			},
+		},
+		// 3
+		{
+			ann: map[string]string{
+				ingtypes.GlobalFrontingProxyPort: "8000",
+				ingtypes.GlobalBindFrontingProxy: "127.0.0.1:7000",
+			},
+			expected: hatypes.GlobalBindConfig{
+				FrontingBind: "127.0.0.1:7000",
+			},
+		},
+	}
+	frontingSockID := 10011
+	for i, test := range testCases {
+		c := setup(t)
+		d := c.createGlobalData(test.ann)
+		c.createUpdater().buildGlobalHTTPStoHTTP(d)
+		test.expected.FrontingSockID = frontingSockID
+		c.compareObjects("fronting proxy", i, d.global.Bind, test.expected)
 		c.teardown()
 	}
 }

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -18,6 +18,9 @@ package types
 
 // Global config
 const (
+	GlobalBindFrontingProxy            = "bind-fronting-proxy"
+	GlobalBindHTTP                     = "bind-http"
+	GlobalBindHTTPS                    = "bind-https"
 	GlobalBindIPAddrHealthz            = "bind-ip-addr-healthz"
 	GlobalBindIPAddrHTTP               = "bind-ip-addr-http"
 	GlobalBindIPAddrStats              = "bind-ip-addr-stats"

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -237,8 +237,8 @@ func (c *config) BuildFrontendGroup() error {
 	}
 	if c.global.Bind.HasFrontingProxy() {
 		bind := hatypes.NewFrontendBind(nil)
-		bind.Socket = fmt.Sprintf("%s:%d", c.global.Bind.ToHTTPBindIP, c.global.Bind.ToHTTPPort)
-		bind.ID = c.global.Bind.ToHTTPSocketID
+		bind.Socket = c.global.Bind.FrontingBind
+		bind.ID = c.global.Bind.FrontingSockID
 		bind.AcceptProxy = c.global.Bind.AcceptProxy
 		fgroup.ToHTTPBind = bind
 	}
@@ -259,7 +259,7 @@ func (c *config) BuildFrontendGroup() error {
 		// One single HAProxy's frontend and bind
 		bind := &frontends[0].Bind
 		bind.Name = "_public"
-		bind.Socket = fmt.Sprintf("%s:%d", c.global.Bind.HTTPSBindIP, c.global.Bind.HTTPSPort)
+		bind.Socket = c.global.Bind.HTTPSBind
 		bind.AcceptProxy = c.global.Bind.AcceptProxy
 		bind.ALPN = c.global.SSL.ALPN
 	}

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -580,15 +580,12 @@ func TestInstanceGlobalBind(t *testing.T) {
 		expectedHTTPS string
 	}{
 		// 0
-		{
-			expectedHTTP:  "bind :0",
-			expectedHTTPS: "bind :0 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front001_bind_crt.list ca-ignore-err all crt-ignore-err all",
-		},
+		{},
 		// 1
 		{
 			bind: hatypes.GlobalBindConfig{
-				HTTPPort:    80,
-				HTTPSPort:   443,
+				HTTPBind:    ":80",
+				HTTPSBind:   ":443",
 				AcceptProxy: true,
 			},
 			expectedHTTP:  "bind :80 accept-proxy",
@@ -597,10 +594,8 @@ func TestInstanceGlobalBind(t *testing.T) {
 		// 2
 		{
 			bind: hatypes.GlobalBindConfig{
-				HTTPBindIP:  "127.0.0.1",
-				HTTPPort:    80,
-				HTTPSBindIP: "127.0.0.1",
-				HTTPSPort:   443,
+				HTTPBind:  "127.0.0.1:80",
+				HTTPSBind: "127.0.0.1:443",
 			},
 			expectedHTTP:  "bind 127.0.0.1:80",
 			expectedHTTPS: "bind 127.0.0.1:443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front001_bind_crt.list ca-ignore-err all crt-ignore-err all",
@@ -617,6 +612,12 @@ func TestInstanceGlobalBind(t *testing.T) {
 		h.AddPath(b, "/")
 
 		c.config.Global().Bind = test.bind
+		if test.expectedHTTP != "" {
+			test.expectedHTTP = "\n    " + test.expectedHTTP
+		}
+		if test.expectedHTTPS != "" {
+			test.expectedHTTPS = "\n    " + test.expectedHTTPS
+		}
 
 		c.Update()
 		c.checkConfig(`
@@ -627,8 +628,7 @@ backend d1_app_8080
     server s1 172.17.0.11:8080 weight 100
 <<backends-default>>
 frontend _front_http
-    mode http
-    ` + test.expectedHTTP + `
+    mode http` + test.expectedHTTP + `
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
     http-request redirect scheme https if { var(req.base),map_beg(/etc/haproxy/maps/_global_https_redir.map,_nomatch) yes }
     <<http-headers>>
@@ -636,8 +636,7 @@ frontend _front_http
     use_backend %[var(req.backend)] unless { var(req.backend) _nomatch }
     default_backend _error404
 frontend _front001
-    mode http
-    ` + test.expectedHTTPS + `
+    mode http` + test.expectedHTTPS + `
     http-request set-var(req.hostbackend) base,lower,regsub(:[0-9]+/,/),map_beg(/etc/haproxy/maps/_front001_host.map,_nomatch)
     <<https-headers>>
     use_backend %[var(req.hostbackend)] unless { var(req.hostbackend) _nomatch }
@@ -725,7 +724,7 @@ empty/ default_empty_8080`)
 
 func TestInstanceToHTTPSocket(t *testing.T) {
 	testCases := []struct {
-		toHTTPPort       int
+		toHTTPBind       string
 		domain           string
 		expectedFront    string
 		expectedMap      string
@@ -735,7 +734,7 @@ func TestInstanceToHTTPSocket(t *testing.T) {
 	}{
 		// 0
 		{
-			toHTTPPort: 8000,
+			toHTTPBind: ":8000",
 			domain:     "d1.local",
 			expectedFront: `
     mode http
@@ -769,7 +768,7 @@ func TestInstanceToHTTPSocket(t *testing.T) {
 		},
 		// 1
 		{
-			toHTTPPort: 8000,
+			toHTTPBind: ":8000",
 			domain:     "*.d1.local",
 			expectedFront: `
     mode http
@@ -811,7 +810,7 @@ func TestInstanceToHTTPSocket(t *testing.T) {
 		},
 		// 2
 		{
-			toHTTPPort: 80,
+			toHTTPBind: ":80",
 			domain:     "d1.local",
 			expectedFront: `
     mode http
@@ -866,8 +865,8 @@ func TestInstanceToHTTPSocket(t *testing.T) {
 		}
 		h.TLS.CAHash = "1"
 		h.TLS.CAFilename = "/var/haproxy/ssl/ca.pem"
-		c.config.Global().Bind.ToHTTPPort = test.toHTTPPort
-		c.config.Global().Bind.ToHTTPSocketID = 11
+		c.config.Global().Bind.FrontingBind = test.toHTTPBind
+		c.config.Global().Bind.FrontingSockID = 11
 
 		c.Update()
 		c.checkConfig(`
@@ -2708,8 +2707,8 @@ func (c *testConfig) newConfig() Config {
 
 func (c *testConfig) configGlobal(global *hatypes.Global) {
 	global.AdminSocket = "/var/run/haproxy.sock"
-	global.Bind.HTTPPort = 80
-	global.Bind.HTTPSPort = 443
+	global.Bind.HTTPBind = ":80"
+	global.Bind.HTTPSBind = ":443"
 	global.Cookie.Key = "Ingress"
 	global.Healthz.Port = 10253
 	global.MaxConn = 2000

--- a/pkg/haproxy/types/global.go
+++ b/pkg/haproxy/types/global.go
@@ -38,10 +38,10 @@ func (u *Userlist) String() string {
 
 // ShareHTTPPort ...
 func (b GlobalBindConfig) ShareHTTPPort() bool {
-	return b.HasFrontingProxy() && b.HTTPBindIP == b.ToHTTPBindIP && b.HTTPPort == b.ToHTTPPort
+	return b.HasFrontingProxy() && b.HTTPBind == b.FrontingBind
 }
 
 // HasFrontingProxy ...
 func (b GlobalBindConfig) HasFrontingProxy() bool {
-	return b.ToHTTPPort > 0
+	return b.FrontingBind != ""
 }

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -43,14 +43,11 @@ type Global struct {
 // GlobalBindConfig ...
 type GlobalBindConfig struct {
 	AcceptProxy    bool
-	HTTPBindIP     string
-	HTTPPort       int
-	HTTPSBindIP    string
-	HTTPSPort      int
+	HTTPBind       string
+	HTTPSBind      string
 	TCPBindIP      string
-	ToHTTPBindIP   string
-	ToHTTPPort     int
-	ToHTTPSocketID int
+	FrontingBind   string
+	FrontingSockID int
 }
 
 // ProcsConfig ...

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -285,7 +285,7 @@ backend {{ $backend.ID }}
 {{- else }}{{/*** if $backend.ModeTCP ***/}}
 
 {{- /*------------------------------------*/}}
-{{- $hasFrontingProxy := $global.Bind.ToHTTPSocketID }}
+{{- $hasFrontingProxy := $global.Bind.HasFrontingProxy }}
 {{- if $backend.HSTS }}
     acl https-request ssl_fc
 {{- if $hasFrontingProxy }}
@@ -613,7 +613,7 @@ backend _error496
 #
 listen _front__tls
     mode tcp
-    bind {{ $global.Bind.HTTPSBindIP }}:{{ $global.Bind.HTTPSPort }}{{ if $global.Bind.AcceptProxy }} accept-proxy{{ end }}
+    bind {{ $global.Bind.HTTPSBind }}{{ if $global.Bind.AcceptProxy }} accept-proxy{{ end }}
 
 {{- /*------------------------------------*/}}
 {{- if $global.UseHTX }}
@@ -680,7 +680,7 @@ listen _front__tls
     server _default_server{{ $fgroup.DefaultBind.Name }} {{ $fgroup.DefaultBind.Socket }} send-proxy-v2
 {{- end }}
 
-{{- $hasFrontingProxy := $global.Bind.ToHTTPSocketID }}
+{{- $hasFrontingProxy := $global.Bind.HasFrontingProxy }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -690,8 +690,8 @@ frontend _front_http
     mode http
 {{- $frontingBind := $fgroup.ToHTTPBind }}
 {{- $hasPlainHTTPSocket := not $global.Bind.ShareHTTPPort }}
-{{- if $hasPlainHTTPSocket }}
-    bind {{ $global.Bind.HTTPBindIP }}:{{ $global.Bind.HTTPPort }}{{ if $global.Bind.AcceptProxy }} accept-proxy{{ end }}
+{{- if and $global.Bind.HTTPBind $hasPlainHTTPSocket }}
+    bind {{ $global.Bind.HTTPBind }}{{ if $global.Bind.AcceptProxy }} accept-proxy{{ end }}
 {{- end }}
 {{- if $frontingBind.Socket }}
     bind {{ $frontingBind.Socket }}
@@ -702,7 +702,7 @@ frontend _front_http
 {{- /*------------------------------------*/}}
 {{- if $hasFrontingProxy }}
 {{- if $hasPlainHTTPSocket }}
-    acl fronting-proxy so_id {{ $global.Bind.ToHTTPSocketID }}
+    acl fronting-proxy so_id {{ $global.Bind.FrontingSockID }}
 {{- else }}
     acl fronting-proxy hdr(X-Forwarded-Proto) -m found
 {{- end }}


### PR DESCRIPTION
The current binding implementation configures IP/wildcard and port number using distinct configuration keys. This limits the number of listening port and IP family haproxy should be listening per frontend. Listening eg both IPv4 and IPv6 cannot be done.

Should be merged to v0.8.