### PR TITLE
Create frontends even without ingress

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -234,9 +234,6 @@ func (c *config) FrontendGroup() *hatypes.FrontendGroup {
 func (c *config) BuildFrontendGroup() error {
 	// tested thanks to instance_test templating tests
 	// ideas to make a nice test or a nice refactor are welcome
-	if len(c.hosts) == 0 {
-		return nil
-	}
 	frontends, sslpassthrough, defaultBind := hatypes.BuildRawFrontends(c.hosts)
 	fgroupMaps := hatypes.CreateMaps()
 	fgroup := &hatypes.FrontendGroup{

--- a/pkg/haproxy/config_test.go
+++ b/pkg/haproxy/config_test.go
@@ -25,8 +25,8 @@ func TestEmptyFrontend(t *testing.T) {
 	if err := c.BuildFrontendGroup(); err != nil {
 		t.Errorf("error creating frontends: %v", err)
 	}
-	if fg := c.FrontendGroup(); fg != nil {
-		t.Error("expected FrontendGroup == nil")
+	if fg := c.FrontendGroup(); fg == nil {
+		t.Error("expected FrontendGroup != nil")
 	}
 	c.AcquireHost("empty")
 	if err := c.BuildFrontendGroup(); err != nil {

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -912,8 +912,7 @@ func TestInstanceTCPBackend(t *testing.T) {
 listen _tcp_postgresql_5432
     bind :5432
     mode tcp
-    server srv001 172.17.0.2:5432
-`,
+    server srv001 172.17.0.2:5432`,
 		},
 		// 1
 		{
@@ -928,8 +927,7 @@ listen _tcp_pq_5432
     bind :5432
     mode tcp
     server srv001 172.17.0.2:5432 check port 5432 inter 2s
-    server srv002 172.17.0.3:5432 check port 5432 inter 2s
-`,
+    server srv002 172.17.0.3:5432 check port 5432 inter 2s`,
 		},
 		// 2
 		{
@@ -943,8 +941,7 @@ listen _tcp_pq_5432
 listen _tcp_pq_5432
     bind :5432 ssl crt /var/haproxy/ssl/pq.pem
     mode tcp
-    server srv001 172.17.0.2:5432 send-proxy-v2
-`,
+    server srv001 172.17.0.2:5432 send-proxy-v2`,
 		},
 		// 3
 		{
@@ -961,15 +958,25 @@ listen _tcp_pq_5432
 listen _tcp_pq_5432
     bind 127.0.0.1:5432 ssl crt /var/haproxy/ssl/pq.pem accept-proxy
     mode tcp
-    server srv001 172.17.0.2:5432 check port 5432 inter 2s send-proxy
-`,
+    server srv001 172.17.0.2:5432 check port 5432 inter 2s send-proxy`,
 		},
 	}
 	for _, test := range testCases {
 		c := setup(t)
 		test.doconfig(c)
 		c.Update()
-		c.checkConfig("<<global>>\n<<defaults>>" + test.expected + "<<support>>")
+		c.checkConfig(`
+<<global>>
+<<defaults>>` + test.expected + `
+backend _error404
+    mode http
+    http-request use-service lua.send-404
+<<frontend-http>>
+    default_backend _error404
+<<frontend-https>>
+    default_backend _error404
+<<support>>
+`)
 		logging := test.logging
 		if logging == "" {
 			logging = defaultLogging
@@ -2449,6 +2456,13 @@ frontend prometheus
 		c.checkConfig(`
 <<global>>
 <<defaults>>
+backend _error404
+    mode http
+    http-request use-service lua.send-404
+<<frontend-http>>
+    default_backend _error404
+<<frontend-https>>
+    default_backend _error404
 listen stats
     mode http` + test.expectedStats + `
     stats enable

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -190,9 +190,6 @@ func (f *Frontend) HasMaxBody() bool {
 
 // BuildRawFrontends ...
 func BuildRawFrontends(hosts []*Host) (frontends []*Frontend, sslpassthrough []*Host, defaultBind *BindConfig) {
-	if len(hosts) == 0 {
-		return nil, nil, nil
-	}
 	// creating frontends and ssl-passthrough hosts
 	for _, host := range hosts {
 		if host.SSLPassthrough {

--- a/pkg/haproxy/types/frontend_test.go
+++ b/pkg/haproxy/types/frontend_test.go
@@ -68,8 +68,8 @@ func TestAppendHostname(t *testing.T) {
 
 func TestBuildFrontendEmpty(t *testing.T) {
 	frontends, _, _ := BuildRawFrontends([]*Host{})
-	if len(frontends) > 0 {
-		t.Errorf("expected len(frontends) == 0, but was %d", len(frontends))
+	if len(frontends) != 1 {
+		t.Errorf("expected len(frontends) == 1, but was %d", len(frontends))
 	}
 }
 

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -572,7 +572,7 @@ backend _acme_challenge
     server _acme_server unix@{{ $cfg.Acme.Socket }}
 {{- end }}
 
-{{- if and $cfg.Backends (not $cfg.DefaultBackend) }}
+{{- if not $cfg.DefaultBackend }}
 
   # # # # # # # # # # # # # # # # # # #
 # #


### PR DESCRIPTION
Fixes a wrong assumption that a frontend need at least one ingress to be configured. Instead, a frontend should always be configured and issue a 404 page, since any host could be matched.

This also fixes configurations whose ingress objects have empty host - empty or wildcard `*` hosts are used to configure or overwrite the default backend without create a proper host entry, and were falling back in the same problem of not create the frontend.