### PR TITLE
[security] [0.7] Update to HAproxy 1.8.25

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM haproxy:1.8.23-alpine
+FROM haproxy:1.8.25-alpine
 RUN apk --no-cache add socat openssl lua5.3 lua-socket
 
 # dumb-init kindly manages SIGCHLD from forked HAProxy processes


### PR DESCRIPTION
This fixes CVE-2020-11100 [as detailed here](https://github.com/haproxy/haproxy/commit/5dfc5d5cd0d2128d77253ead3acf03a421ab5b88).