### PR TITLE
Metric collector and exporter

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -22,13 +22,16 @@ The following command-line options are supported:
 | [`--annotation-prefix`](#annotation-prefix)             | prefix without `/`         | `ingress.kubernetes.io` | v0.8  |
 | [`--default-backend-service`](#default-backend-service) | namespace/servicename      | haproxy's 404 page      |       |
 | [`--default-ssl-certificate`](#default-ssl-certificate) | namespace/secretname       | fake, auto generated    |       |
+| [`--healthz-port`](#stats)                              | port number                | `10254`                 |       |
 | [`--ingress-class`](#ingress-class)                     | name                       | `haproxy`               |       |
 | [`--kubeconfig`](#kubeconfig)                           | /path/to/kubeconfig        | in cluster config       |       |
 | [`--max-old-config-files`](#max-old-config-files)       | num of files               | `0`                     |       |
+| [`--profiling`](#stats)                                 | [true\|false]              | `true`                  |       |
 | [`--publish-service`](#publish-service)                 | namespace/servicename      |                         |       |
 | [`--rate-limit-update`](#rate-limit-update)             | uploads per second (float) | `0.5`                   |       |
 | [`--reload-strategy`](#reload-strategy)                 | [native\|reusesocket]      | `reusesocket`           |       |
 | [`--sort-backends`](#sort-backends)                     | [true\|false]              | `false`                 |       |
+| [`--stats-collect-processing-period`](#stats)           | time                       | `500ms`                 | v0.10 |
 | [`--tcp-services-configmap`](#tcp-services-configmap)   | namespace/configmapname    | no tcp svc              |       |
 | [`--verify-hostname`](#verify-hostname)                 | [true\|false]              | `true`                  |       |
 | [`--wait-before-shutdown`](#wait-before-shutdown)       | seconds as integer         | `0`                     | v0.8  |
@@ -176,6 +179,24 @@ Ingress will randomly shuffle backends and server endpoints on each reload in or
 requesting always the same backends just after reloads, depending on the balancing algorithm.
 Use `--sort-backends` to avoid this behavior and always declare backends and upstream servers
 in the same order.
+
+---
+
+## Stats
+
+Configures an endpoint with statistics, debugging and health checks. The following URIs are provided:
+
+* `/healthz`: a healthz URI for the haproxy-ingress
+* `/metrics`: Prometheus compatible metrics exporter
+* `/debug/pprof`: profiling tools
+* `/build`: build information - controller name, version, git commit hash and repository
+* `/stop`: stops haproxy-ingress controller
+
+Options:
+
+* `--healthz-port`: Defines the port number haproxy-ingress should listen to. Defaults to `10254`.
+* `--profiling`: Configures if the profiling URI should be enabled. Defaults to `true`.
+* `--stats-collect-processing-period`: Defines the interval between two consecutive readings of haproxy's `Idle_pct`, used to generate `haproxy_processing_seconds_total` metric. haproxy updates Idle_pct every `500ms`, which makes that the best configuration value, and it's also the default if not configured. Values higher than `500ms` will produce a less accurate collect. Change to 0 (zero) to disable this metric.
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -78,13 +78,13 @@ type Configuration struct {
 	AcmeTokenConfigmapName  string
 	AcmeTrackTLSAnn         bool
 
-	TCPConfigMapName      string
-	DefaultSSLCertificate string
-	VerifyHostname        bool
-	DefaultHealthzURL     string
-	StatsCollectProcTime  bool
-	PublishService        string
-	Backend               ingress.Controller
+	TCPConfigMapName       string
+	DefaultSSLCertificate  string
+	VerifyHostname         bool
+	DefaultHealthzURL      string
+	StatsCollectProcPeriod time.Duration
+	PublishService         string
+	Backend                ingress.Controller
 
 	UpdateStatus           bool
 	UseNodeInternalIP      bool

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -82,6 +82,7 @@ type Configuration struct {
 	DefaultSSLCertificate string
 	VerifyHostname        bool
 	DefaultHealthzURL     string
+	StatsCollectProcTime  bool
 	PublishService        string
 	Backend               ingress.Controller
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -242,11 +242,11 @@ func (ic *GenericController) Start() {
 }
 
 // CreateDefaultSSLCertificate ...
-func (ic *GenericController) CreateDefaultSSLCertificate() (path, hash string) {
+func (ic *GenericController) CreateDefaultSSLCertificate() (path, hash string, notAfter time.Time) {
 	defCert, defKey := ssl.GetFakeSSLCert()
 	c, err := ssl.AddOrUpdateCertAndKey("default-fake-certificate", defCert, defKey, []byte{})
 	if err != nil {
 		glog.Fatalf("Error generating self signed certificate: %v", err)
 	}
-	return c.PemFileName, c.PemSHA
+	return c.PemFileName, c.PemSHA, c.Certificate.NotAfter
 }

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -107,9 +107,10 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 
 		healthzPort = flags.Int("healthz-port", 10254, "port for healthz endpoint.")
 
-		statsCollectProcTime = flags.Bool("stats-collect-processing-time", true,
-			`Defines if a cumulative processing time should be added to the metrics.
-		 If defined, haproxy-ingress will collect Idle_pct from the admin socket every 500ms.`)
+		statsCollectProcPeriod = flags.Duration("stats-collect-processing-period", 500*time.Millisecond,
+			`Defines the interval between two consecutive readings of haproxy's Idle_pct. haproxy
+		updates Idle_pct every 500ms, which makes that the best configuration value.
+		Change to 0 (zero) to disable this metric.`)
 
 		profiling = flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)
 
@@ -292,7 +293,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		DefaultSSLCertificate:   *defSSLCertificate,
 		VerifyHostname:          *verifyHostname,
 		DefaultHealthzURL:       *defHealthzURL,
-		StatsCollectProcTime:    *statsCollectProcTime,
+		StatsCollectProcPeriod:  *statsCollectProcPeriod,
 		PublishService:          *publishSvc,
 		Backend:                 backend,
 		ForceNamespaceIsolation: *forceIsolation,

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -107,6 +107,10 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 
 		healthzPort = flags.Int("healthz-port", 10254, "port for healthz endpoint.")
 
+		statsCollectProcTime = flags.Bool("stats-collect-processing-time", true,
+			`Defines if a cumulative processing time should be added to the metrics.
+		 If defined, haproxy-ingress will collect Idle_pct from the admin socket every 500ms.`)
+
 		profiling = flags.Bool("profiling", true, `Enable profiling via web interface host:port/debug/pprof/`)
 
 		defSSLCertificate = flags.String("default-ssl-certificate", "", `Name of the secret
@@ -288,6 +292,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		DefaultSSLCertificate:   *defSSLCertificate,
 		VerifyHostname:          *verifyHostname,
 		DefaultHealthzURL:       *defHealthzURL,
+		StatsCollectProcTime:    *statsCollectProcTime,
 		PublishService:          *publishSvc,
 		Backend:                 backend,
 		ForceNamespaceIsolation: *forceIsolation,

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -136,7 +136,7 @@ func (c *cache) buildSecretName(defaultNamespace, secretName string) (string, er
 	)
 }
 
-func (c *cache) GetTLSSecretPath(defaultNamespace, secretName string) (file convtypes.File, err error) {
+func (c *cache) GetTLSSecretPath(defaultNamespace, secretName string) (file convtypes.CrtFile, err error) {
 	fullname, err := c.buildSecretName(defaultNamespace, secretName)
 	if err != nil {
 		return file, err
@@ -148,9 +148,10 @@ func (c *cache) GetTLSSecretPath(defaultNamespace, secretName string) (file conv
 	if sslCert.PemFileName == "" {
 		return file, fmt.Errorf("secret '%s' does not have keys 'tls.crt' and 'tls.key'", fullname)
 	}
-	file = convtypes.File{
+	file = convtypes.CrtFile{
 		Filename: sslCert.PemFileName,
 		SHA1Hash: sslCert.PemSHA,
+		NotAfter: sslCert.Certificate.NotAfter,
 	}
 	return file, nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -133,10 +133,10 @@ func (hc *HAProxyController) configController() {
 }
 
 func (hc *HAProxyController) startServices() {
-	if hc.cfg.StatsCollectProcTime {
+	if hc.cfg.StatsCollectProcPeriod.Milliseconds() > 0 {
 		go wait.Until(func() {
 			hc.instance.CalcIdleMetric()
-		}, 500*time.Millisecond, hc.stopCh)
+		}, hc.cfg.StatsCollectProcPeriod, hc.stopCh)
 	}
 	if hc.leaderelector != nil {
 		go hc.leaderelector.Run()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -286,7 +286,7 @@ func (hc *HAProxyController) SyncIngress(item interface{}) error {
 		globalConfig,
 	)
 	ingConverter.Sync(ingress)
-	timer.Tick("ingress")
+	timer.Tick("parse_ingress")
 
 	//
 	// configmap converters
@@ -300,7 +300,7 @@ func (hc *HAProxyController) SyncIngress(item interface{}) error {
 				hc.cache,
 			)
 			tcpSvcConverter.Sync(tcpConfigmap.Data)
-			timer.Tick("tcpServices")
+			timer.Tick("parse_tcp_svc")
 		} else {
 			hc.logger.Error("error reading TCP services: %v", err)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -260,7 +260,7 @@ func (hc *HAProxyController) SyncIngress(item interface{}) error {
 	//
 	hc.updateCount++
 	hc.logger.Info("Starting HAProxy update id=%d", hc.updateCount)
-	timer := utils.NewTimer()
+	timer := utils.NewTimer(hc.metrics.ControllerProcTime)
 	var ingress []*extensions.Ingress
 	for _, iing := range hc.storeLister.Ingress.List() {
 		ing := iing.(*extensions.Ingress)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -153,7 +153,7 @@ func (hc *HAProxyController) startServices() {
 	}
 }
 
-func (hc *HAProxyController) createDefaultSSLFile(cache convtypes.Cache) (tlsFile convtypes.File) {
+func (hc *HAProxyController) createDefaultSSLFile(cache convtypes.Cache) (tlsFile convtypes.CrtFile) {
 	if hc.cfg.DefaultSSLCertificate != "" {
 		tlsFile, err := cache.GetTLSSecretPath("", hc.cfg.DefaultSSLCertificate)
 		if err == nil {
@@ -163,10 +163,11 @@ func (hc *HAProxyController) createDefaultSSLFile(cache convtypes.Cache) (tlsFil
 	} else {
 		glog.Info("using auto generated fake certificate")
 	}
-	path, hash := hc.controller.CreateDefaultSSLCertificate()
-	tlsFile = convtypes.File{
+	path, hash, notAfter := hc.controller.CreateDefaultSSLCertificate()
+	tlsFile = convtypes.CrtFile{
 		Filename: path,
 		SHA1Hash: hash,
+		NotAfter: notAfter,
 	}
 	return tlsFile
 }

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -88,6 +88,10 @@ func (m *metrics) HAProxyShowInfoResponseTime(duration time.Duration) {
 	m.responseTime.WithLabelValues("show_info").Observe(duration.Seconds())
 }
 
+func (m *metrics) HAProxySetServerResponseTime(duration time.Duration) {
+	m.responseTime.WithLabelValues("set_server").Observe(duration.Seconds())
+}
+
 func (m *metrics) AddIdleFactor(idle int) {
 	now := time.Now()
 	if m.lastTrack.IsZero() {

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2019 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type metrics struct {
+	responseTime       *prometheus.HistogramVec
+	procSecondsCounter *prometheus.CounterVec
+	lastTrack          time.Time
+}
+
+func createMetrics() *metrics {
+	namespace := "haproxyingress"
+	metrics := &metrics{
+		responseTime: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: namespace,
+				Name:      "haproxy_response_time_seconds",
+				Help:      "Response time to commands sent via admin socket",
+				Buckets:   []float64{.0005, .001, .002, .005, .01},
+			},
+			[]string{"command"},
+		),
+		procSecondsCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "haproxy_processing_seconds_total",
+				Help:      "Cumulative time in seconds a single thread spent processing requests, based on Idle_pct.",
+			},
+			[]string{},
+		),
+	}
+	prometheus.MustRegister(metrics.responseTime)
+	prometheus.MustRegister(metrics.procSecondsCounter)
+	return metrics
+}
+
+func (m *metrics) HAProxyShowInfoResponseTime(duration time.Duration) {
+	m.responseTime.WithLabelValues("show_info").Observe(duration.Seconds())
+}
+
+func (m *metrics) AddIdleFactor(idle int) {
+	now := time.Now()
+	if m.lastTrack.IsZero() {
+		m.lastTrack = now
+		return
+	}
+	totalTime := now.Sub(m.lastTrack).Seconds()
+	m.lastTrack = now
+	m.procSecondsCounter.WithLabelValues().Add(float64(100-idle) * totalTime / 100)
+}

--- a/pkg/converters/configmap/tcpservices.go
+++ b/pkg/converters/configmap/tcpservices.go
@@ -82,7 +82,7 @@ func (c *tcpSvcConverter) Sync(tcpservices map[string]string) {
 			c.logger.Warn("skipping TCP service on public port %d: %v", svc.port, err)
 			continue
 		}
-		var crtfile convtypes.File
+		var crtfile convtypes.CrtFile
 		if svc.secret != "" {
 			crtfile, err = c.cache.GetTLSSecretPath("", svc.secret)
 			if err != nil {

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -20,6 +20,7 @@ import (
 	"crypto/sha1"
 	"fmt"
 	"strings"
+	"time"
 
 	api "k8s.io/api/core/v1"
 
@@ -101,15 +102,16 @@ func (c *CacheMock) GetPod(podName string) (*api.Pod, error) {
 }
 
 // GetTLSSecretPath ...
-func (c *CacheMock) GetTLSSecretPath(defaultNamespace, secretName string) (convtypes.File, error) {
+func (c *CacheMock) GetTLSSecretPath(defaultNamespace, secretName string) (convtypes.CrtFile, error) {
 	fullname := c.buildSecretName(defaultNamespace, secretName)
 	if path, found := c.SecretTLSPath[fullname]; found {
-		return convtypes.File{
+		return convtypes.CrtFile{
 			Filename: path,
 			SHA1Hash: fmt.Sprintf("%x", sha1.Sum([]byte(path))),
+			NotAfter: time.Now().AddDate(0, 0, 30),
 		}, nil
 	}
-	return convtypes.File{}, fmt.Errorf("secret not found: '%s'", fullname)
+	return convtypes.CrtFile{}, fmt.Errorf("secret not found: '%s'", fullname)
 }
 
 // GetCASecretPath ...

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -144,6 +144,7 @@ func (c *converter) syncIngress(ing *extensions.Ingress) {
 					if host.TLS.TLSHash == "" {
 						host.TLS.TLSFilename = tlsPath.Filename
 						host.TLS.TLSHash = tlsPath.SHA1Hash
+						host.TLS.TLSNotAfter = tlsPath.NotAfter
 					} else if host.TLS.TLSHash != tlsPath.SHA1Hash {
 						msg := fmt.Sprintf("TLS of host '%s' was already assigned", host.Hostname)
 						if tls.SecretName != "" {
@@ -275,7 +276,7 @@ func (c *converter) addBackend(source *annotations.Source, hostpath, fullSvcName
 	return backend, nil
 }
 
-func (c *converter) addTLS(source *annotations.Source, secretName string) convtypes.File {
+func (c *converter) addTLS(source *annotations.Source, secretName string) convtypes.CrtFile {
 	if secretName != "" {
 		tlsFile, err := c.cache.GetTLSSecretPath(source.Namespace, secretName)
 		if err == nil {

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -19,6 +19,7 @@ package ingress
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kylelemons/godebug/diff"
 	yaml "gopkg.in/yaml.v2"
@@ -1163,9 +1164,10 @@ func (c *testConfig) SyncDef(config map[string]string, ing ...*extensions.Ingres
 			Logger:         c.logger,
 			DefaultConfig:  defaultConfig,
 			DefaultBackend: "system/default",
-			DefaultSSLFile: convtypes.File{
+			DefaultSSLFile: convtypes.CrtFile{
 				Filename: "/tls/tls-default.pem",
 				SHA1Hash: "1",
+				NotAfter: time.Now().AddDate(0, 0, 30),
 			},
 			AnnotationPrefix: "ingress.kubernetes.io",
 		},

--- a/pkg/converters/ingress/types/options.go
+++ b/pkg/converters/ingress/types/options.go
@@ -27,7 +27,7 @@ type ConverterOptions struct {
 	Cache            convtypes.Cache
 	DefaultConfig    func() map[string]string
 	DefaultBackend   string
-	DefaultSSLFile   convtypes.File
+	DefaultSSLFile   convtypes.CrtFile
 	AnnotationPrefix string
 	AcmeTrackTLSAnn  bool
 }

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -17,6 +17,8 @@ limitations under the License.
 package types
 
 import (
+	"time"
+
 	api "k8s.io/api/core/v1"
 )
 
@@ -26,7 +28,7 @@ type Cache interface {
 	GetEndpoints(service *api.Service) (*api.Endpoints, error)
 	GetTerminatingPods(service *api.Service) ([]*api.Pod, error)
 	GetPod(podName string) (*api.Pod, error)
-	GetTLSSecretPath(defaultNamespace, secretName string) (File, error)
+	GetTLSSecretPath(defaultNamespace, secretName string) (CrtFile, error)
 	GetCASecretPath(defaultNamespace, secretName string) (ca, crl File, err error)
 	GetDHSecretPath(defaultNamespace, secretName string) (File, error)
 	GetSecretContent(defaultNamespace, secretName, keyName string) ([]byte, error)
@@ -36,4 +38,11 @@ type Cache interface {
 type File struct {
 	Filename string
 	SHA1Hash string
+}
+
+// CrtFile ...
+type CrtFile struct {
+	Filename string
+	SHA1Hash string
+	NotAfter time.Time
 }

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -21,6 +21,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/kylelemons/godebug/diff"
 
@@ -534,7 +535,7 @@ set server default_app_8080/srv002 weight 1`,
 		dynUpdater := instance.newDynUpdater()
 		dynUpdater.old = test.oldConfig
 		dynUpdater.cur = test.curConfig
-		dynUpdater.cmd = func(socket string, command ...string) ([]string, error) {
+		dynUpdater.cmd = func(socket string, observer func(duration time.Duration), command ...string) ([]string, error) {
 			for _, c := range command {
 				cmd = cmd + c + "\n"
 			}

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -523,7 +523,7 @@ set server default_app_8080/srv002 weight 1`,
 		if test.doconfig1 != nil {
 			test.doconfig1(c)
 			test.oldConfig = c.config.(*config)
-			instance.clearConfig()
+			instance.rotateConfig()
 			c.config = c.newConfig()
 			instance.curConfig = c.config
 		}

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -320,6 +320,12 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 		}
 		return
 	}
+	// A future implementation of ssl certs dynamic update should change this metric
+	for _, host := range i.oldConfig.Hosts() {
+		if host.TLS.TLSHash != "" {
+			i.metrics.SetCertExpireDate(host.Hostname, host.TLS.TLSNotAfter)
+		}
+	}
 	i.metrics.IncUpdateFull()
 	if err := i.reload(); err != nil {
 		i.logger.Error("error reloading server:\n%v", err)

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -24,7 +24,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/acme"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/template"
@@ -186,9 +185,7 @@ func (i *instance) CalcIdleMetric() {
 	if i.oldConfig == nil {
 		return
 	}
-	start := time.Now()
-	msg, err := hautils.HAProxyCommand(i.oldConfig.Global().AdminSocket, "show info")
-	i.metrics.HAProxyShowInfoResponseTime(time.Since(start))
+	msg, err := hautils.HAProxyCommand(i.oldConfig.Global().AdminSocket, i.metrics.HAProxyShowInfoResponseTime, "show info")
 	if err != nil {
 		i.logger.Error("error reading admin socket: %v", err)
 		return

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -284,7 +284,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 		//   - !updated           - there are changes that cannot be dynamically applied
 		//   - updater.cmdCnt > 0 - there are changes that was dynamically applied
 		err := i.templates.Write(i.curConfig)
-		timer.Tick("writeTmpl")
+		timer.Tick("write_tmpl")
 		if err != nil {
 			i.logger.Error("error writing configuration: %v", err)
 			i.metrics.IncUpdateNoop()
@@ -299,7 +299,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 				if err = i.check(); err != nil {
 					i.logger.Error("error validating config file:\n%v", err)
 				}
-				timer.Tick("validate")
+				timer.Tick("validate_cfg")
 			}
 			i.logger.Info("HAProxy updated without needing to reload. Commands sent: %d", updater.cmdCnt)
 			i.metrics.IncUpdateDynamic()
@@ -323,7 +323,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 		i.metrics.UpdateSuccessful(false)
 		return
 	}
-	timer.Tick("reload")
+	timer.Tick("reload_haproxy")
 	i.metrics.UpdateSuccessful(true)
 	i.logger.Info("HAProxy successfully reloaded")
 }

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2791,6 +2791,7 @@ func setup(t *testing.T) *testConfig {
 	configfile := tempdir + "/haproxy.cfg"
 	instance := CreateInstance(logger, InstanceOptions{
 		HAProxyConfigFile: configfile,
+		Metrics:           helper_test.NewMetricsMock(),
 	}).(*instance)
 	if err := instance.templates.NewTemplate(
 		"haproxy.tmpl",

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2950,7 +2950,7 @@ func _yamlMarshal(in interface{}) string {
 }
 
 func (c *testConfig) Update() {
-	timer := utils.NewTimer()
+	timer := utils.NewTimer(nil)
 	c.instance.Update(timer)
 }
 

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -353,6 +353,7 @@ type HostTLSConfig struct {
 	CRLHash          string
 	TLSFilename      string
 	TLSHash          string
+	TLSNotAfter      time.Time
 }
 
 // Backend ...

--- a/pkg/haproxy/utils/utils.go
+++ b/pkg/haproxy/utils/utils.go
@@ -19,12 +19,14 @@ package utils
 import (
 	"fmt"
 	"net"
+	"time"
 )
 
 // HAProxyCommand ...
-func HAProxyCommand(socket string, command ...string) ([]string, error) {
+func HAProxyCommand(socket string, observer func(duration time.Duration), command ...string) ([]string, error) {
 	var msg []string
 	for _, cmd := range command {
+		start := time.Now()
 		c, err := net.Dial("unix", socket)
 		if err != nil {
 			return msg, fmt.Errorf("error connecting to unix socket %s: %v", socket, err)
@@ -42,6 +44,7 @@ func HAProxyCommand(socket string, command ...string) ([]string, error) {
 		} else if r > 2 {
 			msg = append(msg, fmt.Sprintf("response from server: %s", string(readBuffer[:r-2])))
 		}
+		observer(time.Since(start))
 	}
 	return msg, nil
 }

--- a/pkg/types/helper_test/metricsmock.go
+++ b/pkg/types/helper_test/metricsmock.go
@@ -40,6 +40,11 @@ func (m *MetricsMock) HAProxyShowInfoResponseTime(duration time.Duration) {
 func (m *MetricsMock) HAProxySetServerResponseTime(duration time.Duration) {
 }
 
+// ControllerProcTime ...
+func (m *MetricsMock) ControllerProcTime(task string, duration time.Duration) {
+
+}
+
 // AddIdleFactor ...
 func (m *MetricsMock) AddIdleFactor(idle int) {
 }

--- a/pkg/types/helper_test/metricsmock.go
+++ b/pkg/types/helper_test/metricsmock.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2019 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper_test
+
+import (
+	"testing"
+	"time"
+)
+
+// MetricsMock ...
+type MetricsMock struct {
+	Logging []string
+	T       *testing.T
+}
+
+// NewMetricsMock ...
+func NewMetricsMock() *MetricsMock {
+	return &MetricsMock{}
+}
+
+// HAProxyShowInfoResponseTime ...
+func (m *MetricsMock) HAProxyShowInfoResponseTime(duration time.Duration) {
+}
+
+// AddIdleFactor ...
+func (m *MetricsMock) AddIdleFactor(idle int) {
+}
+
+// IncUpdateNoop ...
+func (m *MetricsMock) IncUpdateNoop() {
+}
+
+// IncUpdateDynamic ...
+func (m *MetricsMock) IncUpdateDynamic() {
+}
+
+// IncUpdateFull ...
+func (m *MetricsMock) IncUpdateFull() {
+}
+
+// UpdateSuccessful ...
+func (m *MetricsMock) UpdateSuccessful(success bool) {
+}

--- a/pkg/types/helper_test/metricsmock.go
+++ b/pkg/types/helper_test/metricsmock.go
@@ -36,6 +36,10 @@ func NewMetricsMock() *MetricsMock {
 func (m *MetricsMock) HAProxyShowInfoResponseTime(duration time.Duration) {
 }
 
+// HAProxySetServerResponseTime ...
+func (m *MetricsMock) HAProxySetServerResponseTime(duration time.Duration) {
+}
+
 // AddIdleFactor ...
 func (m *MetricsMock) AddIdleFactor(idle int) {
 }

--- a/pkg/types/helper_test/metricsmock.go
+++ b/pkg/types/helper_test/metricsmock.go
@@ -55,3 +55,7 @@ func (m *MetricsMock) IncUpdateFull() {
 // UpdateSuccessful ...
 func (m *MetricsMock) UpdateSuccessful(success bool) {
 }
+
+// SetCertExpireDate ...
+func (m *MetricsMock) SetCertExpireDate(hostname string, notAfter time.Time) {
+}

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -23,6 +23,7 @@ import (
 // Metrics ...
 type Metrics interface {
 	HAProxyShowInfoResponseTime(duration time.Duration)
+	HAProxySetServerResponseTime(duration time.Duration)
 	AddIdleFactor(idle int)
 	IncUpdateNoop()
 	IncUpdateDynamic()

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -24,4 +24,8 @@ import (
 type Metrics interface {
 	HAProxyShowInfoResponseTime(duration time.Duration)
 	AddIdleFactor(idle int)
+	IncUpdateNoop()
+	IncUpdateDynamic()
+	IncUpdateFull()
+	UpdateSuccessful(success bool)
 }

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -28,4 +28,5 @@ type Metrics interface {
 	IncUpdateDynamic()
 	IncUpdateFull()
 	UpdateSuccessful(success bool)
+	SetCertExpireDate(hostname string, notAfter time.Time)
 }

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2019 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"time"
+)
+
+// Metrics ...
+type Metrics interface {
+	HAProxyShowInfoResponseTime(duration time.Duration)
+	AddIdleFactor(idle int)
+}

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -24,6 +24,7 @@ import (
 type Metrics interface {
 	HAProxyShowInfoResponseTime(duration time.Duration)
 	HAProxySetServerResponseTime(duration time.Duration)
+	ControllerProcTime(task string, duration time.Duration)
 	AddIdleFactor(idle int)
 	IncUpdateNoop()
 	IncUpdateDynamic()

--- a/pkg/utils/timer.go
+++ b/pkg/utils/timer.go
@@ -24,8 +24,9 @@ import (
 
 // Timer ...
 type Timer struct {
-	Start time.Time
-	Ticks []*Tick
+	Start    time.Time
+	Ticks    []*Tick
+	observer func(task string, duration time.Duration)
 }
 
 // Tick ...
@@ -35,17 +36,28 @@ type Tick struct {
 }
 
 // NewTimer ...
-func NewTimer() *Timer {
+func NewTimer(observer func(task string, duration time.Duration)) *Timer {
 	return &Timer{
-		Start: time.Now(),
+		Start:    time.Now(),
+		observer: observer,
 	}
 }
 
 // Tick ...
 func (t *Timer) Tick(eventLabel string) {
+	now := time.Now()
+	if t.observer != nil {
+		var last time.Time
+		if len(t.Ticks) > 0 {
+			last = t.Ticks[len(t.Ticks)-1].When
+		} else {
+			last = t.Start
+		}
+		t.observer(eventLabel, now.Sub(last))
+	}
 	t.Ticks = append(t.Ticks, &Tick{
 		Event: eventLabel,
-		When:  time.Now(),
+		When:  now,
 	})
 }
 


### PR DESCRIPTION
Add a starting version of a metric collector and exporter

* [x] metric raw type and interface
* [x] controller processing time (parsing, writing cfg, reloading, ...)
* [x] haproxy processing time (based on Idle_pct)
* [x] haproxy admin socket response time (show info, set server, ...)
* [x] cumulative updates (noop, dynamic, with reload)
* [x] successful haproxy reload
* [x] certificate expiration correlated with hostname
* [x] doc