### PR TITLE
update to haproxy 2.1.4

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM haproxy:2.0.13-alpine
+FROM haproxy:2.1.4-alpine
 RUN apk --no-cache add socat openssl lua5.3 lua-socket dumb-init
 
 COPY . /


### PR DESCRIPTION
This update also fixes the HPACK decoder used for H2 connections.

See also:

* https://www.mail-archive.com/haproxy@formilux.org/msg36876.html
* https://github.com/haproxy/haproxy/commit/5dfc5d5cd0d2128d77253ead3acf03a421ab5b88
* https://nvd.nist.gov/vuln/detail/CVE-2020-11100