### PR TITLE
Add ssl-redirect-code global config key

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -210,6 +210,7 @@ The table below describes all supported configuration keys.
 | [`ssl-passthrough`](#ssl-passthrough)                | [true\|false]                           | Host    |                    |
 | [`ssl-passthrough-http-port`](#ssl-passthrough)      | backend port                            | Host    |                    |
 | [`ssl-redirect`](#ssl-redirect)                      | [true\|false]                           | Backend | `true`             |
+| [`ssl-redirect-code`](#ssl-redirect)                 | http status code                        | Global  | `302`              |
 | [`stats-auth`](#stats)                               | user:passwd                             | Global  | no auth            |
 | [`stats-port`](#stats)                               | port number                             | Global  | `1936`             |
 | [`stats-proxy-protocol`](#stats)                     | [true\|false]                           | Global  | `false`            |
@@ -1503,11 +1504,17 @@ If using SSL passthrough, only root `/` path is supported.
 |-----------------------------|-----------|-------------------------------|-------|
 | `no-tls-redirect-locations` | `Global`  | `/.well-known/acme-challenge` |       |
 | `ssl-redirect`              | `Backend` | `true`                        |       |
+| `ssl-redirect-code`         | `Global`  | `302`                         | v0.10 |
 
 Configures if an encripted connection should be used.
 
 * `ssl-redirect`: Defines if HAProxy should send a `302 redirect` response to requests made on unencripted connections. Note that this configuration will only make effect if TLS is [configured](https://github.com/jcmoraisjr/haproxy-ingress/tree/master/examples/tls-termination).
+* `ssl-redirect-code`: Defines the HTTP status code used in the redirect. The default value is `302` if not declared. Supported values are `301`, `302`, `303`, `307` and `308`.
 * `no-tls-redirect-locations`: Defines a comma-separated list of URLs that should be removed from the TLS redirect. Requests to `:80` http port and starting with one of the URLs from the list will not be redirected to https despite of the TLS redirect configuration. This option defaults to `/.well-known/acme-challenge`, used by ACME protocol.
+
+See also:
+
+* http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#redirect
 
 ---
 

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -111,6 +111,7 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.Cookie.Key = mapper.Get(ingtypes.GlobalCookieKey).Value
 	d.global.LoadServerState = mapper.Get(ingtypes.GlobalLoadServerState).Bool()
 	d.global.SSL.ALPN = mapper.Get(ingtypes.GlobalTLSALPN).Value
+	d.global.SSL.RedirectCode = mapper.Get(ingtypes.GlobalSSLRedirectCode).Int()
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseChroot = mapper.Get(ingtypes.GlobalUseChroot).Bool()
 	d.global.UseHAProxyUser = mapper.Get(ingtypes.GlobalUseHAProxyUser).Bool()

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -70,6 +70,7 @@ const (
 	GlobalSSLHeadersPrefix             = "ssl-headers-prefix"
 	GlobalSSLModeAsync                 = "ssl-mode-async"
 	GlobalSSLOptions                   = "ssl-options"
+	GlobalSSLRedirectCode              = "ssl-redirect-code"
 	GlobalStatsAuth                    = "stats-auth"
 	GlobalStatsPort                    = "stats-port"
 	GlobalStatsProxyProtocol           = "stats-proxy-protocol"

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -116,6 +116,7 @@ type SSLConfig struct {
 	HeadersPrefix       string
 	ModeAsync           bool
 	Options             string
+	RedirectCode        int
 }
 
 // DHParamConfig ...

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -703,8 +703,9 @@ frontend _front_http
 
 {{- /*------------------------------------*/}}
 {{- if $hasFrontingProxy }}
-    http-request redirect scheme https if
-        {{- "" }} fronting-proxy !{ hdr(X-Forwarded-Proto) https }
+    http-request redirect scheme https
+        {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
+        {{- "" }} if fronting-proxy !{ hdr(X-Forwarded-Proto) https }
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -722,16 +723,19 @@ frontend _front_http
         {{- "" }} var(req.base),map_beg({{ $fgroup.HTTPSRedirMap.MatchFile }})
         {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
     http-request redirect scheme https
+        {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
         {{- "" }} if{{ if $acmeexclusive }} !acme-challenge{{ end }}
         {{- if $hasFrontingProxy }} !fronting-proxy{{ end }}
         {{- "" }} { var(req.redir) yes }
     http-request redirect scheme https
+        {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
         {{- "" }} if{{ if $acmeexclusive }} !acme-challenge{{ end }}
         {{- if $hasFrontingProxy }} !fronting-proxy{{ end }}
         {{- "" }} !{ var(req.redir) -m found }
         {{- "" }} { var(req.base),map_reg({{ $fgroup.HTTPSRedirMap.RegexFile }}) yes }
 {{- else }}
     http-request redirect scheme https
+        {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
         {{- "" }} if{{ if $acmeexclusive }} !acme-challenge{{ end }}
         {{- if $hasFrontingProxy }} !fronting-proxy{{ end }}
         {{- "" }} { var(req.base),map_beg({{ $fgroup.HTTPSRedirMap.MatchFile }}) yes }


### PR DESCRIPTION
A global configuration used to override default scheme redirect.

This cannot be done as annotation in the current version because redirect code does not support `%[var()]`. In a future version, maybe v0.11, some frontend stuff will be moved to haproxy's backends so this config can be revisited and improved.