### PR TITLE
Clear acme work queue on stopped leading

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -197,11 +197,13 @@ func (hc *HAProxyController) OnStartedLeading(ctx context.Context) {
 // OnStoppedLeading ...
 // implements LeaderSubscriber
 func (hc *HAProxyController) OnStoppedLeading() {
+	hc.acmeQueue.Clear()
 }
 
 // OnNewLeader ...
 // implements LeaderSubscriber
 func (hc *HAProxyController) OnNewLeader(identity string) {
+	hc.logger.Info("leader changed to %s", identity)
 }
 
 // Stop shutdown the controller process


### PR DESCRIPTION
A work queue used to process certificate sign should be cleared when leaving the leader. Since k8s' work queue cannot be cleared or stopped, the work queue facade implemented a remove+recreate work queue reusing the same `Run()` event loop.