### PR TITLE
fix case on per-path backend maps

### DIFF
--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -66,6 +66,8 @@ func (hm *HostsMap) AppendAliasName(base, value string) {
 
 // AppendAliasRegex ...
 func (hm *HostsMap) AppendAliasRegex(base, value string) {
+	// always use case insensitive match
+	base = strings.ToLower(base)
 	if base != "" {
 		hm.Regex = append(hm.Regex, &HostsMapEntry{
 			Key:   base,
@@ -76,6 +78,8 @@ func (hm *HostsMap) AppendAliasRegex(base, value string) {
 
 // AppendPath ...
 func (hm *HostsMap) AppendPath(path, id string) {
+	// always use case insensitive match
+	path = strings.ToLower(path)
 	hm.Match = append(hm.Match, &HostsMapEntry{
 		Key:   path,
 		Value: id,


### PR DESCRIPTION
Backend config has a matching host+path map file used to partially apply ACLs. Some users of this map: hsts, waf and whitelist. While the host and path samples are being converted to lowercase since 8d69fa7, the entries in the map was not.