### PR TITLE
Add 4xx error pages and CORS Preflight as Lua services

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -95,11 +95,8 @@ func TestBackends(t *testing.T) {
 			},
 			path: []string{"/", "/sub"},
 			expected: `
-    http-request use-service lua.send-response if METH_OPTIONS
-    http-response set-status 204 reason "No Content" if METH_OPTIONS
-    http-response set-header Content-Type                 "text/plain" if METH_OPTIONS
-    http-response set-header Content-Length               "0" if METH_OPTIONS
-    http-response set-header Access-Control-Max-Age       "86400" if METH_OPTIONS
+    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS
     http-response set-header Access-Control-Allow-Origin  "*"
     http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS"
     http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization"`,
@@ -130,11 +127,8 @@ func TestBackends(t *testing.T) {
     # path01 = d1.local/
     # path02 = d1.local/sub
     http-request set-var(txn.pathID) base,lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath.map)
-    http-request use-service lua.send-response if METH_OPTIONS
-    http-response set-status 204 reason "No Content" if METH_OPTIONS { var(txn.pathID) path01 }
-    http-response set-header Content-Type                 "text/plain" if METH_OPTIONS { var(txn.pathID) path01 }
-    http-response set-header Content-Length               "0" if METH_OPTIONS { var(txn.pathID) path01 }
-    http-response set-header Access-Control-Max-Age       "86400" if METH_OPTIONS { var(txn.pathID) path01 }
+    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS { var(txn.pathID) path01 }
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) path01 }
     http-response set-header Access-Control-Allow-Origin  "*" if { var(txn.pathID) path01 }
     http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) path01 }
     http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if { var(txn.pathID) path01 }
@@ -661,7 +655,6 @@ global
     stats socket /var/run/haproxy.sock level admin expose-fd listeners
     maxconn 2000
     hard-stop-after 15m
-    lua-load /usr/local/etc/haproxy/lua/send-response.lua
     lua-load /usr/local/etc/haproxy/lua/auth-request.lua
     lua-load /usr/local/etc/haproxy/lua/services.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
@@ -2077,7 +2070,6 @@ global
     hard-stop-after 15m
     log 127.0.0.1:1514 len 2048 format rfc3164 local0
     log-tag ingress
-    lua-load /usr/local/etc/haproxy/lua/send-response.lua
     lua-load /usr/local/etc/haproxy/lua/auth-request.lua
     lua-load /usr/local/etc/haproxy/lua/services.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
@@ -2968,7 +2960,6 @@ func (c *testConfig) checkConfig(expected string) {
     stats socket /var/run/haproxy.sock level admin expose-fd listeners
     maxconn 2000
     hard-stop-after 15m
-    lua-load /usr/local/etc/haproxy/lua/send-response.lua
     lua-load /usr/local/etc/haproxy/lua/auth-request.lua
     lua-load /usr/local/etc/haproxy/lua/services.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -663,6 +663,7 @@ global
     hard-stop-after 15m
     lua-load /usr/local/etc/haproxy/lua/send-response.lua
     lua-load /usr/local/etc/haproxy/lua/auth-request.lua
+    lua-load /usr/local/etc/haproxy/lua/services.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256
@@ -690,24 +691,7 @@ backend default_empty_8080
     mode http
 backend _error404
     mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/404.http
-    http-request deny deny_status 400
-backend _error413
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/413.http
-    http-request deny deny_status 400
-backend _error421
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/421.http
-    http-request deny deny_status 400
-backend _error495
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/495.http
-    http-request deny deny_status 400
-backend _error496
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/496.http
-    http-request deny deny_status 400
+    http-request use-service lua.send-404
 <<frontends-default>>
 <<support>>
 `)
@@ -900,10 +884,10 @@ frontend _front001
     http-request del-header X-SSL-Client-DN
     http-request del-header X-SSL-Client-SHA1
     http-request del-header X-SSL-Client-Cert` + test.expectedACL + test.expectedSetvar + `
-    use_backend _error421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
-    use_backend _error496 if { var(req.tls_nocrt_redir) _internal }
-    use_backend _error421 if !tls-has-crt tls-host-need-crt
-    use_backend _error495 if { var(req.tls_invalidcrt_redir) _internal }
+    http-request use-service lua.send-421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
+    http-request use-service lua.send-496 if { var(req.tls_nocrt_redir) _internal }
+    http-request use-service lua.send-421 if !tls-has-crt tls-host-need-crt
+    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) _internal }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.snibackend)] if { var(req.snibackend) -m found }
     default_backend _error404
@@ -1043,7 +1027,6 @@ backend d2_app_8080
 backend _default_backend
     mode http
     server s0 172.17.0.99:8080 weight 100
-<<backend-errors>>
 frontend _front_http
     mode http
     bind :80
@@ -1219,7 +1202,6 @@ backend d2_app_8080
 backend _default_backend
     mode http
     server s0 172.17.0.99:8080 weight 100
-<<backend-errors>>
 frontend _front_http
     mode http
     bind :80
@@ -1314,7 +1296,6 @@ backend d_app_8080
 backend _default_backend
     mode http
     server s0 172.17.0.99:8080 weight 100
-<<backend-errors>>
 <<frontend-http>>
     default_backend _default_backend
 frontend _front001
@@ -1338,10 +1319,10 @@ frontend _front001
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_inv_crt_redir.map,_internal) if tls-has-invalid-crt tls-check-crt
     http-request redirect location %[var(req.tls_nocrt_redir)] code 303 if { var(req.tls_nocrt_redir) -m found } !{ var(req.tls_nocrt_redir) _internal }
     http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303 if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
-    use_backend _error421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
-    use_backend _error496 if { var(req.tls_nocrt_redir) _internal }
-    use_backend _error421 if !tls-has-crt tls-host-need-crt
-    use_backend _error495 if { var(req.tls_invalidcrt_redir) _internal }
+    http-request use-service lua.send-421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
+    http-request use-service lua.send-496 if { var(req.tls_nocrt_redir) _internal }
+    http-request use-service lua.send-421 if !tls-has-crt tls-host-need-crt
+    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) _internal }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.snibackend)] if { var(req.snibackend) -m found }
     default_backend _default_backend
@@ -1450,7 +1431,6 @@ backend d_appca_8080
 backend _default_backend
     mode http
     server s0 172.17.0.99:8080 weight 100
-<<backend-errors>>
 listen _front__tls
     mode tcp
     bind :443
@@ -1485,8 +1465,8 @@ frontend _front001
     http-request set-var(req.snibackend) var(req.base),map_beg(/etc/haproxy/maps/_front001_sni.map) if !{ var(req.snibackend) -m found } !tls-has-crt !tls-host-need-crt
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_inv_crt_redir.map,_internal) if tls-has-invalid-crt tls-check-crt
     http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303 if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
-    use_backend _error421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
-    use_backend _error495 if { var(req.tls_invalidcrt_redir) _internal }
+    http-request use-service lua.send-421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
+    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) _internal }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.snibackend)] if { var(req.snibackend) -m found }
     default_backend _default_backend
@@ -1512,10 +1492,10 @@ frontend _front002
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front002_inv_crt_redir.map,_internal) if tls-has-invalid-crt tls-check-crt
     http-request redirect location %[var(req.tls_nocrt_redir)] code 303 if { var(req.tls_nocrt_redir) -m found } !{ var(req.tls_nocrt_redir) _internal }
     http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303 if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
-    use_backend _error421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
-    use_backend _error496 if { var(req.tls_nocrt_redir) _internal }
-    use_backend _error421 if !tls-has-crt tls-host-need-crt
-    use_backend _error495 if { var(req.tls_invalidcrt_redir) _internal }
+    http-request use-service lua.send-421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
+    http-request use-service lua.send-496 if { var(req.tls_nocrt_redir) _internal }
+    http-request use-service lua.send-421 if !tls-has-crt tls-host-need-crt
+    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) _internal }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.snibackend)] if { var(req.snibackend) -m found }
     default_backend _default_backend
@@ -1643,7 +1623,6 @@ backend d_app3_8080
 backend _default_backend
     mode http
     server s0 172.17.0.99:8080 weight 100
-<<backend-errors>>
 <<frontend-http>>
     default_backend _default_backend
 <<frontend-https>>
@@ -2059,7 +2038,7 @@ frontend _front001
     http-request set-var(req.hostbackend) var(req.base),map_beg(/etc/haproxy/maps/_front001_host.map)
     <<https-headers>>
     http-request set-var(req.maxbody) var(req.base),map_beg_int(/etc/haproxy/maps/_front001_max_body_size.map,0)
-    use_backend _error413 if !{ var(req.maxbody) 0 } { req.body_size,sub(req.maxbody) gt 0 }
+    http-request use-service lua.send-413 if !{ var(req.maxbody) 0 } { req.body_size,sub(req.maxbody) gt 0 }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     default_backend _error404
 <<support>>
@@ -2100,6 +2079,7 @@ global
     log-tag ingress
     lua-load /usr/local/etc/haproxy/lua/send-response.lua
     lua-load /usr/local/etc/haproxy/lua/auth-request.lua
+    lua-load /usr/local/etc/haproxy/lua/services.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256
@@ -2708,8 +2688,8 @@ frontend _front001
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map(/etc/haproxy/maps/_front001_inv_crt_redir.map,_internal) if tls-has-invalid-crt tls-check-crt
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map_reg(/etc/haproxy/maps/_front001_inv_crt_redir_regex.map,_internal) if { var(req.tls_invalidcrt_redir) _internal }
     http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303 if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
-    use_backend _error421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
-    use_backend _error495 if { var(req.tls_invalidcrt_redir) _internal }
+    http-request use-service lua.send-421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
+    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) _internal }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.snibackend)] if { var(req.snibackend) -m found }
     default_backend _error404
@@ -2990,6 +2970,7 @@ func (c *testConfig) checkConfig(expected string) {
     hard-stop-after 15m
     lua-load /usr/local/etc/haproxy/lua/send-response.lua
     lua-load /usr/local/etc/haproxy/lua/auth-request.lua
+    lua-load /usr/local/etc/haproxy/lua/services.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256
@@ -3013,27 +2994,9 @@ func (c *testConfig) checkConfig(expected string) {
     timeout server          50s
     timeout server-fin      50s
     timeout tunnel          1h`,
-		"<<backend-errors>>": `backend _error413
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/413.http
-    http-request deny deny_status 400
-backend _error421
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/421.http
-    http-request deny deny_status 400
-backend _error495
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/495.http
-    http-request deny deny_status 400
-backend _error496
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/496.http
-    http-request deny deny_status 400`,
 		"<<backends-default>>": `backend _error404
     mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/404.http
-    http-request deny deny_status 400
-<<backend-errors>>`,
+    http-request use-service lua.send-404`,
 		"    <<http-headers>>": `    http-request set-header X-Forwarded-Proto http
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -33,7 +33,6 @@ global
     log {{ $global.Syslog.Endpoint }} len {{ $global.Syslog.Length }} format {{ $global.Syslog.Format }} local0
     log-tag {{ $global.Syslog.Tag }}
 {{- end }}
-    lua-load /usr/local/etc/haproxy/lua/send-response.lua
     lua-load /usr/local/etc/haproxy/lua/auth-request.lua
     lua-load /usr/local/etc/haproxy/lua/services.lua
 {{- if $global.SSL.DHParam.Filename }}
@@ -379,8 +378,16 @@ backend {{ $backend.ID }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $backend.HasCorsEnabled }}
-    http-request use-service lua.send-response if METH_OPTIONS
+{{- $needACL := gt (len $backend.Cors) 1 }}
+{{- range $corsCfg := $backend.Cors }}
+{{- $cors := $corsCfg.Config }}
+{{- if $cors.Enabled }}
+{{- $paths := $corsCfg.Paths }}
+    http-request set-var(txn.cors_max_age) str({{ $cors.MaxAge }}) if METH_OPTIONS
+        {{- if $needACL }} { var(txn.pathID) {{ $paths.IDList }} }{{ end }}
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS
+        {{- if $needACL }} { var(txn.pathID) {{ $paths.IDList }} }{{ end }}
+{{- end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -466,14 +473,6 @@ backend {{ $backend.ID }}
 {{- $cors := $corsCfg.Config }}
 {{- if $cors.Enabled }}
 {{- $paths := $corsCfg.Paths }}
-    http-response set-status 204 reason "No Content" if METH_OPTIONS
-        {{- if $needACL }} { var(txn.pathID) {{ $paths.IDList }} }{{ end }}
-    http-response set-header Content-Type                 "text/plain" if METH_OPTIONS
-        {{- if $needACL }} { var(txn.pathID) {{ $paths.IDList }} }{{ end }}
-    http-response set-header Content-Length               "0" if METH_OPTIONS
-        {{- if $needACL }} { var(txn.pathID) {{ $paths.IDList }} }{{ end }}
-    http-response set-header Access-Control-Max-Age       "{{ $cors.MaxAge }}" if METH_OPTIONS
-        {{- if $needACL }} { var(txn.pathID) {{ $paths.IDList }} }{{ end }}
     http-response set-header Access-Control-Allow-Origin  "{{ $cors.AllowOrigin }}"
         {{- if $needACL }} if { var(txn.pathID) {{ $paths.IDList }} }{{ end }}
     http-response set-header Access-Control-Allow-Methods "{{ $cors.AllowMethods }}"

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -35,6 +35,7 @@ global
 {{- end }}
     lua-load /usr/local/etc/haproxy/lua/send-response.lua
     lua-load /usr/local/etc/haproxy/lua/auth-request.lua
+    lua-load /usr/local/etc/haproxy/lua/services.lua
 {{- if $global.SSL.DHParam.Filename }}
     ssl-dh-param-file {{ $global.SSL.DHParam.Filename }}
 {{- else }}
@@ -574,36 +575,16 @@ backend _acme_challenge
     server _acme_server unix@{{ $cfg.Acme.Socket }}
 {{- end }}
 
-{{- if $cfg.Backends }}
+{{- if and $cfg.Backends (not $cfg.DefaultBackend) }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
 #     Error pages
 #
-{{- if not $cfg.DefaultBackend }}
 backend _error404
     mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/404.http
-    http-request deny deny_status 400
+    http-request use-service lua.send-404
 {{- end }}
-backend _error413
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/413.http
-    http-request deny deny_status 400
-backend _error421
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/421.http
-    http-request deny deny_status 400
-backend _error495
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/495.http
-    http-request deny deny_status 400
-backend _error496
-    mode http
-    errorfile 400 /usr/local/etc/haproxy/errors/496.http
-    http-request deny deny_status 400
-
-{{- end }}{{/* if has Backends */}}
 
 {{- $fgroup := $cfg.FrontendGroup }}
 {{- if $fgroup }}
@@ -992,21 +973,21 @@ frontend {{ $frontend.Name }}
 
 {{- /*------------------------------------*/}}
 {{- if $frontend.HasMaxBody }}
-    use_backend _error413 if
+    http-request use-service lua.send-413 if
         {{- "" }} !{ var(req.maxbody) 0 } { req.body_size,sub(req.maxbody) gt 0 }
 {{- end }}
 {{- if $frontend.HasTLSAuth }}
-    use_backend _error421 if
+    http-request use-service lua.send-421 if
         {{- "" }} tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
 {{- if $frontend.HasTLSMandatory }}
-    use_backend _error496 if
+    http-request use-service lua.send-496 if
         {{- "" }} { var(req.tls_nocrt_redir) _internal }
 {{- /* HTTP 421 instead of 404 if missing sni or the provided one doesn't read client crt. */}}
 {{- /* Waiting move the tls-auth stuff to the backend to implement a proper config. */}}
-    use_backend _error421 if
+    http-request use-service lua.send-421 if
         {{- "" }} !tls-has-crt tls-host-need-crt
 {{- end }}
-    use_backend _error495 if
+    http-request use-service lua.send-495 if
         {{- "" }} { var(req.tls_invalidcrt_redir) _internal }
 {{- end }}
 

--- a/rootfs/usr/local/etc/haproxy/lua/services.lua
+++ b/rootfs/usr/local/etc/haproxy/lua/services.lua
@@ -1,0 +1,63 @@
+-- Copyright 2019 The HAProxy Ingress Controller Authors.
+-- 
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License at
+-- 
+--     http://www.apache.org/licenses/LICENSE-2.0
+-- 
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
+local function send(applet, status, response)
+    response = response:gsub("\n", "\r\n")
+    applet:set_status(status)
+    applet:add_header("Content-Length", string.len(response))
+    applet:add_header("Content-Type", "text/html")
+    applet:add_header("Cache-Control", "no-cache")
+    applet:start_response()
+    applet:send(response)
+end
+
+core.register_service("send-404", "http", function(applet)
+    send(applet, 404, [[
+<html><body><h1>404 Not Found</h1>
+The requested URL was not found.
+</body></html>
+]])
+end)
+
+core.register_service("send-413", "http", function(applet)
+    send(applet, 413, [[
+<html><body><h1>413 Request Entity Too Large</h1>
+The request is too large.
+</body></html>
+]])
+end)
+
+core.register_service("send-421", "http", function(applet)
+    send(applet, 421, [[
+<html><body><h1>421 Misdirected Request</h1>
+Request sent to a non-authoritative server.
+</body></html>
+]])
+end)
+
+core.register_service("send-495", "http", function(applet)
+    send(applet, 495, [[
+<html><body><h1>495 SSL Certificate Error</h1>
+An invalid certificate has been provided.
+</body></html>
+]])
+end)
+
+core.register_service("send-496", "http", function(applet)
+    send(applet, 496, [[
+<html><body><h1>496 SSL Certificate Required</h1>
+A client certificate must be provided.
+</body></html>
+]])
+end)

--- a/rootfs/usr/local/etc/haproxy/lua/services.lua
+++ b/rootfs/usr/local/etc/haproxy/lua/services.lua
@@ -22,6 +22,14 @@ local function send(applet, status, response)
     applet:send(response)
 end
 
+core.register_service("send-cors-preflight", "http", function(applet)
+    applet:set_status(204)
+    applet:add_header("Content-Length", 0)
+    applet:add_header("Content-Type", "text/plain")
+    applet:add_header("Access-Control-Max-Age", applet:get_var("txn.cors_max_age"))
+    applet:start_response()
+end)
+
 core.register_service("send-404", "http", function(applet)
     send(applet, 404, [[
 <html><body><h1>404 Not Found</h1>


### PR DESCRIPTION
Using Lua services has the following benefits:

* The http status code in the log will always be correct - 413, 421, 495, 496, and the self-made 404 was being logged as 400.
* A Lua service can be issued from the backend, which will simplify the frontend config (future refactor).
* Configure the whole response within a service already being used - CORS Preflight.