### PR TITLE
[DOCS] Rename configmap to ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Updates made to the cluster are applied on the fly to the HAProxy instance.
 Find some useful links below:
 
 * Home of HAProxy Ingress docs: [haproxy-ingress.github.io/docs](https://haproxy-ingress.github.io/docs/)
-* Global configmap options and ingress/service annotations, now named configuration keys: [haproxy-ingress.github.io/docs/configuration/keys/](https://haproxy-ingress.github.io/docs/configuration/keys/)
+* Global ConfigMap options and ingress/service annotations, now named configuration keys: [haproxy-ingress.github.io/docs/configuration/keys/](https://haproxy-ingress.github.io/docs/configuration/keys/)
 * Static command-line options: [haproxy-ingress.github.io/docs/configuration/command-line/](https://haproxy-ingress.github.io/docs/configuration/command-line/)
 * Old single-page doc (up to v0.8): [/release-0.8/README.md](https://github.com/jcmoraisjr/haproxy-ingress/blob/release-0.8/README.md)
 

--- a/docs/content/en/docs/configuration/_index.md
+++ b/docs/content/en/docs/configuration/_index.md
@@ -3,7 +3,7 @@ title: "Configuration"
 linkTitle: "Configuration"
 weight: 4
 description: >
-  All configuration options: ingress/service annotations, global configmap options, command-line options and template overwriting.
+  All configuration options: ingress/service annotations, global ConfigMap options, command-line options and template overwriting.
 ---
 
 See below all the supported HAProxy Ingress configuration options.

--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -47,12 +47,12 @@ against a server which implements the acme protocol, version 2.
 Supported acme command-line options:
 
 * `--acme-check-period`: interval between checks for expiring certificates. Defaults to `24h`.
-* `--acme-election-id`: prefix of the configmap name used to store the leader election data. Only the leader of a haproxy-ingress cluster should start the authorization and sign certificate process. Defaults to `acme-leader`.
+* `--acme-election-id`: prefix of the ConfigMap name used to store the leader election data. Only the leader of a haproxy-ingress cluster should start the authorization and sign certificate process. Defaults to `acme-leader`.
 * `--acme-fail-initial-duration`: the starting time to wait and retry after a failed authorization and sign process. Defaults to `5m`.
 * `--acme-fail-max-duration`: the time between retries of failed authorization will exponentially grow up to the max duration time. Defaults to `8h`.
 * `--acme-secret-key-name`: secret name used to store the client private key. Defaults to `acme-private-key`. A new key, hence a new client, is created if the secret does not exist.
 * `--acme-server`: mandatory, starts a local server used to answer challenges from the acme environment. This option should be provided on all haproxy-ingress instances to the certificate signing work properly.
-* `--acme-token-configmap-name`: the configmap name used to store temporary tokens generated during the challenge. Defaults to `acme-validation-tokens`. Such tokens need to be stored in k8s because any haproxy-ingress instance might receive the request from the acme environment.
+* `--acme-token-configmap-name`: the ConfigMap name used to store temporary tokens generated during the challenge. Defaults to `acme-validation-tokens`. Such tokens need to be stored in k8s because any haproxy-ingress instance might receive the request from the acme environment.
 * `--acme-track-tls-annotation`: defines if ingress objects with annotation `kubernetes.io/tls-acme: "true"` should also be tracked. Defaults to `false`.
 
 See also:
@@ -204,9 +204,9 @@ Options:
 
 Configure `--tcp-services-configmap` argument with `namespace/configmapname` resource with TCP
 services and ports that HAProxy should listen to. Use the HAProxy's port number as the key of the
-configmap.
+ConfigMap.
 
-The value of the configmap entry is a colon separated list of the following items:
+The value of the ConfigMap entry is a colon separated list of the following items:
 
 1. `<namespace>/<service-name>`, mandatory, is the well known notation of the service that will receive incoming connections.
 1. `<portnumber>`, mandatory, is the port number the upstream service is listening - this is not related to the listening port of HAProxy.

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -3,29 +3,29 @@ title: "Configuration keys"
 linkTitle: "Configuration keys"
 weight: 3
 description: >
-  List of all ingress/service annotations and global configmap options.
+  List of all ingress/service annotations and global ConfigMap options.
 ---
 
-Most of HAProxy Ingress configurations are made using a configmap object or annotating
+Most of HAProxy Ingress configurations are made using a ConfigMap object or annotating
 the ingress or service object. Ingress or service annotations are used to make local
-configurations, and the configmap is used to make global configurations or change
+configurations, and the ConfigMap is used to make global configurations or change
 default configuration values.
 
-# Configmap
+# ConfigMap
 
-Global configurations and changing default values are made via a configmap object.
-Configmap declaration is optional but highly recommended. Create an empty configmap
+Global configurations and changing default values are made via a ConfigMap object.
+ConfigMap declaration is optional but highly recommended. Create an empty ConfigMap
 using `kubectl create configmap` and configures in the haproxy-ingress deployment using
 the command-line option `--configmap=<namespace>/<configmap-name>`.
 
-Changes to any key in the configmap object is applied on the fly, the haproxy instance
+Changes to any key in the ConfigMap object is applied on the fly, the haproxy instance
 is restarted or dynamically updated if needed.
 
-All configuration key names are supported as a configmap keys. When declared, its value
+All configuration key names are supported as a ConfigMap keys. When declared, its value
 is used as the default value if not overwritten elsewhere.
 
-A configuration key is used verbatim as the configmap key name, without any prefix.
-The configmap spec expects a string as the key value, so declare numbers and booleans
+A configuration key is used verbatim as the ConfigMap key name, without any prefix.
+The ConfigMap spec expects a string as the key value, so declare numbers and booleans
 as strings, HAProxy Ingress will convert it when needed.
 
 # Ingress and services
@@ -51,8 +51,8 @@ service object accepts configuration keys of scope `Backend` only. See
 [Scope](#scope) below.
 
 Configuration keys declared in services have the highest precedence, overwriting
-configuration keys declared in the configmap and ingress objects. Ingress object
-overwrite the default value and the configmap configuration.
+configuration keys declared in the ConfigMap and ingress objects. Ingress object
+overwrite the default value and the ConfigMap configuration.
 
 # Scope
 
@@ -61,17 +61,17 @@ defines where a configuration key can be declared and how it interacts with ingr
 and service objects.
 
 * Scope `Global`: Defines configuration keys that should be declared only in the
-configmap object. Configuration keys of the global scope declared as ingress or
+ConfigMap object. Configuration keys of the global scope declared as ingress or
 service annotations are ignored. A configuration key of the global scope never
 conflict.
 * Scope `Host`: Defines configuration keys that binds to the hostname. Configuration
-keys of the host scope can be declared in the configmap as a default value, or in
+keys of the host scope can be declared in the ConfigMap as a default value, or in
 an ingress object. A conflict warning will be logged if the same host configuration
 key with distinct values are declared in distict ingress objects but to the same
 hostname.
 * Scope `Backend`: Defines configuration keys that binds to the service object, which
 is converted to a HAProxy backend after the configuration parsing. Configuration keys
-of the backend scope can be declared in the configmap as a default value, in an ingress
+of the backend scope can be declared in the ConfigMap as a default value, in an ingress
 object, or in a service object. A conflict warning will be logged if the same backend
 configuration key with distinct values are declared in distict ingress objects but
 to the same service or HAProxy backend. A backend configuration key declared in a
@@ -685,7 +685,7 @@ See also:
 Add HAProxy configuration snippet to the configuration file. Use multiline content
 to add more than one line of configuration.
 
-Examples - configmap:
+Examples - ConfigMap:
 
 ```yaml
     config-global: |
@@ -847,7 +847,7 @@ servers on each backend and update them via a Unix socket without reloading HAPr
 Unused servers will stay in a disabled state. If the change cannot be made via socket,
 a new HAProxy instance will be started.
 
-Starting on v0.8, a new configmap option `slots-min-free` can be used to configure the
+Starting on v0.8, a new ConfigMap option `slots-min-free` can be used to configure the
 minimum number of free/empty servers per backend. If HAProxy need to be restarted and
 an backend has less than `slots-min-free` available servers, another
 `backend-server-slots-increment` new empty servers would be created.

--- a/docs/content/en/docs/configuration/template.md
+++ b/docs/content/en/docs/configuration/template.md
@@ -6,15 +6,15 @@ description: >
   Overwrite the default template files.
 ---
 
-Change the default templates mounting a new template file using a configmap.
-Note that in the current version, updates to the configmap will not update the
+Change the default templates mounting a new template file using a ConfigMap.
+Note that in the current version, updates to the ConfigMap will not update the
 in-memory parsed template.
 
 All templates support [Sprig](https://masterminds.github.io/sprig/) template library. 
 This library provides a group of commonly used template functions to work with dictionaries, 
 lists, math etc.
 
-| Mounting directory         | Configmap keys (filenames) | Source (choose a proper tag)                                                   |
+| Mounting directory         | ConfigMap keys (filenames) | Source (choose a proper tag)                                                   |
 |----------------------------|----------------------------|--------------------------------------------------------------------------------|
 | `/etc/haproxy/template`    | `haproxy.tmpl`             | [haproxy.tmpl](https://github.com/jcmoraisjr/haproxy-ingress/blob/release-0.8/rootfs/etc/haproxy/template/haproxy.tmpl)                      |
 | `/etc/haproxy/modsecurity` | `spoe-modsecurity.tmpl`    | [spoe-modsecurity.tmpl](https://github.com/jcmoraisjr/haproxy-ingress/blob/release-0.8/rootfs/etc/haproxy/modsecurity/spoe-modsecurity.tmpl) |

--- a/docs/content/en/docs/examples/modsecurity.md
+++ b/docs/content/en/docs/examples/modsecurity.md
@@ -55,11 +55,11 @@ modsecurity-spoa-pp6jz   1/1       Running   0          7s        192.168.100.99
 
 ## Configuring HAProxy Ingress
 
-Add the configmap key `modsecurity-endpoints` with a comma-separated list of `IP:port`
+Add the ConfigMap key `modsecurity-endpoints` with a comma-separated list of `IP:port`
 of the ModSecurity agent server(s). The default port number of the agent is `12345`.
 A `kubectl -n ingress-controller edit configmap haproxy-ingress` should work.
 
-Example of a configmap content if ModSecurity agents has IPs `192.168.100.99` and
+Example of a ConfigMap content if ModSecurity agents has IPs `192.168.100.99` and
 `192.168.100.100`:
 
 ```yaml

--- a/examples/custom-configuration/README.md
+++ b/examples/custom-configuration/README.md
@@ -30,6 +30,6 @@ The only difference from the deployment instructions is the --configmap paramete
 - --configmap=default/haproxy-conf
 ```
 
-If the Configmap it is updated, HAProxy will be reloaded with the new configuration.
+If the ConfigMap it is updated, HAProxy will be reloaded with the new configuration.
 
 Check all the config options in the [HAProxy Ingress docs](https://github.com/jcmoraisjr/haproxy-ingress#configmap)

--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -63,18 +63,18 @@ NAME                                       READY     STATUS    RESTARTS   AGE
 ingress-default-backend-1110790216-gqr61   1/1       Running   0          10s
 ```
 
-## Configmap
+## ConfigMap
 
-Create a configmap named `haproxy-ingress`:
+Create a ConfigMap named `haproxy-ingress`:
 
 ```console
 $ kubectl --namespace=ingress-controller create configmap haproxy-ingress
 configmap "haproxy-ingress" created
 ```
 
-A configmap is used to provide global or default configuration like
+A ConfigMap is used to provide global or default configuration like
 timeouts, SSL/TLS settings, a syslog service endpoint and so on. The
-configmap can be edited or replaced later in order to apply new
+ConfigMap can be edited or replaced later in order to apply new
 configuration on a running ingress controller. All supported options
 are [here](https://github.com/jcmoraisjr/haproxy-ingress#configmap).
 

--- a/examples/dns-service-discovery/README.md
+++ b/examples/dns-service-discovery/README.md
@@ -14,13 +14,13 @@ Example - using internal kubernetes resources
 
 *Note: Configure IP address of your cluster DNS server*
 
-* Update ingress with simple [configmap](/examples/dns-service-discovery/haproxy-config-map.yml)
+* Update ingress with simple [ConfigMap](/examples/dns-service-discovery/haproxy-config-map.yml)
 
 ```console
 $ kubectl apply -f haproxy-config-map.yml
 ```
 
-* configmap with all options displayed [configmap](/examples/dns-service-discovery/all-options-haproxy-config-map.yml)
+* ConfigMap with all options displayed [ConfigMap](/examples/dns-service-discovery/all-options-haproxy-config-map.yml)
 
 ```console
 $ kubectl apply -f all-options-haproxy-config-map.yml
@@ -45,7 +45,7 @@ Two important settings:
 - `clusterIP: None`: service must be [**headless**](https://kubernetes.io/docs/concepts/services-networking/service/#headless-services). See also [dns headless doc](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
 
 
-## Configmap options
+## ConfigMap options
 
 * `cluster-dns-domain` can be used if kubedns does not points to cluster.local
 * `dns-resolvers` multiline list of DNS resolvers

--- a/examples/modsecurity/README.md
+++ b/examples/modsecurity/README.md
@@ -49,11 +49,11 @@ modsecurity-spoa-pp6jz   1/1       Running   0          7s        192.168.100.99
 
 ## Configuring HAProxy Ingress
 
-Add the configmap key `modsecurity-endpoints` with a comma-separated list of `IP:port`
+Add the ConfigMap key `modsecurity-endpoints` with a comma-separated list of `IP:port`
 of the ModSecurity agent server(s). The default port number of the agent is `12345`.
 A `kubectl -n ingress-controller edit configmap haproxy-ingress` should work.
 
-Example of a configmap content if ModSecurity agents has IPs `192.168.100.99` and
+Example of a ConfigMap content if ModSecurity agents has IPs `192.168.100.99` and
 `192.168.100.100`:
 
 ```yaml

--- a/pkg/common/ingress/store/main.go
+++ b/pkg/common/ingress/store/main.go
@@ -58,13 +58,13 @@ func (sl *SecretLister) CreateOrUpdate(secret *apiv1.Secret) (err error) {
 	return err
 }
 
-// ConfigMapLister makes a Store that lists Configmaps.
+// ConfigMapLister makes a Store that lists ConfigMaps.
 type ConfigMapLister struct {
 	Client k8s.Interface
 	cache.Store
 }
 
-// GetByName searches for a configmap in the local configmaps Store
+// GetByName searches for a ConfigMap in the local ConfigMaps Store
 func (cml *ConfigMapLister) GetByName(name string) (*apiv1.ConfigMap, error) {
 	s, exists, err := cml.GetByKey(name)
 	if err != nil {


### PR DESCRIPTION
* As in the official Kubernetes documentation it is called `ConfigMap` and not `configmap`
* https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/