### PR TITLE
Fix TLS handshake on backend

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -382,10 +382,23 @@ func TestBackends(t *testing.T) {
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
 				b.Server.Protocol = "h2"
+			},
+			srvsuffix: "proto h2",
+		},
+		{
+			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
+				b.Server.Protocol = "h2"
+				b.Server.Secure = true
+			},
+			srvsuffix: "proto h2 alpn h2 ssl verify none",
+		},
+		{
+			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
+				b.Server.Protocol = "h2"
 				b.Server.Secure = true
 				b.Server.CAFilename = "/var/haproxy/ssl/ca.pem"
 			},
-			srvsuffix: "proto h2 ssl verify required ca-file /var/haproxy/ssl/ca.pem",
+			srvsuffix: "proto h2 alpn h2 ssl verify required ca-file /var/haproxy/ssl/ca.pem",
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -533,7 +533,9 @@ backend {{ $backend.ID }}
 {{- define "backend" }}
     {{- $backend := .p1 }}
     {{- $server := $backend.Server }}
-    {{- if eq $server.Protocol "h2" }} proto h2{{ end }}
+    {{- if eq $server.Protocol "h2" }} proto h2
+        {{- if $server.Secure }} alpn h2{{ end }}
+    {{- end }}
     {{- if $server.MaxConn }} maxconn {{ $server.MaxConn }}{{ end }}
     {{- if $server.MaxQueue }} maxqueue {{ $server.MaxQueue }}{{ end }}
     {{- if $server.Secure }} ssl


### PR DESCRIPTION
A secure h2 connection to the backend was broken due to the missing `alpn` keyword. The protocol was correctly configured as `h2` but the TLS handshake was using the default alpn config which is `http1.1`.