### PR TITLE
check acme account before retrieving

### DIFF
--- a/pkg/acme/signer.go
+++ b/pkg/acme/signer.go
@@ -87,6 +87,9 @@ func (s *signer) AcmeAccount(endpoint, emails string, termsAgreed bool) {
 		return
 	}
 	s.client = nil
+	if endpoint == "" && emails == "" && !termsAgreed {
+		return
+	}
 	s.logger.Info("loading account %+v", account)
 	client, err := NewClient(s.logger, s.cache, &account)
 	if err != nil {


### PR DESCRIPTION
An acme account might be empty if endpoint or emails wasn't filled or the terms wasn't agreed. In this case the client shouldn't try to connect the acme environment and acme processing should be stopped.