### PR TITLE
Add ssl-fingerprint-lower config key

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -203,6 +203,7 @@ The table below describes all supported configuration keys.
 | [`ssl-dh-default-max-size`](#ssl-dh)                 | number                                  | Global  | `1024`             |
 | [`ssl-dh-param`](#ssl-dh)                            | namespace/secret name                   | Global  | no custom DH param |
 | [`ssl-engine`](#ssl-engine)                          | OpenSSL engine name and parameters      | Global  | no engine set      |
+| [`ssl-fingerprint-lower`](#auth-tls)                 | [true\|false]                           | Backend | `false`            |
 | [`ssl-headers-prefix`](#auth-tls)                    | prefix                                  | Global  | `X-SSL`            |
 | [`ssl-mode-async`](#ssl-engine)                      | [true\|false]                           | Global  | `false`            |
 | [`ssl-options`](#ssl-options)                        | space-separated list                    | Global  | [see description](#ssl-options) |
@@ -415,12 +416,13 @@ See also:
 | `auth-tls-error-page`    | `Host`    |         |       |
 | `auth-tls-secret`        | `Host`    |         |       |
 | `auth-tls-verify-client` | `Host`    |         |       |
+| `ssl-fingerprint-lower`  | `Backend` | `false` | v0.10 |
 | `ssl-headers-prefix`     | `Global`  | `X-SSL` |       |
 
 Configure client authentication with X509 certificate. The following headers are
 added to the request:
 
-* `X-SSL-Client-SHA1`: Hex encoding of the SHA-1 fingerprint of the X509 certificate
+* `X-SSL-Client-SHA1`: Hex encoding of the SHA-1 fingerprint of the X509 certificate. The default output uses uppercase hexadecimal digits, configure `ssl-fingerprint-lower` to `true` to use lowercase digits instead.
 * `X-SSL-Client-DN`: Distinguished name of the certificate
 * `X-SSL-Client-CN`: Common name of the certificate
 
@@ -434,6 +436,7 @@ The following keys are supported:
 * `auth-tls-error-page`: Optional URL of the page to redirect the user if he doesn't provide a certificate or the certificate is invalid.
 * `auth-tls-secret`: Mandatory secret name with `ca.crt` key providing all certificate authority bundles used to validate client certificates. Since v0.9, an optional `ca.crl` key can also provide a CRL in PEM format for the server to verify against.
 * `auth-tls-verify-client`: Optional configuration of Client Verification behavior. Supported values are `off`, `on`, `optional` and `optional_no_ca`. The default value is `on` if a valid secret is provided, `off` otherwise.
+* `ssl-fingerprint-lower`: Defines if the certificate fingerprint should be in lowercase hexadecimal digits. The default value is `false`, which uses uppercase digits.
 * `ssl-headers-prefix`: Configures which prefix should be used on HTTP headers. Since [RFC 6648](https://tools.ietf.org/html/rfc6648) `X-` prefix on unstandardized headers changed from a convention to deprecation. This configuration allows to select which pattern should be used on header names.
 
 See also:

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -687,6 +687,7 @@ func (c *updater) buildBackendServerNaming(d *backData) {
 
 func (c *updater) buildBackendSSL(d *backData) {
 	d.backend.TLS.AddCertHeader = d.mapper.Get(ingtypes.BackAuthTLSCertHeader).Bool()
+	d.backend.TLS.FingerprintLower = d.mapper.Get(ingtypes.BackSSLFingerprintLower).Bool()
 	if cfg := d.mapper.Get(ingtypes.BackSSLCiphersBackend); cfg.Source != nil {
 		d.backend.Server.Ciphers = cfg.Value
 	}

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -113,6 +113,7 @@ const (
 	BackSessionCookieStrategy  = "session-cookie-strategy"
 	BackSSLCipherSuitesBackend = "ssl-cipher-suites-backend"
 	BackSSLCiphersBackend      = "ssl-ciphers-backend"
+	BackSSLFingerprintLower    = "ssl-fingerprint-lower"
 	BackSSLOptionsBackend      = "ssl-options-backend"
 	BackSSLRedirect            = "ssl-redirect"
 	BackTimeoutConnect         = "timeout-connect"

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1273,6 +1273,7 @@ func TestInstanceSingleFrontendTwoBindsCA(t *testing.T) {
 
 	b.SSLRedirect = b.CreateConfigBool(true)
 	b.TLS.AddCertHeader = true
+	b.TLS.FingerprintLower = true
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 
 	c.Update()
@@ -1284,7 +1285,7 @@ backend d_app_8080
     acl local-offload ssl_fc
     http-request set-header X-SSL-Client-CN   %{+Q}[ssl_c_s_dn(cn)]
     http-request set-header X-SSL-Client-DN   %{+Q}[ssl_c_s_dn]
-    http-request set-header X-SSL-Client-SHA1 %{+Q}[ssl_c_sha1,hex]
+    http-request set-header X-SSL-Client-SHA1 %{+Q}[ssl_c_sha1,hex,lower]
     http-request set-header X-SSL-Client-Cert %{+Q}[ssl_c_der,base64]
     server s1 172.17.0.11:8080 weight 100
 backend _default_backend

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -589,8 +589,9 @@ type BackendTimeoutConfig struct {
 
 // BackendTLSConfig ...
 type BackendTLSConfig struct {
-	AddCertHeader bool
-	HasTLSAuth    bool
+	AddCertHeader    bool
+	FingerprintLower bool
+	HasTLSAuth       bool
 }
 
 // UserlistConfig ...

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -369,7 +369,9 @@ backend {{ $backend.ID }}
 {{- $needSSLACL := not $backend.HasSSLRedirect }}
     http-request set-header {{ $global.SSL.HeadersPrefix }}-Client-CN   %{+Q}[ssl_c_s_dn(cn)]{{ if $needSSLACL }}   if local-offload{{ end }}
     http-request set-header {{ $global.SSL.HeadersPrefix }}-Client-DN   %{+Q}[ssl_c_s_dn]{{ if $needSSLACL }}       if local-offload{{ end }}
-    http-request set-header {{ $global.SSL.HeadersPrefix }}-Client-SHA1 %{+Q}[ssl_c_sha1,hex]{{ if $needSSLACL }}   if local-offload{{ end }}
+    http-request set-header {{ $global.SSL.HeadersPrefix }}-Client-SHA1 %{+Q}[ssl_c_sha1,hex
+        {{- if $backend.TLS.FingerprintLower }},lower{{ end }}]
+        {{- if $needSSLACL }}   if local-offload{{ end }}
 {{- if $backend.TLS.AddCertHeader }}
     http-request set-header {{ $global.SSL.HeadersPrefix }}-Client-Cert %{+Q}[ssl_c_der,base64]{{ if $needSSLACL }} if local-offload{{ end }}
 {{- end }}


### PR DESCRIPTION
Adds the ability to convert the sha1 hash of the x509 certificate fingerprint, presented in hexadecimal, to lowercase digits. The default is to use uppercase digits.