### PR TITLE
Change unix sockets user to haproxy

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -652,6 +652,7 @@ func TestInstanceEmpty(t *testing.T) {
 	c.checkConfig(`
 global
     daemon
+    unix-bind user haproxy group haproxy mode 0600
     stats socket /var/run/haproxy.sock level admin expose-fd listeners mode 600
     maxconn 2000
     hard-stop-after 15m
@@ -2065,6 +2066,7 @@ func TestInstanceSyslog(t *testing.T) {
 	c.checkConfig(`
 global
     daemon
+    unix-bind user haproxy group haproxy mode 0600
     stats socket /var/run/haproxy.sock level admin expose-fd listeners mode 600
     maxconn 2000
     hard-stop-after 15m
@@ -2977,6 +2979,7 @@ func (c *testConfig) checkConfig(expected string) {
 	replace := map[string]string{
 		"<<global>>": `global
     daemon
+    unix-bind user haproxy group haproxy mode 0600
     stats socket /var/run/haproxy.sock level admin expose-fd listeners mode 600
     maxconn 2000
     hard-stop-after 15m

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -14,6 +14,7 @@ global
     user haproxy
     group haproxy
 {{- end }}
+    unix-bind user haproxy group haproxy mode 0600
 {{- if $global.UseChroot }}
     chroot /var/empty
 {{- end }}


### PR DESCRIPTION
The internal ACME server (answer ACME challenges) and the http frontend (only if internal fronting TCP proxy is needed) uses unix sockets to the haproxy process communicate with. If the controller starts as root but `use-haproxy-user` is declared, haproxy wouldn't have permission to write to the socket. Now all sockets has `haproxy` as owner and `0600` as its permission, even if the process continue to run as root.