### PR TITLE
fix label naming of cert signing metric

### DIFF
--- a/pkg/acme/signer.go
+++ b/pkg/acme/signer.go
@@ -132,10 +132,10 @@ func (s *signer) verify(secretName string, domains []string) (verifyErr error) {
 			collector = s.metrics.IncCertSigningMissing
 			reason = "certificate does not exist"
 		} else if tls.Crt.NotAfter.Before(duedate) {
-			collector = s.metrics.IncCertSigningOutdated
+			collector = s.metrics.IncCertSigningExpiring
 			reason = fmt.Sprintf("certificate expires in %s", tls.Crt.NotAfter.String())
 		} else {
-			collector = s.metrics.IncCertSigningChangedDomains
+			collector = s.metrics.IncCertSigningOutdated
 			reason = "added one or more domains to an existing certificate"
 		}
 		s.verifyCount++

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -168,10 +168,10 @@ func (m *metrics) IncCertSigningMissing(domains string, success bool) {
 	m.certSigningCounter.WithLabelValues(domains, "missing", strconv.FormatBool(success)).Inc()
 }
 
-func (m *metrics) IncCertSigningOutdated(domains string, success bool) {
-	m.certSigningCounter.WithLabelValues(domains, "outdated", strconv.FormatBool(success)).Inc()
+func (m *metrics) IncCertSigningExpiring(domains string, success bool) {
+	m.certSigningCounter.WithLabelValues(domains, "expiring", strconv.FormatBool(success)).Inc()
 }
 
-func (m *metrics) IncCertSigningChangedDomains(domains string, success bool) {
-	m.certSigningCounter.WithLabelValues(domains, "changeddomains", strconv.FormatBool(success)).Inc()
+func (m *metrics) IncCertSigningOutdated(domains string, success bool) {
+	m.certSigningCounter.WithLabelValues(domains, "outdated", strconv.FormatBool(success)).Inc()
 }

--- a/pkg/types/helper_test/metricsmock.go
+++ b/pkg/types/helper_test/metricsmock.go
@@ -73,10 +73,10 @@ func (m *MetricsMock) SetCertExpireDate(domain, cn string, notAfter *time.Time) 
 func (m *MetricsMock) IncCertSigningMissing(domains string, success bool) {
 }
 
-// IncCertSigningOutdated ...
-func (m *MetricsMock) IncCertSigningOutdated(domains string, success bool) {
+// IncCertSigningExpiring ...
+func (m *MetricsMock) IncCertSigningExpiring(domains string, success bool) {
 }
 
-// IncCertSigningChangedDomains ...
-func (m *MetricsMock) IncCertSigningChangedDomains(domains string, success bool) {
+// IncCertSigningOutdated ...
+func (m *MetricsMock) IncCertSigningOutdated(domains string, success bool) {
 }

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -32,6 +32,6 @@ type Metrics interface {
 	UpdateSuccessful(success bool)
 	SetCertExpireDate(domain, cn string, notAfter *time.Time)
 	IncCertSigningMissing(domains string, success bool)
+	IncCertSigningExpiring(domains string, success bool)
 	IncCertSigningOutdated(domains string, success bool)
-	IncCertSigningChangedDomains(domains string, success bool)
 }


### PR DESCRIPTION
Use a proper label naming:

* `missing`: a new cert was issued because the current one wasn't found or was invalid
* `expiring`: the current cert expiring date is below the configured threshold
* `outdated`: the current cert doesn't fit the current spec, eg missing a domain