### PR TITLE
fix txn.namespace on http requests

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -234,6 +234,7 @@ func (c *config) BuildFrontendGroup() error {
 		HTTPRootRedirMap:  fgroupMaps.AddMap(c.mapsDir + "/_global_http_root_redir.map"),
 		HTTPSRedirMap:     fgroupMaps.AddMap(c.mapsDir + "/_global_https_redir.map"),
 		SSLPassthroughMap: fgroupMaps.AddMap(c.mapsDir + "/_global_sslpassthrough.map"),
+		VarNamespaceMap:   fgroupMaps.AddMap(c.mapsDir + "/_global_k8s_ns.map"),
 	}
 	if c.global.Bind.HasFrontingProxy() {
 		bind := hatypes.NewFrontendBind(nil)
@@ -274,7 +275,6 @@ func (c *config) BuildFrontendGroup() error {
 		frontend.TLSInvalidCrtErrorPagesMap = frontend.Maps.AddMap(mapsPrefix + "_inv_crt_redir.map")
 		frontend.TLSNoCrtErrorList = frontend.Maps.AddMap(mapsPrefix + "_no_crt.list")
 		frontend.TLSNoCrtErrorPagesMap = frontend.Maps.AddMap(mapsPrefix + "_no_crt_redir.map")
-		frontend.VarNamespaceMap = frontend.Maps.AddMap(mapsPrefix + "_k8s_ns.map")
 		frontend.Bind.CrtList = frontend.Maps.AddMap(mapsPrefix + "_bind_crt.list")
 		frontend.Bind.UseServerList = frontend.Maps.AddMap(mapsPrefix + "_use_server.list")
 	}
@@ -358,7 +358,7 @@ func (c *config) BuildFrontendGroup() error {
 				} else {
 					ns = "-"
 				}
-				f.VarNamespaceMap.AppendHostname(base, ns)
+				fgroup.VarNamespaceMap.AppendHostname(base, ns)
 			}
 			// TODO implement deny 413 and move all MaxBodySize stuff to backend
 			if len(maxBodySizes) > 0 {

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -126,6 +126,18 @@ func (fg *FrontendGroup) HasTCPProxy() bool {
 	return fg.HasSSLPassthrough || len(fg.Frontends) > 1
 }
 
+// HasVarNamespace ...
+func (fg *FrontendGroup) HasVarNamespace() bool {
+	for _, f := range fg.Frontends {
+		for _, host := range f.Hosts {
+			if host.VarNamespace {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // String ...
 func (f *Frontend) String() string {
 	return fmt.Sprintf("%+v", *f)
@@ -161,16 +173,6 @@ func (f *Frontend) HasNoCrtErrorPage() bool {
 func (f *Frontend) HasTLSMandatory() bool {
 	for _, host := range f.Hosts {
 		if host.HasTLSAuth() && !host.TLS.CAVerifyOptional {
-			return true
-		}
-	}
-	return false
-}
-
-// HasVarNamespace ...
-func (f *Frontend) HasVarNamespace() bool {
-	for _, host := range f.Hosts {
-		if host.VarNamespace {
 			return true
 		}
 	}

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -223,6 +223,7 @@ type FrontendGroup struct {
 	HTTPRootRedirMap  *HostsMap
 	HTTPSRedirMap     *HostsMap
 	SSLPassthroughMap *HostsMap
+	VarNamespaceMap   *HostsMap
 }
 
 // Frontend ...
@@ -242,7 +243,6 @@ type Frontend struct {
 	TLSInvalidCrtErrorPagesMap *HostsMap
 	TLSNoCrtErrorList          *HostsMap
 	TLSNoCrtErrorPagesMap      *HostsMap
-	VarNamespaceMap            *HostsMap
 }
 
 // BindConfig ...

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -757,6 +757,17 @@ frontend _front_http
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- if $fgroup.HasVarNamespace }}
+    http-request set-var(txn.namespace) 
+        {{- "" }} var(req.base),map_beg({{ $fgroup.VarNamespaceMap.MatchFile }},-)
+{{- if $fgroup.VarNamespaceMap.HasRegex }}
+    http-request set-var(txn.namespace) 
+        {{- "" }} var(req.base),map_reg({{ $fgroup.VarNamespaceMap.RegexFile }},-)
+        {{- "" }} if { var(txn.namespace) -- - }
+{{- end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
     http-request set-header X-Forwarded-Proto http
         {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-CN
@@ -823,7 +834,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $frontend.HasTLSAuth $frontend.HostBackendsMap.HasRegex $frontend.HasVarNamespace $frontend.HasMaxBody }}
+{{- if or $frontend.HasTLSAuth $frontend.HostBackendsMap.HasRegex $fgroup.HasVarNamespace $frontend.HasMaxBody }}
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
     http-request set-var(req.hostbackend)
         {{- "" }} var(req.base),map_beg({{ $frontend.HostBackendsMap.MatchFile }},_nomatch)
@@ -852,13 +863,13 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $frontend.HasVarNamespace }}
+{{- if $fgroup.HasVarNamespace }}
     http-request set-var(txn.namespace) 
-        {{- "" }} var(req.base),map_beg({{ $frontend.VarNamespaceMap.MatchFile }},-)
-{{- if $frontend.VarNamespaceMap.HasRegex }}
+        {{- "" }} var(req.base),map_beg({{ $fgroup.VarNamespaceMap.MatchFile }},-)
+{{- if $fgroup.VarNamespaceMap.HasRegex }}
     http-request set-var(txn.namespace) 
-        {{- "" }} var(req.base),map_reg({{ $frontend.VarNamespaceMap.RegexFile }},-)
-        {{- "" }} if { var(txn.namespace) - }
+        {{- "" }} var(req.base),map_reg({{ $fgroup.VarNamespaceMap.RegexFile }},-)
+        {{- "" }} if { var(txn.namespace) -- - }
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Requests on http frontend wasn't filling txn.namespace var. This haproxy var can be used in http logs to reference the k8s namespace owner of the ingress object which declares the domain and path of the request. The namespace mapping should also be changed to an internal global scope in order to have visibility from the http frontend.

This should be merged to v0.8.