### PR TITLE
GlobalSSLRedirectCode was missing a default value

### DIFF
--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -89,6 +89,7 @@ func createDefaults() map[string]string {
 		types.GlobalSSLDHDefaultMaxSize:          "2048",
 		types.GlobalSSLHeadersPrefix:             "X-SSL",
 		types.GlobalSSLOptions:                   defaultSSLOptions,
+		types.GlobalSSLRedirectCode:              "302",
 		types.GlobalStatsPort:                    "1936",
 		types.GlobalSyslogFormat:                 "rfc5424",
 		types.GlobalSyslogLength:                 "1024",


### PR DESCRIPTION
This caused the haproxy.tmpl rendering to fail unless `ssl-redirect-code` was
specified by the user.