### PR TITLE
Remove haproxy warning filter

### DIFF
--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -354,7 +354,7 @@ func (i *instance) check() error {
 		return nil
 	}
 	out, err := exec.Command(i.options.HAProxyCmd, "-c", "-f", i.options.HAProxyConfigFile).CombinedOutput()
-	outstr := filterOutput(out)
+	outstr := string(out)
 	if err != nil {
 		return fmt.Errorf(outstr)
 	}
@@ -367,7 +367,7 @@ func (i *instance) reload() error {
 		return nil
 	}
 	out, err := exec.Command(i.options.ReloadCmd, i.options.ReloadStrategy, i.options.HAProxyConfigFile).CombinedOutput()
-	outstr := filterOutput(out)
+	outstr := string(out)
 	if len(outstr) > 0 {
 		i.logger.Warn("output from haproxy:\n%v", outstr)
 	}
@@ -375,18 +375,6 @@ func (i *instance) reload() error {
 		return err
 	}
 	return nil
-}
-
-func filterOutput(out []byte) string {
-	// workaround a misplaced warn from haproxy until the fix is merged
-	skip := "contains no embedded dots nor does not start with a dot"
-	outstr := ""
-	for _, line := range strings.Split(string(out), "\n") {
-		if line != "" && strings.Index(line, skip) < 0 {
-			outstr += line + "\n"
-		}
-	}
-	return outstr
 }
 
 func (i *instance) rotateConfig() {


### PR DESCRIPTION
An output filter was added since `session-cookie-shared` config key due to a misplaced haproxy warning. This was already fixed and new releases were issued on all supported haproxy versions, so no need to filter anymore.

Should be applied up to v0.8.