### PR TITLE
add external call to certificate check

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -202,6 +202,7 @@ Configures an endpoint with statistics, debugging and health checks. The followi
 
 * `/healthz`: a healthz URI for the haproxy-ingress
 * `/metrics`: Prometheus compatible metrics exporter
+* `/acme/check` (`POST`): starts check for missing, expiring or outdated certificates controlled by acme client. Should be issued in the leader.
 * `/debug/pprof`: profiling tools
 * `/build`: build information - controller name, version, git commit hash and repository
 * `/stop`: stops haproxy-ingress controller

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -333,6 +333,27 @@ func registerHandlers(enableProfiling bool, port int, ic *GenericController) {
 
 	mux.Handle("/metrics", promhttp.Handler())
 
+	mux.HandleFunc("/acme/check", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		var out string
+		count, err := ic.cfg.Backend.AcmeCheck()
+		if err != nil {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			out = fmt.Sprintf("Error starting the certificate check: %v.\nSee further information in the controller log.\n", err)
+		} else {
+			w.WriteHeader(http.StatusOK)
+			if count > 0 {
+				out = fmt.Sprintf("Acme check successfully started. Added %d certificate(s) in the processing queue.\n", count)
+			} else {
+				out = fmt.Sprintf("Acme certificate list is empty.\n")
+			}
+		}
+		w.Write([]byte(out))
+	})
+
 	mux.HandleFunc("/build", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		b, _ := json.Marshal(ic.Info())

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -52,6 +52,8 @@ type Controller interface {
 	SetListers(*StoreLister)
 	// Info returns information about the ingress controller
 	Info() *BackendInfo
+	// AcmeCheck starts a certificate missing/expiring/outdated check
+	AcmeCheck() (int, error)
 	// ConfigureFlags allow to configure more flags before the parsing of
 	// command line arguments
 	ConfigureFlags(*pflag.FlagSet)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -151,7 +151,9 @@ func (hc *HAProxyController) startServices() {
 			hc.logger.Fatal("error creating the acme server listener: %v", err)
 		}
 		go hc.acmeQueue.Run()
-		go wait.Until(hc.instance.AcmePeriodicCheck, hc.cfg.AcmeCheckPeriod, hc.stopCh)
+		go wait.JitterUntil(func() {
+			_, _ = hc.instance.AcmeCheck("periodic check")
+		}, hc.cfg.AcmeCheckPeriod, 0, false, hc.stopCh)
 	}
 }
 
@@ -188,10 +190,15 @@ func (hc *HAProxyController) createFakeCAFile() (crtFile convtypes.CrtFile) {
 	return crtFile
 }
 
+// AcmeCheck ...
+func (hc *HAProxyController) AcmeCheck() (int, error) {
+	return hc.instance.AcmeCheck("external call")
+}
+
 // OnStartedLeading ...
 // implements LeaderSubscriber
 func (hc *HAProxyController) OnStartedLeading(ctx context.Context) {
-	hc.instance.AcmePeriodicCheck()
+	_, _ = hc.instance.AcmeCheck("starting leader")
 }
 
 // OnStoppedLeading ...

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -49,7 +49,7 @@ type InstanceOptions struct {
 
 // Instance ...
 type Instance interface {
-	AcmePeriodicCheck()
+	AcmeCheck(source string) (int, error)
 	ParseTemplates() error
 	Config() Config
 	CalcIdleMetric()
@@ -79,21 +79,25 @@ type instance struct {
 	metrics      types.Metrics
 }
 
-func (i *instance) AcmePeriodicCheck() {
-	if i.oldConfig == nil || i.options.AcmeQueue == nil {
-		return
+func (i *instance) AcmeCheck(source string) (int, error) {
+	var count int
+	if i.oldConfig == nil {
+		return count, fmt.Errorf("controller wasn't started yet")
+	}
+	if i.options.AcmeQueue == nil {
+		return count, fmt.Errorf("Acme queue wasn't configured")
 	}
 	hasAccount := i.acmeEnsureConfig(i.oldConfig.AcmeData())
 	if !hasAccount {
-		return
+		return count, fmt.Errorf("Cannot create or retrieve the acme client account")
 	}
 	le := i.options.LeaderElector
 	if !le.IsLeader() {
-		i.logger.Info("skipping acme periodic check, leader is %s", le.LeaderName())
-		return
+		msg := fmt.Sprintf("skipping acme periodic check, leader is %s", le.LeaderName())
+		i.logger.Info(msg)
+		return count, fmt.Errorf(msg)
 	}
-	i.logger.Info("starting periodic certificate check")
-	var count int
+	i.logger.Info("starting certificate check (%s)", source)
 	for storage, domains := range i.oldConfig.AcmeData().Certs {
 		i.acmeAddCert(storage, domains)
 		count++
@@ -103,6 +107,7 @@ func (i *instance) AcmePeriodicCheck() {
 	} else {
 		i.logger.Info("finish adding %d certificate(s) to the work queue", count)
 	}
+	return count, nil
 }
 
 func (i *instance) acmeEnsureConfig(acmeConfig *hatypes.AcmeData) bool {


### PR DESCRIPTION
Added URI `POST /acme/check` which starts check for missing, expiring or outdated certificates controlled by acme client.