### PR TITLE
improve equality comparison with acme changes

### DIFF
--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -42,14 +42,14 @@ func (c *updater) buildGlobalAcme(d *globalData) {
 		c.logger.Warn("acme terms was not agreed, configure '%s' with \"true\" value", ingtypes.GlobalAcmeTermsAgreed)
 		return
 	}
+	d.acmeData.Emails = emails
+	d.acmeData.Endpoint = endpoint
+	d.acmeData.Expiring = time.Duration(d.mapper.Get(ingtypes.GlobalAcmeExpiring).Int()) * 24 * time.Hour
+	d.acmeData.TermsAgreed = termsAgreed
 	d.acme.Prefix = "/.well-known/acme-challenge/"
 	d.acme.Socket = "/var/run/acme.sock"
-	d.acme.Emails = emails
 	d.acme.Enabled = true
-	d.acme.Endpoint = endpoint
-	d.acme.Expiring = time.Duration(d.mapper.Get(ingtypes.GlobalAcmeExpiring).Int()) * 24 * time.Hour
 	d.acme.Shared = d.mapper.Get(ingtypes.GlobalAcmeShared).Bool()
-	d.acme.TermsAgreed = termsAgreed
 }
 
 func (c *updater) buildGlobalBind(d *globalData) {

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -51,8 +51,8 @@ func (c *updater) buildHostCertSigner(d *hostData) {
 		c.logger.Warn("ignoring invalid cert-signer on %v: %s", signer.Source, signer.Value)
 		return
 	}
-	acme := c.haproxy.Acme()
-	if acme.Endpoint == "" || acme.Emails == "" {
+	acmeData := c.haproxy.AcmeData()
+	if acmeData.Endpoint == "" || acmeData.Emails == "" {
 		c.logger.Warn("ignoring acme signer on %v due to missing endpoint or email config", signer.Source)
 		return
 	}

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -51,9 +51,10 @@ type updater struct {
 }
 
 type globalData struct {
-	acme   *hatypes.Acme
-	global *hatypes.Global
-	mapper *Mapper
+	acmeData *hatypes.AcmeData
+	acme     *hatypes.Acme
+	global   *hatypes.Global
+	mapper   *Mapper
 }
 
 type hostData struct {
@@ -98,9 +99,10 @@ func (c *updater) splitCIDR(cidrlist *ConfigValue) []string {
 
 func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mapper) {
 	d := &globalData{
-		acme:   haproxyConfig.Acme(),
-		global: haproxyConfig.Global(),
-		mapper: mapper,
+		acmeData: haproxyConfig.AcmeData(),
+		acme:     haproxyConfig.Acme(),
+		global:   haproxyConfig.Global(),
+		mapper:   mapper,
 	}
 	d.global.AdminSocket = "/var/run/haproxy-stats.sock"
 	d.global.MaxConn = mapper.Get(ingtypes.GlobalMaxConnections).Int()

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -168,7 +168,7 @@ func (c *converter) syncIngress(ing *extensions.Ingress) {
 		}
 		if tlsAcme {
 			if tls.SecretName != "" {
-				c.haproxy.Acme().AddDomains(ing.Namespace+"/"+tls.SecretName, tls.Hosts)
+				c.haproxy.AcmeData().AddDomains(ing.Namespace+"/"+tls.SecretName, tls.Hosts)
 			} else {
 				c.logger.Warn("skipping cert signer of ingress '%s': missing secret name", fullIngName)
 			}

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -43,6 +43,7 @@ type Config interface {
 	BuildBackendMaps() error
 	DefaultHost() *hatypes.Host
 	DefaultBackend() *hatypes.Backend
+	AcmeData() *hatypes.AcmeData
 	Acme() *hatypes.Acme
 	Global() *hatypes.Global
 	TCPBackends() []*hatypes.TCPBackend
@@ -53,9 +54,10 @@ type Config interface {
 }
 
 type config struct {
-	// external state, cannot reflect in Config.Equals()
-	acme *hatypes.Acme
+	// external state, non haproxy data, cannot reflect in Config.Equals()
+	acmeData *hatypes.AcmeData
 	// haproxy internal state
+	acme            *hatypes.Acme
 	fgroup          *hatypes.FrontendGroup
 	mapsTemplate    *template.Config
 	mapsDir         string
@@ -80,6 +82,7 @@ func createConfig(options options) *config {
 		mapsTemplate = template.CreateConfig()
 	}
 	return &config{
+		acmeData:     &hatypes.AcmeData{},
 		acme:         &hatypes.Acme{},
 		global:       &hatypes.Global{},
 		mapsTemplate: mapsTemplate,
@@ -473,6 +476,10 @@ func (c *config) DefaultBackend() *hatypes.Backend {
 	return c.defaultBackend
 }
 
+func (c *config) AcmeData() *hatypes.AcmeData {
+	return c.acmeData
+}
+
 func (c *config) Acme() *hatypes.Acme {
 	return c.acme
 }
@@ -504,6 +511,6 @@ func (c *config) Equals(other Config) bool {
 	}
 	// (config struct): external state, cannot reflect in Config.Equals()
 	copy := *c2
-	copy.acme = c.acme
+	copy.acmeData = c.acmeData
 	return reflect.DeepEqual(c, &copy)
 }

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -76,7 +76,7 @@ func (i *instance) AcmePeriodicCheck() {
 	if i.oldConfig == nil || i.options.AcmeQueue == nil {
 		return
 	}
-	hasAccount := i.acmeEnsureConfig(i.oldConfig.Acme())
+	hasAccount := i.acmeEnsureConfig(i.oldConfig.AcmeData())
 	if !hasAccount {
 		return
 	}
@@ -87,7 +87,7 @@ func (i *instance) AcmePeriodicCheck() {
 	}
 	i.logger.Info("starting periodic certificate check")
 	var count int
-	for storage, domains := range i.oldConfig.Acme().Certs {
+	for storage, domains := range i.oldConfig.AcmeData().Certs {
 		i.acmeAddCert(storage, domains)
 		count++
 	}
@@ -98,7 +98,7 @@ func (i *instance) AcmePeriodicCheck() {
 	}
 }
 
-func (i *instance) acmeEnsureConfig(acmeConfig *hatypes.Acme) bool {
+func (i *instance) acmeEnsureConfig(acmeConfig *hatypes.AcmeData) bool {
 	signer := i.options.AcmeSigner
 	signer.AcmeConfig(acmeConfig.Expiring)
 	signer.AcmeAccount(acmeConfig.Endpoint, acmeConfig.Emails, acmeConfig.TermsAgreed)
@@ -183,14 +183,14 @@ func (i *instance) acmeUpdate() {
 	}
 	le := i.options.LeaderElector
 	if le.IsLeader() {
-		hasAccount := i.acmeEnsureConfig(i.curConfig.Acme())
+		hasAccount := i.acmeEnsureConfig(i.curConfig.AcmeData())
 		if !hasAccount {
 			return
 		}
 	}
 	var updated bool
-	oldCerts := i.oldConfig.Acme().Certs
-	curCerts := i.curConfig.Acme().Certs
+	oldCerts := i.oldConfig.AcmeData().Certs
+	curCerts := i.curConfig.AcmeData().Certs
 	// Remove from the retry queue certs that was removed from the config
 	for storage, domains := range oldCerts {
 		curdomains, found := curCerts[storage]

--- a/pkg/haproxy/types/global.go
+++ b/pkg/haproxy/types/global.go
@@ -21,7 +21,7 @@ import (
 )
 
 // AddDomains ...
-func (acme *Acme) AddDomains(storage string, domains []string) {
+func (acme *AcmeData) AddDomains(storage string, domains []string) {
 	if acme.Certs == nil {
 		acme.Certs = map[string]map[string]struct{}{}
 	}

--- a/pkg/haproxy/types/global_test.go
+++ b/pkg/haproxy/types/global_test.go
@@ -58,7 +58,7 @@ func TestAcmeAddDomain(t *testing.T) {
 		},
 	}
 	for i, test := range testCases {
-		acme := Acme{}
+		acme := AcmeData{}
 		for _, cert := range test.certs {
 			acme.AddDomains(cert[0], cert[1:])
 		}

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -20,17 +20,21 @@ import (
 	"time"
 )
 
-// Acme ...
-type Acme struct {
+// AcmeData ...
+type AcmeData struct {
 	Certs       map[string]map[string]struct{}
 	Emails      string
-	Enabled     bool
 	Endpoint    string
 	Expiring    time.Duration
-	Prefix      string
-	Shared      bool
-	Socket      string
 	TermsAgreed bool
+}
+
+// Acme ...
+type Acme struct {
+	Enabled bool
+	Prefix  string
+	Shared  bool
+	Socket  string
 }
 
 // Global ...


### PR DESCRIPTION
There is a couple of acme config that reflect in the haproxy configuration, eg enabled and socket. This change creates a distinct data type and field with acme-exclusive data and acme config used by haproxy. If only acmeData changes, a reload isn't needed.