### PR TITLE
fix panic reading empty targetRef from ep

### DIFF
--- a/pkg/converters/utils/services.go
+++ b/pkg/converters/utils/services.go
@@ -138,8 +138,15 @@ func newEndpointAddr(addr *api.EndpointAddress, port int) *Endpoint {
 	return &Endpoint{
 		IP:        addr.IP,
 		Port:      port,
-		TargetRef: fmt.Sprintf("%s/%s", addr.TargetRef.Namespace, addr.TargetRef.Name),
+		TargetRef: targetRefToString(addr.TargetRef),
 	}
+}
+
+func targetRefToString(targetRef *api.ObjectReference) string {
+	if targetRef == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s/%s", targetRef.Namespace, targetRef.Name)
 }
 
 func newEndpointIP(ip string, port int) *Endpoint {

--- a/pkg/converters/utils/services_test.go
+++ b/pkg/converters/utils/services_test.go
@@ -103,6 +103,14 @@ func TestCreateEndpoints(t *testing.T) {
 	for _, test := range testCases {
 		c := setup(t)
 		svc, ep := helper_test.CreateService("default/echo", test.declarePort, test.endpoints)
+		for _, ss := range ep.Subsets {
+			for i := range ss.Addresses {
+				ss.Addresses[i].TargetRef = nil
+			}
+			for i := range ss.NotReadyAddresses {
+				ss.NotReadyAddresses[i].TargetRef = nil
+			}
+		}
 		cache := &helper_test.CacheMock{
 			SvcList: []*api.Service{svc},
 			EpList:  map[string]*api.Endpoints{"default/echo": ep},
@@ -111,9 +119,6 @@ func TestCreateEndpoints(t *testing.T) {
 		var endpoints []*Endpoint
 		if port != nil {
 			endpoints, _, _ = CreateEndpoints(cache, svc, port)
-		}
-		for _, ep := range endpoints {
-			ep.TargetRef = ""
 		}
 		if !reflect.DeepEqual(endpoints, test.expected) {
 			t.Errorf("endpoints differ: expected=%+v actual=%+v", test.expected, endpoints)


### PR DESCRIPTION
Endpoint's targetRef was being read without checking for nil value. A string targetRef version is optional and used eg on blue/green deployment. Using an empty string if nil is enough.

Should be merged to v0.8