### PR TITLE
do ssl-redirect only if tls declares the hostname

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -318,7 +318,7 @@ func (c *config) BuildFrontendGroup() error {
 				backend := c.FindBackend(path.Backend.Namespace, path.Backend.Name, path.Backend.Port)
 				base := host.Hostname + path.Path
 				hasSSLRedirect := false
-				if backend != nil {
+				if host.TLS.HasTLS() && backend != nil {
 					hasSSLRedirect = backend.HasSSLRedirectHostpath(base)
 				}
 				// TODO use only root path if all uri has the same conf

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -64,3 +64,8 @@ func (h *Host) HasTLSAuth() bool {
 func (h *Host) String() string {
 	return fmt.Sprintf("%+v", *h)
 }
+
+// HasTLS ...
+func (h *HostTLSConfig) HasTLS() bool {
+	return h.TLSFilename != ""
+}


### PR DESCRIPTION
Ingress.spec.tls declares hostnames/domains and an optional secret with crt+key used to ssl-offload https requests on that domains. If a secret name is not declared or is invalid, the default crt+key is used instead.

This commit fixes a misbehaviour when ssl-redirect is true, declared or inherited from configmap, without a TLS being declared. Now ssl-redirect only return 302 redirect if ingress.spec.tls declares the hostname/domain.

Should be merged to v0.8.