### PR TITLE
add buckets-response-time command-line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -20,6 +20,7 @@ The following command-line options are supported:
 | [`--acme-track-tls-annotation`](#acme)                  | [true\|false]              | `false`                 | v0.9 |
 | [`--allow-cross-namespace`](#allow-cross-namespace)     | [true\|false]              | `false`                 |       |
 | [`--annotation-prefix`](#annotation-prefix)             | prefix without `/`         | `ingress.kubernetes.io` | v0.8  |
+| [`--buckets-response-time`](#buckets-response-time)     | float64 slice           | `.0005,.001,.002,.005,.01` | v0.10 |
 | [`--default-backend-service`](#default-backend-service) | namespace/servicename      | haproxy's 404 page      |       |
 | [`--default-ssl-certificate`](#default-ssl-certificate) | namespace/secretname       | fake, auto generated    |       |
 | [`--healthz-port`](#stats)                              | port number                | `10254`                 |       |
@@ -78,6 +79,12 @@ objects. The default value is `ingress.kubernetes.io` if not declared, which mea
 should be configured with the annotation name `ingress.kubernetes.io/ssl-redirect`. Annotations
 with other prefix are ignored. This allows using HAProxy Ingress with other ingress controllers
 that shares ingress and service objects without conflicting each other.
+
+---
+
+## --buckets-response-time
+
+Configures the buckets of the histogram `haproxyingress_haproxy_response_time_seconds`, used to compute the response time of the haproxy's admin socket. The response time unit is in seconds.
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -79,6 +79,8 @@ type Configuration struct {
 	AcmeTokenConfigmapName  string
 	AcmeTrackTLSAnn         bool
 
+	BucketsResponseTime []float64
+
 	TCPConfigMapName       string
 	DefaultSSLCertificate  string
 	VerifyHostname         bool

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -79,6 +79,11 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		acmeTrackTLSAnn = flags.Bool("acme-track-tls-annotation", false,
 			`Enable tracking of ingress objects annotated with 'kubernetes.io/tls-acme'`)
 
+		bucketsResponseTime = flags.Float64Slice("buckets-response-time",
+			[]float64{.0005, .001, .002, .005, .01},
+			`Configures the buckets of the histogram used to compute the response time of the haproxy's admin socket.
+		The response time unit is in seconds.`)
+
 		publishSvc = flags.String("publish-service", "",
 			`Service fronting the ingress controllers. Takes the form
  		namespace/name. The controller will set the endpoint records on the
@@ -287,6 +292,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		AcmeSecretKeyName:         *acmeSecretKeyName,
 		AcmeTokenConfigmapName:    *acmeTokenConfigmapName,
 		AcmeTrackTLSAnn:           *acmeTrackTLSAnn,
+		BucketsResponseTime:       *bucketsResponseTime,
 		RateLimitUpdate:           *rateLimitUpdate,
 		ResyncPeriod:              *resyncPeriod,
 		DefaultService:            *defaultSvc,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -95,7 +95,7 @@ func (hc *HAProxyController) configController() {
 	hc.stopCh = hc.controller.GetStopCh()
 	hc.logger = &logger{depth: 1}
 	hc.cache = newCache(hc.cfg.Client, hc.storeLister, hc.controller)
-	hc.metrics = createMetrics()
+	hc.metrics = createMetrics(hc.cfg.BucketsResponseTime)
 	var acmeSigner acme.Signer
 	if hc.cfg.AcmeServer {
 		electorID := fmt.Sprintf("%s-%s", hc.cfg.AcmeElectionID, hc.cfg.IngressClass)

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -33,7 +33,7 @@ type metrics struct {
 	lastTrack          time.Time
 }
 
-func createMetrics() *metrics {
+func createMetrics(bucketsResponseTime []float64) *metrics {
 	namespace := "haproxyingress"
 	metrics := &metrics{
 		responseTime: prometheus.NewHistogramVec(
@@ -41,7 +41,7 @@ func createMetrics() *metrics {
 				Namespace: namespace,
 				Name:      "haproxy_response_time_seconds",
 				Help:      "Response time to commands sent via admin socket",
-				Buckets:   []float64{.0005, .001, .002, .005, .01},
+				Buckets:   bucketsResponseTime,
 			},
 			[]string{"command"},
 		),


### PR DESCRIPTION
A new command-line option `buckets-response-time` used to overwrite the buckets of the histogram `haproxyingress_haproxy_response_time_seconds`. Such histogram is used to compute the response time (seconds) of the haproxy's admin socket.