### PR TITLE
Sort tcp services by name and port

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -102,7 +102,12 @@ func (c *config) AcquireTCPBackend(servicename string, port int) *hatypes.TCPBac
 	}
 	c.tcpbackends = append(c.tcpbackends, backend)
 	sort.Slice(c.tcpbackends, func(i, j int) bool {
-		return c.tcpbackends[i].Name < c.tcpbackends[j].Name
+		back1 := c.tcpbackends[i]
+		back2 := c.tcpbackends[j]
+		if back1.Name == back2.Name {
+			return back1.Port < back2.Port
+		}
+		return back1.Name < back2.Name
 	})
 	return backend
 }


### PR DESCRIPTION
HAProxy Ingress compares old and cur configuration objects to detect if an apiserver notification is in fact a configuration change. This will only work properly if slices are always in the same order. TCP services were being sorted only by name, which will lead to random restarts if only the port number changes. This happens because the source of the data is a `configmap.data[]` which is a map.

Fixes #493