### PR TITLE
Update crt metric if date changes

### DIFF
--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -342,7 +342,7 @@ func (i *instance) updateCertExpiring() {
 			continue
 		}
 		oldHost := i.oldConfig.FindHost(curHost.Hostname)
-		if oldHost == nil || oldHost.TLS.TLSCommonName != curHost.TLS.TLSCommonName {
+		if oldHost == nil || oldHost.TLS.TLSCommonName != curHost.TLS.TLSCommonName || oldHost.TLS.TLSNotAfter != curHost.TLS.TLSNotAfter {
 			i.metrics.SetCertExpireDate(curHost.Hostname, curHost.TLS.TLSCommonName, &curHost.TLS.TLSNotAfter)
 		}
 	}


### PR DESCRIPTION
Ensures that the x509 certificate expiring metric is updated if a new certificate is issued.