### PR TITLE
Add CN label in the cert_expire metric

### DIFF
--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"crypto/x509"
 	"fmt"
 	"strings"
 	"sync"
@@ -242,11 +243,11 @@ func (ic *GenericController) Start() {
 }
 
 // CreateDefaultSSLCertificate ...
-func (ic *GenericController) CreateDefaultSSLCertificate() (path, hash string, notAfter time.Time) {
+func (ic *GenericController) CreateDefaultSSLCertificate() (path, hash string, crt *x509.Certificate) {
 	defCert, defKey := ssl.GetFakeSSLCert()
 	c, err := ssl.AddOrUpdateCertAndKey("default-fake-certificate", defCert, defKey, []byte{})
 	if err != nil {
 		glog.Fatalf("Error generating self signed certificate: %v", err)
 	}
-	return c.PemFileName, c.PemSHA, c.Certificate.NotAfter
+	return c.PemFileName, c.PemSHA, c.Certificate
 }

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -149,9 +149,10 @@ func (c *cache) GetTLSSecretPath(defaultNamespace, secretName string) (file conv
 		return file, fmt.Errorf("secret '%s' does not have keys 'tls.crt' and 'tls.key'", fullname)
 	}
 	file = convtypes.CrtFile{
-		Filename: sslCert.PemFileName,
-		SHA1Hash: sslCert.PemSHA,
-		NotAfter: sslCert.Certificate.NotAfter,
+		Filename:   sslCert.PemFileName,
+		SHA1Hash:   sslCert.PemSHA,
+		CommonName: sslCert.Certificate.Subject.CommonName,
+		NotAfter:   sslCert.Certificate.NotAfter,
 	}
 	return file, nil
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -163,11 +163,12 @@ func (hc *HAProxyController) createDefaultSSLFile(cache convtypes.Cache) (tlsFil
 	} else {
 		glog.Info("using auto generated fake certificate")
 	}
-	path, hash, notAfter := hc.controller.CreateDefaultSSLCertificate()
+	path, hash, crt := hc.controller.CreateDefaultSSLCertificate()
 	tlsFile = convtypes.CrtFile{
-		Filename: path,
-		SHA1Hash: hash,
-		NotAfter: notAfter,
+		Filename:   path,
+		SHA1Hash:   hash,
+		CommonName: crt.Subject.CommonName,
+		NotAfter:   crt.NotAfter,
 	}
 	return tlsFile
 }

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -91,7 +91,7 @@ func createMetrics() *metrics {
 				Name:      "cert_expire_date_epoch",
 				Help:      "The SSL certificate expiration date in unix epoch time.",
 			},
-			[]string{"hostname"},
+			[]string{"domain", "cn"},
 		),
 	}
 	prometheus.MustRegister(metrics.responseTime)
@@ -145,6 +145,6 @@ func (m *metrics) UpdateSuccessful(success bool) {
 	m.updateSuccessGauge.WithLabelValues().Set(value[success])
 }
 
-func (m *metrics) SetCertExpireDate(hostname string, notAfter time.Time) {
-	m.certExpireGauge.WithLabelValues(hostname).Set(float64(notAfter.Unix()))
+func (m *metrics) SetCertExpireDate(domain, cn string, notAfter time.Time) {
+	m.certExpireGauge.WithLabelValues(domain, cn).Set(float64(notAfter.Unix()))
 }

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -145,6 +145,10 @@ func (m *metrics) UpdateSuccessful(success bool) {
 	m.updateSuccessGauge.WithLabelValues().Set(value[success])
 }
 
-func (m *metrics) SetCertExpireDate(domain, cn string, notAfter time.Time) {
+func (m *metrics) SetCertExpireDate(domain, cn string, notAfter *time.Time) {
+	if notAfter == nil {
+		m.certExpireGauge.DeleteLabelValues(domain, cn)
+		return
+	}
 	m.certExpireGauge.WithLabelValues(domain, cn).Set(float64(notAfter.Unix()))
 }

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -106,9 +106,10 @@ func (c *CacheMock) GetTLSSecretPath(defaultNamespace, secretName string) (convt
 	fullname := c.buildSecretName(defaultNamespace, secretName)
 	if path, found := c.SecretTLSPath[fullname]; found {
 		return convtypes.CrtFile{
-			Filename: path,
-			SHA1Hash: fmt.Sprintf("%x", sha1.Sum([]byte(path))),
-			NotAfter: time.Now().AddDate(0, 0, 30),
+			Filename:   path,
+			SHA1Hash:   fmt.Sprintf("%x", sha1.Sum([]byte(path))),
+			CommonName: "localhost.localdomain",
+			NotAfter:   time.Now().AddDate(0, 0, 30),
 		}, nil
 	}
 	return convtypes.CrtFile{}, fmt.Errorf("secret not found: '%s'", fullname)

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -144,6 +144,7 @@ func (c *converter) syncIngress(ing *extensions.Ingress) {
 					if host.TLS.TLSHash == "" {
 						host.TLS.TLSFilename = tlsPath.Filename
 						host.TLS.TLSHash = tlsPath.SHA1Hash
+						host.TLS.TLSCommonName = tlsPath.CommonName
 						host.TLS.TLSNotAfter = tlsPath.NotAfter
 					} else if host.TLS.TLSHash != tlsPath.SHA1Hash {
 						msg := fmt.Sprintf("TLS of host '%s' was already assigned", host.Hostname)

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -1165,9 +1165,10 @@ func (c *testConfig) SyncDef(config map[string]string, ing ...*extensions.Ingres
 			DefaultConfig:  defaultConfig,
 			DefaultBackend: "system/default",
 			DefaultSSLFile: convtypes.CrtFile{
-				Filename: "/tls/tls-default.pem",
-				SHA1Hash: "1",
-				NotAfter: time.Now().AddDate(0, 0, 30),
+				Filename:   "/tls/tls-default.pem",
+				SHA1Hash:   "1",
+				CommonName: "localhost.localdomain",
+				NotAfter:   time.Now().AddDate(0, 0, 30),
 			},
 			AnnotationPrefix: "ingress.kubernetes.io",
 		},

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -42,7 +42,8 @@ type File struct {
 
 // CrtFile ...
 type CrtFile struct {
-	Filename string
-	SHA1Hash string
-	NotAfter time.Time
+	Filename   string
+	SHA1Hash   string
+	CommonName string
+	NotAfter   time.Time
 }

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -306,12 +306,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 		}
 		return
 	}
-	// A future implementation of ssl certs dynamic update should change this metric
-	for _, host := range i.curConfig.Hosts() {
-		if host.TLS.TLSHash != "" {
-			i.metrics.SetCertExpireDate(host.Hostname, host.TLS.TLSCommonName, host.TLS.TLSNotAfter)
-		}
-	}
+	i.updateCertExpiring()
 	i.metrics.IncUpdateFull()
 	if err := i.reload(); err != nil {
 		i.logger.Error("error reloading server:\n%v", err)
@@ -321,6 +316,36 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 	timer.Tick("reload_haproxy")
 	i.metrics.UpdateSuccessful(true)
 	i.logger.Info("HAProxy successfully reloaded")
+}
+
+func (i *instance) updateCertExpiring() {
+	// TODO move to dynupdate when dynamic crt update is implemented
+	if i.oldConfig == nil {
+		for _, curHost := range i.curConfig.Hosts() {
+			if curHost.TLS.HasTLS() {
+				i.metrics.SetCertExpireDate(curHost.Hostname, curHost.TLS.TLSCommonName, &curHost.TLS.TLSNotAfter)
+			}
+		}
+		return
+	}
+	for _, oldHost := range i.oldConfig.Hosts() {
+		if !oldHost.TLS.HasTLS() {
+			continue
+		}
+		curHost := i.curConfig.FindHost(oldHost.Hostname)
+		if curHost == nil || oldHost.TLS.TLSCommonName != curHost.TLS.TLSCommonName {
+			i.metrics.SetCertExpireDate(oldHost.Hostname, oldHost.TLS.TLSCommonName, nil)
+		}
+	}
+	for _, curHost := range i.curConfig.Hosts() {
+		if !curHost.TLS.HasTLS() {
+			continue
+		}
+		oldHost := i.oldConfig.FindHost(curHost.Hostname)
+		if oldHost == nil || oldHost.TLS.TLSCommonName != curHost.TLS.TLSCommonName {
+			i.metrics.SetCertExpireDate(curHost.Hostname, curHost.TLS.TLSCommonName, &curHost.TLS.TLSNotAfter)
+		}
+	}
 }
 
 func (i *instance) check() error {

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -309,7 +309,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 	// A future implementation of ssl certs dynamic update should change this metric
 	for _, host := range i.curConfig.Hosts() {
 		if host.TLS.TLSHash != "" {
-			i.metrics.SetCertExpireDate(host.Hostname, host.TLS.TLSNotAfter)
+			i.metrics.SetCertExpireDate(host.Hostname, host.TLS.TLSCommonName, host.TLS.TLSNotAfter)
 		}
 	}
 	i.metrics.IncUpdateFull()

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -358,6 +358,7 @@ type HostTLSConfig struct {
 	CAVerifyOptional bool
 	CRLFilename      string
 	CRLHash          string
+	TLSCommonName    string
 	TLSFilename      string
 	TLSHash          string
 	TLSNotAfter      time.Time

--- a/pkg/types/helper_test/metricsmock.go
+++ b/pkg/types/helper_test/metricsmock.go
@@ -66,5 +66,5 @@ func (m *MetricsMock) UpdateSuccessful(success bool) {
 }
 
 // SetCertExpireDate ...
-func (m *MetricsMock) SetCertExpireDate(domain, cn string, notAfter time.Time) {
+func (m *MetricsMock) SetCertExpireDate(domain, cn string, notAfter *time.Time) {
 }

--- a/pkg/types/helper_test/metricsmock.go
+++ b/pkg/types/helper_test/metricsmock.go
@@ -66,5 +66,5 @@ func (m *MetricsMock) UpdateSuccessful(success bool) {
 }
 
 // SetCertExpireDate ...
-func (m *MetricsMock) SetCertExpireDate(hostname string, notAfter time.Time) {
+func (m *MetricsMock) SetCertExpireDate(domain, cn string, notAfter time.Time) {
 }

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -30,5 +30,5 @@ type Metrics interface {
 	IncUpdateDynamic()
 	IncUpdateFull()
 	UpdateSuccessful(success bool)
-	SetCertExpireDate(hostname string, notAfter time.Time)
+	SetCertExpireDate(domain, cn string, notAfter time.Time)
 }

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -30,5 +30,5 @@ type Metrics interface {
 	IncUpdateDynamic()
 	IncUpdateFull()
 	UpdateSuccessful(success bool)
-	SetCertExpireDate(domain, cn string, notAfter time.Time)
+	SetCertExpireDate(domain, cn string, notAfter *time.Time)
 }


### PR DESCRIPTION
More than one domain could share the same certificate. The CN label is a good candidate to be used as the aggregation field

Old `hostname` label was changed to `domain` to avoid conflict.