### PR TITLE
deduplicate changes within a small time range

### DIFF
--- a/pkg/common/task/queue_test.go
+++ b/pkg/common/task/queue_test.go
@@ -108,30 +108,6 @@ func TestEnqueueFailed(t *testing.T) {
 	}
 }
 
-func TestEnqueueKeyError(t *testing.T) {
-	// initialize result
-	atomic.StoreUint32(&sr, 0)
-	q := NewCustomTaskQueue(mockSynFn, mockErrorKeyFn)
-	stopCh := make(chan struct{})
-	// run queue
-	go q.Run(5*time.Second, stopCh)
-	// mock object whichi will be enqueue
-	mo := mockEnqueueObj{
-		k: "testKey",
-		v: "testValue",
-	}
-
-	q.Enqueue(mo)
-	// wait for 'mockSynFn'
-	time.Sleep(time.Millisecond * 10)
-	// key error, so the result should be 0
-	if atomic.LoadUint32(&sr) != 0 {
-		t.Errorf("error occurs while get key, so sr should be 0, but is %d", sr)
-	}
-	// shutdown queue before exit
-	q.Shutdown()
-}
-
 func TestSkipEnqueue(t *testing.T) {
 	// initialize result
 	atomic.StoreUint32(&sr, 0)


### PR DESCRIPTION
Ingress parsing is a somewhat expensive task on big clusters (1000+ ingress objects). Thanks `--rate-limit-update` two consecutive parsings cannot happen below a configurable amount of time.

However a flood of changes wasn't being deduplicated. If eg rate limit is 0.25 (at least 4s between updates) and 10 changes would happen, the controller would parse all the configuration 10 times, in the next 40s (ok 36s). The change here is to enqueue the same object, which will be deduplicated by the work queue, instead of the object received to be enqueued. Reasons why this is not a problem at all:

- Only status and controller parsers (v07 and v08+) uses this work queue
- Status already starts the job using the same dummy string
- Controller receives the changed object but doesn't use it - all the configuration is parsed on every single change - this can be reviewed in the future