### PR TITLE
restart the leader elector when stop leading

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -141,7 +141,7 @@ func (hc *HAProxyController) startServices() {
 		}, hc.cfg.StatsCollectProcPeriod, hc.stopCh)
 	}
 	if hc.leaderelector != nil {
-		go hc.leaderelector.Run()
+		go hc.leaderelector.Run(hc.stopCh)
 	}
 	if hc.cfg.AcmeServer {
 		// TODO deduplicate acme socket

--- a/pkg/types/leaderelector.go
+++ b/pkg/types/leaderelector.go
@@ -20,5 +20,5 @@ package types
 type LeaderElector interface {
 	IsLeader() bool
 	LeaderName() string
-	Run()
+	Run(stopCh <-chan struct{})
 }


### PR DESCRIPTION
Leader elector stops when the leader cannot update the leading status. This change adds the leader elector bootstrap into a loop so it will restart the acquiring process.