### PR TITLE
Remove frontend group

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -563,7 +563,7 @@ func (c *updater) buildBackendOAuth(d *backData) {
 }
 
 func (c *updater) findBackend(namespace, uriPrefix string) *hatypes.HostBackend {
-	for _, host := range c.haproxy.Hosts() {
+	for _, host := range c.haproxy.Hosts().Items {
 		for _, path := range host.Paths {
 			if strings.TrimRight(path.Path, "/") == uriPrefix && path.Backend.Namespace == namespace {
 				return &path.Backend

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -1148,7 +1148,7 @@ func TestOAuth(t *testing.T) {
 		if test.backend != "" {
 			b := strings.Split(test.backend, ":")
 			backend := c.haproxy.AcquireBackend(b[0], b[1], "8080")
-			c.haproxy.AcquireHost("app.local").AddPath(backend, b[2])
+			c.haproxy.Hosts().AcquireHost("app.local").AddPath(backend, b[2])
 		}
 		c.createUpdater().buildBackendOAuth(d)
 		c.compareObjects("oauth", i, d.backend.OAuth, test.oauthExp)

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -180,7 +180,7 @@ func (c *converter) syncIngress(ing *extensions.Ingress) {
 
 func (c *converter) syncAnnotations() {
 	c.updater.UpdateGlobalConfig(c.haproxy, c.globalConfig)
-	for _, host := range c.haproxy.Hosts() {
+	for _, host := range c.haproxy.Hosts().Items {
 		if ann, found := c.hostAnnotations[host]; found {
 			c.updater.UpdateHostConfig(host, ann)
 		}
@@ -195,7 +195,7 @@ func (c *converter) syncAnnotations() {
 func (c *converter) addDefaultHostBackend(source *annotations.Source, fullSvcName, svcPort string, annHost, annBack map[string]string) error {
 	hostname := "*"
 	uri := "/"
-	if fr := c.haproxy.FindHost(hostname); fr != nil {
+	if fr := c.haproxy.Hosts().FindHost(hostname); fr != nil {
 		if fr.FindPath(uri) != nil {
 			return fmt.Errorf("path %s was already defined on default host", uri)
 		}
@@ -210,7 +210,7 @@ func (c *converter) addDefaultHostBackend(source *annotations.Source, fullSvcNam
 }
 
 func (c *converter) addHost(hostname string, source *annotations.Source, ann map[string]string) *hatypes.Host {
-	host := c.haproxy.AcquireHost(hostname)
+	host := c.haproxy.Hosts().AcquireHost(hostname)
 	mapper, found := c.hostAnnotations[host]
 	if !found {
 		mapper = c.mapBuilder.NewMapper()

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -1362,11 +1362,11 @@ func convertHost(hafronts ...*hatypes.Host) []hostMock {
 }
 
 func (c *testConfig) compareConfigFront(expected string) {
-	c.compareText(_yamlMarshal(convertHost(c.hconfig.Hosts()...)), expected)
+	c.compareText(_yamlMarshal(convertHost(c.hconfig.Hosts().Items...)), expected)
 }
 
 func (c *testConfig) compareConfigDefaultFront(expected string) {
-	host := c.hconfig.DefaultHost()
+	host := c.hconfig.Hosts().DefaultHost()
 	if host != nil {
 		c.compareText(_yamlMarshal(convertHost(host)[0]), expected)
 	} else {

--- a/pkg/haproxy/config_test.go
+++ b/pkg/haproxy/config_test.go
@@ -35,8 +35,6 @@ func TestEmptyFrontend(t *testing.T) {
 	fg := c.FrontendGroup()
 	if fg == nil {
 		t.Error("expected FrontendGroup != nil")
-	} else if len(fg.Frontends) == 0 {
-		t.Error("expected at least one frontend")
 	}
 }
 

--- a/pkg/haproxy/config_test.go
+++ b/pkg/haproxy/config_test.go
@@ -28,7 +28,7 @@ func TestEmptyFrontend(t *testing.T) {
 	if fg := c.FrontendGroup(); fg == nil {
 		t.Error("expected FrontendGroup != nil")
 	}
-	c.AcquireHost("empty")
+	c.hosts.AcquireHost("empty")
 	if err := c.BuildFrontendGroup(); err != nil {
 		t.Errorf("error creating frontends: %v", err)
 	}
@@ -40,8 +40,8 @@ func TestEmptyFrontend(t *testing.T) {
 
 func TestAcquireHostDiff(t *testing.T) {
 	c := createConfig(options{})
-	f1 := c.AcquireHost("h1")
-	f2 := c.AcquireHost("h2")
+	f1 := c.hosts.AcquireHost("h1")
+	f2 := c.hosts.AcquireHost("h2")
 	if f1.Hostname != "h1" {
 		t.Errorf("expected %v but was %v", "h1", f1.Hostname)
 	}
@@ -52,8 +52,8 @@ func TestAcquireHostDiff(t *testing.T) {
 
 func TestAcquireHostSame(t *testing.T) {
 	c := createConfig(options{})
-	f1 := c.AcquireHost("h1")
-	f2 := c.AcquireHost("h1")
+	f1 := c.hosts.AcquireHost("h1")
+	f2 := c.hosts.AcquireHost("h1")
 	if f1 != f2 {
 		t.Errorf("expected same host but was different")
 	}
@@ -101,12 +101,12 @@ func TestEqual(t *testing.T) {
 	if !c1.Equals(c2) {
 		t.Error("c1 and c2 should be equals (with backends)")
 	}
-	h1 := c1.AcquireHost("d")
+	h1 := c1.hosts.AcquireHost("d")
 	h1.AddPath(b1, "/")
 	if c1.Equals(c2) {
 		t.Error("c1 and c2 should not be equals (hosts on one side)")
 	}
-	h2 := c2.AcquireHost("d")
+	h2 := c2.hosts.AcquireHost("d")
 	h2.AddPath(b2, "/")
 	if !c1.Equals(c2) {
 		t.Error("c1 and c2 should be equals (with hosts)")

--- a/pkg/haproxy/config_test.go
+++ b/pkg/haproxy/config_test.go
@@ -22,19 +22,19 @@ import (
 
 func TestEmptyFrontend(t *testing.T) {
 	c := createConfig(options{})
-	if err := c.BuildFrontendGroup(); err != nil {
+	if err := c.WriteFrontendMaps(); err != nil {
 		t.Errorf("error creating frontends: %v", err)
 	}
-	if fg := c.FrontendGroup(); fg == nil {
-		t.Error("expected FrontendGroup != nil")
+	if maps := c.frontend.Maps; maps == nil {
+		t.Error("expected frontend.Maps != nil")
 	}
 	c.hosts.AcquireHost("empty")
-	if err := c.BuildFrontendGroup(); err != nil {
+	if err := c.WriteFrontendMaps(); err != nil {
 		t.Errorf("error creating frontends: %v", err)
 	}
-	fg := c.FrontendGroup()
-	if fg == nil {
-		t.Error("expected FrontendGroup != nil")
+	maps := c.frontend.Maps
+	if maps == nil {
+		t.Error("expected frontend.Maps != nil")
 	}
 }
 
@@ -111,8 +111,8 @@ func TestEqual(t *testing.T) {
 	if !c1.Equals(c2) {
 		t.Error("c1 and c2 should be equals (with hosts)")
 	}
-	err1 := c1.BuildFrontendGroup()
-	err2 := c2.BuildFrontendGroup()
+	err1 := c1.WriteFrontendMaps()
+	err2 := c2.WriteFrontendMaps()
 	if err1 != nil {
 		t.Errorf("error building c1: %v", err1)
 	}

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -265,12 +265,12 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 	//
 	defer i.rotateConfig()
 	i.curConfig.SyncConfig()
-	if err := i.curConfig.BuildFrontendGroup(); err != nil {
+	if err := i.curConfig.WriteFrontendMaps(); err != nil {
 		i.logger.Error("error building configuration group: %v", err)
 		i.metrics.IncUpdateNoop()
 		return
 	}
-	if err := i.curConfig.BuildBackendMaps(); err != nil {
+	if err := i.curConfig.WriteBackendMaps(); err != nil {
 		i.logger.Error("error building backend maps: %v", err)
 		i.metrics.IncUpdateNoop()
 		return

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -326,27 +326,27 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 func (i *instance) updateCertExpiring() {
 	// TODO move to dynupdate when dynamic crt update is implemented
 	if i.oldConfig == nil {
-		for _, curHost := range i.curConfig.Hosts() {
+		for _, curHost := range i.curConfig.Hosts().Items {
 			if curHost.TLS.HasTLS() {
 				i.metrics.SetCertExpireDate(curHost.Hostname, curHost.TLS.TLSCommonName, &curHost.TLS.TLSNotAfter)
 			}
 		}
 		return
 	}
-	for _, oldHost := range i.oldConfig.Hosts() {
+	for _, oldHost := range i.oldConfig.Hosts().Items {
 		if !oldHost.TLS.HasTLS() {
 			continue
 		}
-		curHost := i.curConfig.FindHost(oldHost.Hostname)
+		curHost := i.curConfig.Hosts().FindHost(oldHost.Hostname)
 		if curHost == nil || oldHost.TLS.TLSCommonName != curHost.TLS.TLSCommonName {
 			i.metrics.SetCertExpireDate(oldHost.Hostname, oldHost.TLS.TLSCommonName, nil)
 		}
 	}
-	for _, curHost := range i.curConfig.Hosts() {
+	for _, curHost := range i.curConfig.Hosts().Items {
 		if !curHost.TLS.HasTLS() {
 			continue
 		}
-		oldHost := i.oldConfig.FindHost(curHost.Hostname)
+		oldHost := i.oldConfig.Hosts().FindHost(curHost.Hostname)
 		if oldHost == nil || oldHost.TLS.TLSCommonName != curHost.TLS.TLSCommonName || oldHost.TLS.TLSNotAfter != curHost.TLS.TLSNotAfter {
 			i.metrics.SetCertExpireDate(curHost.Hostname, curHost.TLS.TLSCommonName, &curHost.TLS.TLSNotAfter)
 		}

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -264,6 +264,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 	//   - i.metrics.UpdateSuccessful(<bool>) should be called only if haproxy is reloaded or cfg is validated
 	//
 	defer i.rotateConfig()
+	i.curConfig.SyncConfig()
 	if err := i.curConfig.BuildFrontendGroup(); err != nil {
 		i.logger.Error("error building configuration group: %v", err)
 		i.metrics.IncUpdateNoop()

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1175,7 +1175,7 @@ d1.local/ d2_app_8080
 	c.logger.CompareLogging(defaultLogging)
 }
 
-func TestInstanceSingleFrontendSingleBind(t *testing.T) {
+func TestInstanceFrontend(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()
 
@@ -1262,7 +1262,7 @@ d2.local/app -
 	c.logger.CompareLogging(defaultLogging)
 }
 
-func TestInstanceSingleFrontendTwoBindsCA(t *testing.T) {
+func TestInstanceFrontendCA(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()
 

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -514,7 +514,7 @@ func TestBackends(t *testing.T) {
 
 		b = c.config.AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.AcquireHost("d1.local")
+		h = c.config.Hosts().AcquireHost("d1.local")
 		for _, p := range test.path {
 			h.AddPath(b, p)
 		}
@@ -563,7 +563,7 @@ func TestInstanceBare(t *testing.T) {
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/")
 
 	c.Update()
@@ -615,7 +615,7 @@ func TestInstanceGlobalBind(t *testing.T) {
 
 		b = c.config.AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.AcquireHost("d1.local")
+		h = c.config.Hosts().AcquireHost("d1.local")
 		h.AddPath(b, "/")
 
 		c.config.Global().Bind = test.bind
@@ -659,7 +659,7 @@ func TestInstanceEmpty(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()
 
-	c.config.AcquireHost("empty").AddPath(c.config.AcquireBackend("default", "empty", "8080"), "/")
+	c.config.Hosts().AcquireHost("empty").AddPath(c.config.AcquireBackend("default", "empty", "8080"), "/")
 	c.Update()
 
 	c.checkConfig(`
@@ -843,7 +843,7 @@ func TestInstanceToHTTPSocket(t *testing.T) {
 		var b *hatypes.Backend
 
 		b = c.config.AcquireBackend("d1", "app", "8080")
-		h = c.config.AcquireHost(test.domain)
+		h = c.config.Hosts().AcquireHost(test.domain)
 		h.AddPath(b, "/")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
 		b.HSTS = []*hatypes.BackendConfigHSTS{
@@ -1011,7 +1011,7 @@ func TestInstanceDefaultHost(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
-	h = c.config.AcquireHost("*")
+	h = c.config.Hosts().AcquireHost("*")
 	h.AddPath(b, "/")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
@@ -1020,7 +1020,7 @@ func TestInstanceDefaultHost(t *testing.T) {
 	h.VarNamespace = true
 
 	b = c.config.AcquireBackend("d2", "app", "8080")
-	h = c.config.AcquireHost("d2.local")
+	h = c.config.Hosts().AcquireHost("d2.local")
 	h.AddPath(b, "/app")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
@@ -1092,7 +1092,7 @@ func TestInstanceStrictHost(t *testing.T) {
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/path")
 	c.config.Global().StrictHost = true
 
@@ -1131,12 +1131,12 @@ func TestInstanceStrictHostDefaultHost(t *testing.T) {
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/path")
 
 	b = c.config.AcquireBackend("d2", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h = c.config.AcquireHost("*")
+	h = c.config.Hosts().AcquireHost("*")
 	h.AddPath(b, "/")
 
 	c.config.Global().StrictHost = true
@@ -1187,7 +1187,7 @@ func TestInstanceFrontend(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/")
 	b.SSLRedirect = b.CreateConfigBool(true)
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
@@ -1196,7 +1196,7 @@ func TestInstanceFrontend(t *testing.T) {
 	h.TLS.TLSHash = "1"
 
 	b = c.config.AcquireBackend("d2", "app", "8080")
-	h = c.config.AcquireHost("d2.local")
+	h = c.config.Hosts().AcquireHost("d2.local")
 	h.AddPath(b, "/app")
 	b.SSLRedirect = b.CreateConfigBool(true)
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
@@ -1274,7 +1274,7 @@ func TestInstanceFrontendCA(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.AcquireBackend("d", "app", "8080")
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
@@ -1282,7 +1282,7 @@ func TestInstanceFrontendCA(t *testing.T) {
 	h.TLS.CAHash = "1"
 	h.TLS.CAErrorPage = "http://d1.local/error.html"
 
-	h = c.config.AcquireHost("d2.local")
+	h = c.config.Hosts().AcquireHost("d2.local")
 	h.AddPath(b, "/")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
@@ -1391,7 +1391,7 @@ func TestInstanceSomePaths(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.AcquireBackend("d", "app0", "8080")
-	h = c.config.AcquireHost("d.local")
+	h = c.config.Hosts().AcquireHost("d.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/")
@@ -1469,7 +1469,7 @@ func TestInstanceCustomFrontend(t *testing.T) {
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/")
 	c.config.Global().CustomFrontend = []string{
 		"# new header",
@@ -1522,7 +1522,7 @@ func TestInstanceSSLRedirect(t *testing.T) {
 
 	b = c.config.AcquireBackend("d1", "app-api", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/")
@@ -1530,7 +1530,7 @@ func TestInstanceSSLRedirect(t *testing.T) {
 
 	b = c.config.AcquireBackend("d2", "app-front", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h = c.config.AcquireHost("d2.local")
+	h = c.config.Hosts().AcquireHost("d2.local")
 	h.TLS.TLSFilename = ""
 	h.TLS.TLSHash = ""
 	h.AddPath(b, "/")
@@ -1579,14 +1579,14 @@ func TestInstanceSSLPassthrough(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.AcquireBackend("d2", "app", "8080")
-	h = c.config.AcquireHost("d2.local")
+	h = c.config.Hosts().AcquireHost("d2.local")
 	h.AddPath(b, "/")
 	b.SSLRedirect = b.CreateConfigBool(true)
 	b.Endpoints = []*hatypes.Endpoint{endpointS31}
 	h.SSLPassthrough = true
 
 	b = c.config.AcquireBackend("d3", "app-ssl", "8443")
-	h = c.config.AcquireHost("d3.local")
+	h = c.config.Hosts().AcquireHost("d3.local")
 	h.AddPath(b, "/")
 	b.Endpoints = []*hatypes.Endpoint{endpointS41s}
 	h.SSLPassthrough = true
@@ -1657,7 +1657,7 @@ func TestInstanceRootRedirect(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/")
@@ -1666,7 +1666,7 @@ func TestInstanceRootRedirect(t *testing.T) {
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 
 	b = c.config.AcquireBackend("d2", "app", "8080")
-	h = c.config.AcquireHost("d2.local")
+	h = c.config.Hosts().AcquireHost("d2.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/app1")
@@ -1746,20 +1746,20 @@ func TestInstanceAlias(t *testing.T) {
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/")
 	h.Alias.AliasName = "*.d1.local"
 
 	b = c.config.AcquireBackend("d2", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h = c.config.AcquireHost("d2.local")
+	h = c.config.Hosts().AcquireHost("d2.local")
 	h.AddPath(b, "/")
 	h.Alias.AliasName = "sub.d2.local"
 	h.Alias.AliasRegex = "^[a-z]+\\.d2\\.local$"
 
 	b = c.config.AcquireBackend("d3", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS31}
-	h = c.config.AcquireHost("d3.local")
+	h = c.config.Hosts().AcquireHost("d3.local")
 	h.AddPath(b, "/")
 	h.Alias.AliasRegex = ".*d3\\.local$"
 
@@ -1824,7 +1824,7 @@ func TestInstanceMaxBody(t *testing.T) {
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/")
 	h.AddPath(b, "/app")
 	b.MaxBodySize = []*hatypes.BackendConfigInt{{
@@ -1834,7 +1834,7 @@ func TestInstanceMaxBody(t *testing.T) {
 
 	b = c.config.AcquireBackend("d2", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h = c.config.AcquireHost("d2.local")
+	h = c.config.Hosts().AcquireHost("d2.local")
 	h.AddPath(b, "/")
 
 	c.Update()
@@ -1878,7 +1878,7 @@ func TestInstanceSyslog(t *testing.T) {
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/")
 
 	syslog := &c.config.Global().Syslog
@@ -1971,13 +1971,13 @@ func TestDNS(t *testing.T) {
 	b = c.config.AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21, endpointS22}
 	b.Resolver = "k8s"
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/")
 
 	b = c.config.AcquireBackend("d2", "app", "http")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21, endpointS22}
 	b.Resolver = "k8s"
-	h = c.config.AcquireHost("d2.local")
+	h = c.config.Hosts().AcquireHost("d2.local")
 	h.AddPath(b, "/")
 
 	c.Update()
@@ -2079,7 +2079,7 @@ userlist default_auth2
 
 		b = c.config.AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.AcquireHost("d1.local")
+		h = c.config.Hosts().AcquireHost("d1.local")
 		h.AddPath(b, "/")
 		h.AddPath(b, "/admin")
 
@@ -2166,7 +2166,7 @@ frontend _front_http
 
 		b = c.config.AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.AcquireHost("d1.local")
+		h = c.config.Hosts().AcquireHost("d1.local")
 		h.AddPath(b, "/")
 
 		acme := c.config.Acme()
@@ -2387,7 +2387,7 @@ func TestModSecurity(t *testing.T) {
 
 		b = c.config.AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.AcquireHost("d1.local")
+		h = c.config.Hosts().AcquireHost("d1.local")
 		if test.path == "" {
 			test.path = "/"
 		}
@@ -2444,15 +2444,15 @@ func TestInstanceWildcardHostname(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.AcquireBackend("d1", "app", "8080")
-	h = c.config.AcquireHost("d1.local")
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/")
-	h = c.config.AcquireHost("*.app.d1.local")
+	h = c.config.Hosts().AcquireHost("*.app.d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/")
-	h = c.config.AcquireHost("*.sub.d1.local")
+	h = c.config.Hosts().AcquireHost("*.sub.d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/")
@@ -2464,7 +2464,7 @@ func TestInstanceWildcardHostname(t *testing.T) {
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 
 	b = c.config.AcquireBackend("d2", "app", "8080")
-	h = c.config.AcquireHost("*.d2.local")
+	h = c.config.Hosts().AcquireHost("*.d2.local")
 	h.AddPath(b, "/")
 	h.RootRedirect = "/app"
 	b.SSLRedirect = b.CreateConfigBool(false)

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -128,8 +128,8 @@ func (fg *FrontendGroup) HasMaxBody() bool {
 }
 
 // HasVarNamespace ...
-func (fg *FrontendGroup) HasVarNamespace() bool {
-	for _, host := range fg.Frontend.Hosts {
+func (f *Frontend) HasVarNamespace() bool {
+	for _, host := range f.Hosts {
 		if host.VarNamespace {
 			return true
 		}
@@ -176,12 +176,4 @@ func (f *Frontend) HasTLSMandatory() bool {
 		}
 	}
 	return false
-}
-
-// NewFrontend ...
-func NewFrontend(name string, hosts []*Host) *Frontend {
-	return &Frontend{
-		Name:  name,
-		Hosts: hosts,
-	}
 }

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -127,53 +127,7 @@ func (fg *FrontendGroup) HasMaxBody() bool {
 	return fg.MaxBodySizeMap.HasHost()
 }
 
-// HasVarNamespace ...
-func (f *Frontend) HasVarNamespace() bool {
-	for _, host := range f.Hosts {
-		if host.VarNamespace {
-			return true
-		}
-	}
-	return false
-}
-
 // String ...
 func (f *Frontend) String() string {
 	return fmt.Sprintf("%+v", *f)
-}
-
-// HasTLSAuth ...
-func (f *Frontend) HasTLSAuth() bool {
-	for _, host := range f.Hosts {
-		if host.HasTLSAuth() {
-			return true
-		}
-	}
-	return false
-}
-
-// HasInvalidErrorPage ...
-func (f *Frontend) HasInvalidErrorPage() bool {
-	for _, host := range f.Hosts {
-		if host.TLS.CAErrorPage != "" {
-			return true
-		}
-	}
-	return false
-}
-
-// HasNoCrtErrorPage ...
-func (f *Frontend) HasNoCrtErrorPage() bool {
-	// Use currently the same attribute
-	return f.HasInvalidErrorPage()
-}
-
-// HasTLSMandatory ...
-func (f *Frontend) HasTLSMandatory() bool {
-	for _, host := range f.Hosts {
-		if host.HasTLSAuth() && !host.TLS.CAVerifyOptional {
-			return true
-		}
-	}
-	return false
 }

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -123,8 +123,8 @@ func (hm *HostsMaps) AddMap(filename string) *HostsMap {
 }
 
 // HasMaxBody ...
-func (fg *FrontendGroup) HasMaxBody() bool {
-	return fg.MaxBodySizeMap.HasHost()
+func (f *Frontend) HasMaxBody() bool {
+	return f.Maps.MaxBodySizeMap.HasHost()
 }
 
 // String ...

--- a/pkg/haproxy/types/frontend_test.go
+++ b/pkg/haproxy/types/frontend_test.go
@@ -18,9 +18,6 @@ package types
 
 import (
 	"testing"
-
-	"github.com/kylelemons/godebug/diff"
-	yaml "gopkg.in/yaml.v2"
 )
 
 func TestAppendHostname(t *testing.T) {
@@ -62,38 +59,6 @@ func TestAppendHostname(t *testing.T) {
 				t.Errorf("item %d, expected key '%s', but was '%s'", i, test.expectedRegex, hm.Regex[0].Key)
 				continue
 			}
-		}
-	}
-}
-
-func TestBuildFrontendEmpty(t *testing.T) {
-	frontends, _, _ := BuildRawFrontends([]*Host{})
-	if len(frontends) != 1 {
-		t.Errorf("expected len(frontends) == 1, but was %d", len(frontends))
-	}
-}
-
-func TestBuildSSLPassthrough(t *testing.T) {
-	h1 := &Host{Hostname: "h1.local"}
-	h2 := &Host{Hostname: "h2.local", SSLPassthrough: true}
-	testCases := []struct {
-		hosts    []*Host
-		expected []*Host
-	}{
-		// 0
-		{
-			hosts:    []*Host{h1, h2},
-			expected: []*Host{h2},
-		},
-	}
-	for i, test := range testCases {
-		_, sslpassthrough, _ := BuildRawFrontends(test.hosts)
-		actualRaw, _ := yaml.Marshal(sslpassthrough)
-		expectedRaw, _ := yaml.Marshal(test.expected)
-		actual := string(actualRaw)
-		expected := string(expectedRaw)
-		if actual != expected {
-			t.Errorf("sslpassthrough '%d' actual and expected differs:\n%v", i, diff.Diff(actual, expected))
 		}
 	}
 }

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -21,6 +21,119 @@ import (
 	"sort"
 )
 
+// AcquireHost ...
+func (h *Hosts) AcquireHost(hostname string) *Host {
+	if host := h.FindHost(hostname); host != nil {
+		return host
+	}
+	host := createHost(hostname)
+	if host.Hostname != "*" {
+		h.Items = append(h.Items, host)
+		sort.Slice(h.Items, func(i, j int) bool {
+			return h.Items[i].Hostname < h.Items[j].Hostname
+		})
+	} else {
+		h.defaultHost = host
+	}
+	return host
+}
+
+// FindHost ...
+func (h *Hosts) FindHost(hostname string) *Host {
+	if hostname == "*" && h.defaultHost != nil {
+		return h.defaultHost
+	}
+	for _, f := range h.Items {
+		if f.Hostname == hostname {
+			return f
+		}
+	}
+	return nil
+}
+
+func createHost(hostname string) *Host {
+	return &Host{
+		Hostname: hostname,
+	}
+}
+
+// DefaultHost ...
+func (h *Hosts) DefaultHost() *Host {
+	return h.defaultHost
+}
+
+// HasSSLPassthrough ...
+func (h *Hosts) HasSSLPassthrough() bool {
+	// TODO this is just another HasXXX() or FindXXX() which iterates over
+	// thousands of items to find an answer. Sometimes this is done more
+	// than once. This need to be improved.
+	// We can find this answer (regarding HasSSLPassthrough) on
+	// ssl-passthrough map but it is (currently) built on instance.update()
+	// which would need some knowledge and synchronization from the caller.
+	for _, host := range h.Items {
+		if host.SSLPassthrough {
+			return true
+		}
+	}
+	return false
+}
+
+// HasHTTP ...
+func (h *Hosts) HasHTTP() bool {
+	for _, host := range h.Items {
+		if !host.SSLPassthrough {
+			return true
+		}
+	}
+	return false
+}
+
+// HasInvalidErrorPage ...
+func (h *Hosts) HasInvalidErrorPage() bool {
+	for _, host := range h.Items {
+		if host.TLS.CAErrorPage != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// HasNoCrtErrorPage ...
+func (h *Hosts) HasNoCrtErrorPage() bool {
+	// Use currently the same attribute
+	return h.HasInvalidErrorPage()
+}
+
+// HasTLSAuth ...
+func (h *Hosts) HasTLSAuth() bool {
+	for _, host := range h.Items {
+		if host.HasTLSAuth() {
+			return true
+		}
+	}
+	return false
+}
+
+// HasTLSMandatory ...
+func (h *Hosts) HasTLSMandatory() bool {
+	for _, host := range h.Items {
+		if host.HasTLSAuth() && !host.TLS.CAVerifyOptional {
+			return true
+		}
+	}
+	return false
+}
+
+// HasVarNamespace ...
+func (h *Hosts) HasVarNamespace() bool {
+	for _, host := range h.Items {
+		if host.VarNamespace {
+			return true
+		}
+	}
+	return false
+}
+
 // FindPath ...
 func (h *Host) FindPath(path string) *HostPath {
 	for _, p := range h.Paths {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -246,8 +246,8 @@ type HostsMaps struct {
 	Items []*HostsMap
 }
 
-// FrontendGroup ...
-type FrontendGroup struct {
+// FrontendMaps ...
+type FrontendMaps struct {
 	HTTPFrontsMap     *HostsMap
 	HTTPRootRedirMap  *HostsMap
 	HTTPSRedirMap     *HostsMap
@@ -270,6 +270,7 @@ type FrontendGroup struct {
 // Frontend ...
 type Frontend struct {
 	Name        string
+	Maps        *FrontendMaps
 	BindName    string
 	BindSocket  string
 	BindID      int

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -248,7 +248,6 @@ type HostsMaps struct {
 
 // FrontendGroup ...
 type FrontendGroup struct {
-	Frontend          *Frontend
 	HasSSLPassthrough bool
 	//
 	HTTPFrontsMap     *HostsMap
@@ -272,17 +271,11 @@ type FrontendGroup struct {
 
 // Frontend ...
 type Frontend struct {
-	Name  string
-	Bind  BindConfig
-	Hosts []*Host
-}
-
-// BindConfig ...
-type BindConfig struct {
-	Name   string
-	Socket string
-	ID     int
-	//
+	Name        string
+	BindName    string
+	BindSocket  string
+	BindID      int
+	Hosts       []*Host
 	AcceptProxy bool
 }
 

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -248,27 +248,15 @@ type HostsMaps struct {
 
 // FrontendGroup ...
 type FrontendGroup struct {
-	Frontends []*Frontend
-	//
-	DefaultBind       *BindConfig
+	Frontend          *Frontend
 	HasSSLPassthrough bool
-	ToHTTPBind        BindConfig
 	//
-	Maps              *HostsMaps
 	HTTPFrontsMap     *HostsMap
 	HTTPRootRedirMap  *HostsMap
 	HTTPSRedirMap     *HostsMap
 	SSLPassthroughMap *HostsMap
 	VarNamespaceMap   *HostsMap
-}
-
-// Frontend ...
-type Frontend struct {
-	Name  string
-	Bind  BindConfig
-	Hosts []*Host
 	//
-	Maps                       *HostsMaps
 	HostBackendsMap            *HostsMap
 	MaxBodySizeMap             *HostsMap
 	RootRedirMap               *HostsMap
@@ -277,6 +265,16 @@ type Frontend struct {
 	TLSInvalidCrtErrorPagesMap *HostsMap
 	TLSNoCrtErrorList          *HostsMap
 	TLSNoCrtErrorPagesMap      *HostsMap
+	//
+	CrtList       *HostsMap
+	UseServerList *HostsMap
+}
+
+// Frontend ...
+type Frontend struct {
+	Name  string
+	Bind  BindConfig
+	Hosts []*Host
 }
 
 // BindConfig ...
@@ -286,22 +284,6 @@ type BindConfig struct {
 	ID     int
 	//
 	AcceptProxy bool
-	ALPN        string
-	TLS         []*BindTLSConfig
-	//
-	UseServerList *HostsMap
-	CrtList       *HostsMap
-}
-
-// BindTLSConfig ...
-type BindTLSConfig struct {
-	CAFilename  string
-	CAHash      string
-	CRLFilename string
-	CRLHash     string
-	CrtFilename string
-	CrtHash     string
-	Hostnames   []string
 }
 
 // Host ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -248,8 +248,6 @@ type HostsMaps struct {
 
 // FrontendGroup ...
 type FrontendGroup struct {
-	HasSSLPassthrough bool
-	//
 	HTTPFrontsMap     *HostsMap
 	HTTPRootRedirMap  *HostsMap
 	HTTPSRedirMap     *HostsMap
@@ -275,8 +273,13 @@ type Frontend struct {
 	BindName    string
 	BindSocket  string
 	BindID      int
-	Hosts       []*Host
 	AcceptProxy bool
+}
+
+// Hosts ...
+type Hosts struct {
+	Items       []*Host
+	defaultHost *Host
 }
 
 // Host ...

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -598,7 +598,8 @@ backend _error404
 # #
 #
 {{- $frontend := $cfg.Frontend }}
-{{- if $fgroup.HasSSLPassthrough }}
+{{- $hosts := $cfg.Hosts }}
+{{- if $hosts.HasSSLPassthrough }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -623,7 +624,7 @@ listen _front__tls
     tcp-request inspect-delay 5s
 
 {{- /*------------------------------------*/}}
-{{- if $fgroup.HasSSLPassthrough }}
+{{- if $hosts.HasSSLPassthrough }}
     tcp-request content set-var(req.sslpassback)
         {{- "" }} req.ssl_sni,lower,map({{ $fgroup.SSLPassthroughMap.MatchFile }})
 {{- end }}
@@ -638,10 +639,10 @@ listen _front__tls
     tcp-request content accept if { req.ssl_hello_type 1 }
 
 {{- /*------------------------------------*/}}
-{{- if $fgroup.HasSSLPassthrough }}
+{{- if $hosts.HasSSLPassthrough }}
     use_backend %[var(req.sslpassback)] if { var(req.sslpassback) -m found }
 {{- end }}
-{{- if $frontend.Hosts }}
+{{- if $hosts.HasHTTP }}
     ## {{ $frontend.BindName }}
     use-server _server{{ $frontend.BindName }} if { req.ssl_sni -i -f {{ $fgroup.UseServerList.MatchFile }} }
     server _server{{ $frontend.BindName }} {{ $frontend.BindSocket }} send-proxy-v2 weight 0
@@ -753,7 +754,7 @@ frontend _front_http
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $frontend.HasVarNamespace }}
+{{- if $hosts.HasVarNamespace }}
     http-request set-var(txn.namespace) 
         {{- "" }} var(req.base),map_beg({{ $fgroup.VarNamespaceMap.MatchFile }},-)
 {{- if $fgroup.VarNamespaceMap.HasRegex }}
@@ -826,7 +827,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $frontend.HasTLSAuth $fgroup.HostBackendsMap.HasRegex $frontend.HasVarNamespace $fgroup.HasMaxBody }}
+{{- if or $hosts.HasTLSAuth $fgroup.HostBackendsMap.HasRegex $hosts.HasVarNamespace $fgroup.HasMaxBody }}
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
     http-request set-var(req.hostbackend)
         {{- "" }} var(req.base),map_beg({{ $fgroup.HostBackendsMap.MatchFile }})
@@ -841,7 +842,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $frontend.HasTLSAuth $fgroup.RootRedirMap.HasHost }}
+{{- if or $hosts.HasTLSAuth $fgroup.RootRedirMap.HasHost }}
     http-request set-var(req.host) hdr(host),lower,regsub(:[0-9]+$,)
 {{- end }}
 {{- if $fgroup.RootRedirMap.HasHost }}
@@ -855,7 +856,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $frontend.HasVarNamespace }}
+{{- if $hosts.HasVarNamespace }}
     http-request set-var(txn.namespace) 
         {{- "" }} var(req.base),map_beg({{ $fgroup.VarNamespaceMap.MatchFile }},-)
 {{- if $fgroup.VarNamespaceMap.HasRegex }}
@@ -878,8 +879,8 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $frontend.HasTLSAuth }}
-{{- $mandatory := $frontend.HasTLSMandatory }}
+{{- if $hosts.HasTLSAuth }}
+{{- $mandatory := $hosts.HasTLSMandatory }}
     acl tls-has-crt ssl_c_used
 {{- if $mandatory }}
     acl tls-need-crt ssl_fc_sni -i -f {{ $fgroup.TLSNoCrtErrorList.MatchFile }}
@@ -939,11 +940,11 @@ frontend {{ $frontend.Name }}
         {{- "" }},map_reg({{ $fgroup.TLSInvalidCrtErrorPagesMap.RegexFile }},_internal)
         {{- "" }} if { var(req.tls_invalidcrt_redir) _internal }
 {{- end }}
-{{- if and $mandatory $frontend.HasNoCrtErrorPage }}
+{{- if and $mandatory $hosts.HasNoCrtErrorPage }}
     http-request redirect location %[var(req.tls_nocrt_redir)] code 303
         {{- "" }} if { var(req.tls_nocrt_redir) -m found } !{ var(req.tls_nocrt_redir) _internal }
 {{- end }}
-{{- if $frontend.HasInvalidErrorPage }}
+{{- if $hosts.HasInvalidErrorPage }}
     http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303
         {{- "" }} if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
 {{- end }}
@@ -959,10 +960,10 @@ frontend {{ $frontend.Name }}
     http-request use-service lua.send-413 if
         {{- "" }} !{ var(req.maxbody) 0 } { req.body_size,sub(req.maxbody) gt 0 }
 {{- end }}
-{{- if $frontend.HasTLSAuth }}
+{{- if $hosts.HasTLSAuth }}
     http-request use-service lua.send-421 if
         {{- "" }} tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
-{{- if $frontend.HasTLSMandatory }}
+{{- if $hosts.HasTLSMandatory }}
     http-request use-service lua.send-496 if
         {{- "" }} { var(req.tls_nocrt_redir) _internal }
 {{- /* HTTP 421 instead of 404 if missing sni or the provided one doesn't read client crt. */}}
@@ -977,7 +978,7 @@ frontend {{ $frontend.Name }}
 {{- /*------------------------------------*/}}
     use_backend %[var(req.hostbackend)]
         {{- "" }} if { var(req.hostbackend) -m found }
-{{- if $frontend.HasTLSAuth }}
+{{- if $hosts.HasTLSAuth }}
     use_backend %[var(req.snibackend)]
         {{- "" }} if { var(req.snibackend) -m found }
 {{- end }}
@@ -989,8 +990,9 @@ frontend {{ $frontend.Name }}
 {{- /*------------------------------------*/}}
 {{- define "defaultbackend" }}
 {{- $cfg := .p1 }}
-{{- if $cfg.DefaultHost }}
-{{- range $path := $cfg.DefaultHost.Paths }}
+{{- $hosts := $cfg.Hosts }}
+{{- if $hosts.DefaultHost }}
+{{- range $path := $hosts.DefaultHost.Paths }}
     use_backend {{ $path.Backend.ID }}
         {{- if ne $path.Path "/" }} if { path_beg {{ $path.Path }} }{{ end }}
 {{- end }}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -587,8 +587,10 @@ backend _error404
     http-request use-service lua.send-404
 {{- end }}
 
-{{- $fgroup := $cfg.FrontendGroup }}
-{{- if $fgroup }}
+{{- $frontend := $cfg.Frontend }}
+{{- $hosts := $cfg.Hosts }}
+{{- $fmaps := $frontend.Maps }}
+{{- if $fmaps }}
 
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -597,8 +599,6 @@ backend _error404
 # #   FRONTENDS
 # #
 #
-{{- $frontend := $cfg.Frontend }}
-{{- $hosts := $cfg.Hosts }}
 {{- if $hosts.HasSSLPassthrough }}
 
   # # # # # # # # # # # # # # # # # # #
@@ -626,12 +626,12 @@ listen _front__tls
 {{- /*------------------------------------*/}}
 {{- if $hosts.HasSSLPassthrough }}
     tcp-request content set-var(req.sslpassback)
-        {{- "" }} req.ssl_sni,lower,map({{ $fgroup.SSLPassthroughMap.MatchFile }})
+        {{- "" }} req.ssl_sni,lower,map({{ $fmaps.SSLPassthroughMap.MatchFile }})
 {{- end }}
-{{- if $fgroup.SSLPassthroughMap.HasRegex }}
+{{- if $fmaps.SSLPassthroughMap.HasRegex }}
 {{- /*** TODO map_reg() running on every request ***/}}
     tcp-request content set-var(req.sslpassregback)
-        {{- "" }} req.ssl_sni,lower,map_reg({{ $fgroup.SSLPassthroughMap.RegexFile }})
+        {{- "" }} req.ssl_sni,lower,map_reg({{ $fmaps.SSLPassthroughMap.RegexFile }})
         {{- "" }} if !{ var(req.sslpassback) -m found }
 {{- end }}
 
@@ -644,17 +644,17 @@ listen _front__tls
 {{- end }}
 {{- if $hosts.HasHTTP }}
     ## {{ $frontend.BindName }}
-    use-server _server{{ $frontend.BindName }} if { req.ssl_sni -i -f {{ $fgroup.UseServerList.MatchFile }} }
+    use-server _server{{ $frontend.BindName }} if { req.ssl_sni -i -f {{ $fmaps.UseServerList.MatchFile }} }
     server _server{{ $frontend.BindName }} {{ $frontend.BindSocket }} send-proxy-v2 weight 0
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $fgroup.SSLPassthroughMap.HasRegex }}
+{{- if $fmaps.SSLPassthroughMap.HasRegex }}
     use_backend %[var(req.sslpassback)] if { var(req.sslpassback) -m found }
 {{- end }}
-{{- if $fgroup.UseServerList.HasRegex }}
+{{- if $fmaps.UseServerList.HasRegex }}
     ## {{ $frontend.BindName }} wildcard
-    use-server _server{{ $frontend.BindName }}_wildcard if { req.ssl_sni -i -m reg -f {{ $fgroup.UseServerList.RegexFile }} }
+    use-server _server{{ $frontend.BindName }}_wildcard if { req.ssl_sni -i -m reg -f {{ $fmaps.UseServerList.RegexFile }} }
     server _server{{ $frontend.BindName }}_wildcard {{ $frontend.BindSocket }} send-proxy-v2 weight 0
 {{- end }}
 
@@ -716,9 +716,9 @@ frontend _front_http
 
 {{- /*------------------------------------*/}}
 {{- $acmeexclusive := and $cfg.Acme.Enabled (not $cfg.Acme.Shared) }}
-{{- if $fgroup.HTTPSRedirMap.HasRegex }}
+{{- if $fmaps.HTTPSRedirMap.HasRegex }}
     http-request set-var(req.redir)
-        {{- "" }} var(req.base),map_beg({{ $fgroup.HTTPSRedirMap.MatchFile }})
+        {{- "" }} var(req.base),map_beg({{ $fmaps.HTTPSRedirMap.MatchFile }})
         {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
     http-request redirect scheme https
         {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
@@ -730,23 +730,23 @@ frontend _front_http
         {{- "" }} if{{ if $acmeexclusive }} !acme-challenge{{ end }}
         {{- if $hasFrontingProxy }} !fronting-proxy{{ end }}
         {{- "" }} !{ var(req.redir) -m found }
-        {{- "" }} { var(req.base),map_reg({{ $fgroup.HTTPSRedirMap.RegexFile }}) yes }
+        {{- "" }} { var(req.base),map_reg({{ $fmaps.HTTPSRedirMap.RegexFile }}) yes }
 {{- else }}
     http-request redirect scheme https
         {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
         {{- "" }} if{{ if $acmeexclusive }} !acme-challenge{{ end }}
         {{- if $hasFrontingProxy }} !fronting-proxy{{ end }}
-        {{- "" }} { var(req.base),map_beg({{ $fgroup.HTTPSRedirMap.MatchFile }}) yes }
+        {{- "" }} { var(req.base),map_beg({{ $fmaps.HTTPSRedirMap.MatchFile }}) yes }
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $fgroup.HTTPRootRedirMap.HasHost }}
+{{- if $fmaps.HTTPRootRedirMap.HasHost }}
     http-request set-var(req.host) hdr(host),lower,regsub(:[0-9]+$,)
     http-request set-var(req.rootredir)
-        {{- "" }} var(req.host),map({{ $fgroup.HTTPRootRedirMap.MatchFile }})
-{{- if $fgroup.HTTPRootRedirMap.HasRegex }}
+        {{- "" }} var(req.host),map({{ $fmaps.HTTPRootRedirMap.MatchFile }})
+{{- if $fmaps.HTTPRootRedirMap.HasRegex }}
     http-request set-var(req.rootredir)
-        {{- "" }} var(req.host),map_reg({{ $fgroup.HTTPRootRedirMap.RegexFile }}) if !{ var(req.rootredir) -m found }
+        {{- "" }} var(req.host),map_reg({{ $fmaps.HTTPRootRedirMap.RegexFile }}) if !{ var(req.rootredir) -m found }
 {{- end }}
     http-request redirect location %[var(req.rootredir)]
         {{- "" }} if{{ if $acmeexclusive }} !acme-challenge{{ end }}
@@ -756,10 +756,10 @@ frontend _front_http
 {{- /*------------------------------------*/}}
 {{- if $hosts.HasVarNamespace }}
     http-request set-var(txn.namespace) 
-        {{- "" }} var(req.base),map_beg({{ $fgroup.VarNamespaceMap.MatchFile }},-)
-{{- if $fgroup.VarNamespaceMap.HasRegex }}
+        {{- "" }} var(req.base),map_beg({{ $fmaps.VarNamespaceMap.MatchFile }},-)
+{{- if $fmaps.VarNamespaceMap.HasRegex }}
     http-request set-var(txn.namespace) 
-        {{- "" }} var(req.base),map_reg({{ $fgroup.VarNamespaceMap.RegexFile }},-)
+        {{- "" }} var(req.base),map_reg({{ $fmaps.VarNamespaceMap.RegexFile }},-)
         {{- "" }} if { var(txn.namespace) -- - }
 {{- end }}
 {{- end }}
@@ -777,10 +777,10 @@ frontend _front_http
         {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
 
 {{- /*------------------------------------*/}}
-    http-request set-var(req.backend) var(req.base),map_beg({{ $fgroup.HTTPFrontsMap.MatchFile }})
-{{- if $fgroup.HTTPFrontsMap.HasRegex }}
+    http-request set-var(req.backend) var(req.base),map_beg({{ $fmaps.HTTPFrontsMap.MatchFile }})
+{{- if $fmaps.HTTPFrontsMap.HasRegex }}
     http-request set-var(req.backend)
-        {{- "" }} var(req.base),map_reg({{ $fgroup.HTTPFrontsMap.RegexFile }})
+        {{- "" }} var(req.base),map_reg({{ $fmaps.HTTPFrontsMap.RegexFile }})
         {{- "" }} if !{ var(req.backend) -m found }
 {{- end }}
 
@@ -813,7 +813,7 @@ frontend {{ $frontend.Name }}
         {{- if $frontend.BindID }} id {{ $frontend.BindID }}{{ end }}
         {{- if $frontend.AcceptProxy }} accept-proxy{{ end }}
         {{- "" }} ssl alpn {{ $global.SSL.ALPN }}
-        {{- "" }} crt-list {{ $fgroup.CrtList.MatchFile }}
+        {{- "" }} crt-list {{ $fmaps.CrtList.MatchFile }}
         {{- "" }} ca-ignore-err all crt-ignore-err all
 {{- end }}
 
@@ -827,30 +827,30 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $hosts.HasTLSAuth $fgroup.HostBackendsMap.HasRegex $hosts.HasVarNamespace $fgroup.HasMaxBody }}
+{{- if or $hosts.HasTLSAuth $fmaps.HostBackendsMap.HasRegex $hosts.HasVarNamespace $frontend.HasMaxBody }}
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
     http-request set-var(req.hostbackend)
-        {{- "" }} var(req.base),map_beg({{ $fgroup.HostBackendsMap.MatchFile }})
+        {{- "" }} var(req.base),map_beg({{ $fmaps.HostBackendsMap.MatchFile }})
 {{- else }}
     http-request set-var(req.hostbackend) base,lower,regsub(:[0-9]+/,/)
-        {{- "" }},map_beg({{ $fgroup.HostBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fmaps.HostBackendsMap.MatchFile }})
 {{- end }}
-{{- if $fgroup.HostBackendsMap.HasRegex }}
+{{- if $fmaps.HostBackendsMap.HasRegex }}
     http-request set-var(req.hostbackend)
-        {{- "" }} var(req.base),map_reg({{ $fgroup.HostBackendsMap.RegexFile }})
+        {{- "" }} var(req.base),map_reg({{ $fmaps.HostBackendsMap.RegexFile }})
         {{- "" }} if !{ var(req.hostbackend) -m found }
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $hosts.HasTLSAuth $fgroup.RootRedirMap.HasHost }}
+{{- if or $hosts.HasTLSAuth $fmaps.RootRedirMap.HasHost }}
     http-request set-var(req.host) hdr(host),lower,regsub(:[0-9]+$,)
 {{- end }}
-{{- if $fgroup.RootRedirMap.HasHost }}
+{{- if $fmaps.RootRedirMap.HasHost }}
     http-request set-var(req.rootredir)
-        {{- "" }} var(req.host),map({{ $fgroup.RootRedirMap.MatchFile }})
-{{- if $fgroup.RootRedirMap.HasRegex }}
+        {{- "" }} var(req.host),map({{ $fmaps.RootRedirMap.MatchFile }})
+{{- if $fmaps.RootRedirMap.HasRegex }}
     http-request set-var(req.rootredir)
-        {{- "" }} var(req.host),map_reg({{ $fgroup.RootRedirMap.RegexFile }}) if !{ var(req.rootredir) -m found }
+        {{- "" }} var(req.host),map_reg({{ $fmaps.RootRedirMap.RegexFile }}) if !{ var(req.rootredir) -m found }
 {{- end }}
     http-request redirect location %[var(req.rootredir)] if { path / } { var(req.rootredir) -m found }
 {{- end }}
@@ -858,10 +858,10 @@ frontend {{ $frontend.Name }}
 {{- /*------------------------------------*/}}
 {{- if $hosts.HasVarNamespace }}
     http-request set-var(txn.namespace) 
-        {{- "" }} var(req.base),map_beg({{ $fgroup.VarNamespaceMap.MatchFile }},-)
-{{- if $fgroup.VarNamespaceMap.HasRegex }}
+        {{- "" }} var(req.base),map_beg({{ $fmaps.VarNamespaceMap.MatchFile }},-)
+{{- if $fmaps.VarNamespaceMap.HasRegex }}
     http-request set-var(txn.namespace) 
-        {{- "" }} var(req.base),map_reg({{ $fgroup.VarNamespaceMap.RegexFile }},-)
+        {{- "" }} var(req.base),map_reg({{ $fmaps.VarNamespaceMap.RegexFile }},-)
         {{- "" }} if { var(txn.namespace) -- - }
 {{- end }}
 {{- end }}
@@ -874,8 +874,8 @@ frontend {{ $frontend.Name }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-Cert
 
 {{- /*------------------------------------*/}}
-{{- if $fgroup.HasMaxBody }}
-    http-request set-var(req.maxbody) var(req.base),map_beg_int({{ $fgroup.MaxBodySizeMap.MatchFile }},0)
+{{- if $frontend.HasMaxBody }}
+    http-request set-var(req.maxbody) var(req.base),map_beg_int({{ $fmaps.MaxBodySizeMap.MatchFile }},0)
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -883,61 +883,61 @@ frontend {{ $frontend.Name }}
 {{- $mandatory := $hosts.HasTLSMandatory }}
     acl tls-has-crt ssl_c_used
 {{- if $mandatory }}
-    acl tls-need-crt ssl_fc_sni -i -f {{ $fgroup.TLSNoCrtErrorList.MatchFile }}
-{{- if $fgroup.TLSNoCrtErrorList.HasRegex }}
-    acl tls-need-crt ssl_fc_sni -i -m reg -f {{ $fgroup.TLSNoCrtErrorList.RegexFile }}
+    acl tls-need-crt ssl_fc_sni -i -f {{ $fmaps.TLSNoCrtErrorList.MatchFile }}
+{{- if $fmaps.TLSNoCrtErrorList.HasRegex }}
+    acl tls-need-crt ssl_fc_sni -i -m reg -f {{ $fmaps.TLSNoCrtErrorList.RegexFile }}
 {{- end }}
 {{- end }}
-    acl tls-host-need-crt var(req.host) -i -f {{ $fgroup.TLSNoCrtErrorList.MatchFile }}
-{{- if $fgroup.TLSNoCrtErrorList.HasRegex }}
-    acl tls-host-need-crt var(req.host) -i -m reg -f {{ $fgroup.TLSNoCrtErrorList.RegexFile }}
+    acl tls-host-need-crt var(req.host) -i -f {{ $fmaps.TLSNoCrtErrorList.MatchFile }}
+{{- if $fmaps.TLSNoCrtErrorList.HasRegex }}
+    acl tls-host-need-crt var(req.host) -i -m reg -f {{ $fmaps.TLSNoCrtErrorList.RegexFile }}
 {{- end }}
     acl tls-has-invalid-crt ssl_c_ca_err gt 0
     acl tls-has-invalid-crt ssl_c_err gt 0
-    acl tls-check-crt ssl_fc_sni -i -f {{ $fgroup.TLSInvalidCrtErrorList.MatchFile }}
-{{- if $fgroup.TLSInvalidCrtErrorList.HasRegex }}
-    acl tls-check-crt ssl_fc_sni -i -m reg -f {{ $fgroup.TLSInvalidCrtErrorList.RegexFile }}
+    acl tls-check-crt ssl_fc_sni -i -f {{ $fmaps.TLSInvalidCrtErrorList.MatchFile }}
+{{- if $fmaps.TLSInvalidCrtErrorList.HasRegex }}
+    acl tls-check-crt ssl_fc_sni -i -m reg -f {{ $fmaps.TLSInvalidCrtErrorList.RegexFile }}
 {{- end }}
     http-request set-var(req.path) path
     http-request set-var(req.snibase) ssl_fc_sni,concat(,req.path),lower
-{{- if $fgroup.SNIBackendsMap.HasRegex }}
+{{- if $fmaps.SNIBackendsMap.HasRegex }}
     http-request set-var(req.snibackend) var(req.snibase)
-        {{- "" }},map_beg({{ $fgroup.SNIBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fmaps.SNIBackendsMap.MatchFile }})
     http-request set-var(req.snibackend) var(req.snibase)
-        {{- "" }},map_reg({{ $fgroup.SNIBackendsMap.RegexFile }})
+        {{- "" }},map_reg({{ $fmaps.SNIBackendsMap.RegexFile }})
         {{- "" }} if !{ var(req.snibackend) -m found }
     http-request set-var(req.snibackend) var(req.base)
-        {{- "" }},map_beg({{ $fgroup.SNIBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fmaps.SNIBackendsMap.MatchFile }})
         {{- "" }} if !{ var(req.snibackend) -m found }
         {{- "" }} !tls-has-crt !tls-host-need-crt
     http-request set-var(req.snibackend) var(req.base)
-        {{- "" }},map_reg({{ $fgroup.SNIBackendsMap.RegexFile }})
+        {{- "" }},map_reg({{ $fmaps.SNIBackendsMap.RegexFile }})
         {{- "" }} if !{ var(req.snibackend) -m found }
         {{- "" }} !tls-has-crt !tls-host-need-crt
 {{- else }}
     http-request set-var(req.snibackend) var(req.snibase)
-        {{- "" }},map_beg({{ $fgroup.SNIBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fmaps.SNIBackendsMap.MatchFile }})
     http-request set-var(req.snibackend) var(req.base)
-        {{- "" }},map_beg({{ $fgroup.SNIBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fmaps.SNIBackendsMap.MatchFile }})
         {{- "" }} if !{ var(req.snibackend) -m found }
         {{- "" }} !tls-has-crt !tls-host-need-crt
 {{- end }}
 {{- if $mandatory }}
     http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower
-        {{- "" }},map({{ $fgroup.TLSNoCrtErrorPagesMap.MatchFile }},_internal)
+        {{- "" }},map({{ $fmaps.TLSNoCrtErrorPagesMap.MatchFile }},_internal)
         {{- "" }} if !tls-has-crt tls-need-crt
-{{- if $fgroup.TLSNoCrtErrorPagesMap.HasRegex }}
+{{- if $fmaps.TLSNoCrtErrorPagesMap.HasRegex }}
     http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower
-        {{- "" }},map_reg({{ $fgroup.TLSNoCrtErrorPagesMap.RegexFile }},_internal)
+        {{- "" }},map_reg({{ $fmaps.TLSNoCrtErrorPagesMap.RegexFile }},_internal)
         {{- "" }} if { var(req.tls_nocrt_redir) _internal }
 {{- end }}
 {{- end }}
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower
-        {{- "" }},map({{ $fgroup.TLSInvalidCrtErrorPagesMap.MatchFile }},_internal)
+        {{- "" }},map({{ $fmaps.TLSInvalidCrtErrorPagesMap.MatchFile }},_internal)
         {{- "" }} if tls-has-invalid-crt tls-check-crt
-{{- if $fgroup.TLSInvalidCrtErrorPagesMap.HasRegex }}
+{{- if $fmaps.TLSInvalidCrtErrorPagesMap.HasRegex }}
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower
-        {{- "" }},map_reg({{ $fgroup.TLSInvalidCrtErrorPagesMap.RegexFile }},_internal)
+        {{- "" }},map_reg({{ $fmaps.TLSInvalidCrtErrorPagesMap.RegexFile }},_internal)
         {{- "" }} if { var(req.tls_invalidcrt_redir) _internal }
 {{- end }}
 {{- if and $mandatory $hosts.HasNoCrtErrorPage }}
@@ -956,7 +956,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $fgroup.HasMaxBody }}
+{{- if $frontend.HasMaxBody }}
     http-request use-service lua.send-413 if
         {{- "" }} !{ var(req.maxbody) 0 } { req.body_size,sub(req.maxbody) gt 0 }
 {{- end }}
@@ -984,7 +984,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 {{- template "defaultbackend" map $cfg }}
 
-{{- end }}{{/* if $fgroup */}}
+{{- end }}{{/* if $fmaps */}}
 
 {{- /*------------------------------------*/}}
 {{- /*------------------------------------*/}}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -597,7 +597,7 @@ backend _error404
 # #   FRONTENDS
 # #
 #
-{{- $frontend := $fgroup.Frontend }}
+{{- $frontend := $cfg.Frontend }}
 {{- if $fgroup.HasSSLPassthrough }}
 
   # # # # # # # # # # # # # # # # # # #
@@ -642,26 +642,24 @@ listen _front__tls
     use_backend %[var(req.sslpassback)] if { var(req.sslpassback) -m found }
 {{- end }}
 {{- if $frontend.Hosts }}
-{{- $bind := $frontend.Bind }}
-    ## {{ $bind.Name }}
-    use-server _server{{ $bind.Name }} if { req.ssl_sni -i -f {{ $fgroup.UseServerList.MatchFile }} }
-    server _server{{ $bind.Name }} {{ $bind.Socket }} send-proxy-v2 weight 0
+    ## {{ $frontend.BindName }}
+    use-server _server{{ $frontend.BindName }} if { req.ssl_sni -i -f {{ $fgroup.UseServerList.MatchFile }} }
+    server _server{{ $frontend.BindName }} {{ $frontend.BindSocket }} send-proxy-v2 weight 0
 {{- end }}
 
 {{- /*------------------------------------*/}}
 {{- if $fgroup.SSLPassthroughMap.HasRegex }}
     use_backend %[var(req.sslpassback)] if { var(req.sslpassback) -m found }
 {{- end }}
-{{- $bind := $frontend.Bind }}
 {{- if $fgroup.UseServerList.HasRegex }}
-    ## {{ $bind.Name }} wildcard
-    use-server _server{{ $bind.Name }}_wildcard if { req.ssl_sni -i -m reg -f {{ $fgroup.UseServerList.RegexFile }} }
-    server _server{{ $bind.Name }}_wildcard {{ $bind.Socket }} send-proxy-v2 weight 0
+    ## {{ $frontend.BindName }} wildcard
+    use-server _server{{ $frontend.BindName }}_wildcard if { req.ssl_sni -i -m reg -f {{ $fgroup.UseServerList.RegexFile }} }
+    server _server{{ $frontend.BindName }}_wildcard {{ $frontend.BindSocket }} send-proxy-v2 weight 0
 {{- end }}
 
 {{- /*------------------------------------*/}}
     # default backend
-    server _default_server{{ $frontend.Bind.Name }} {{ $frontend.Bind.Socket }} send-proxy-v2
+    server _default_server{{ $frontend.BindName }} {{ $frontend.BindSocket }} send-proxy-v2
 {{- end }}
 
 {{- $hasFrontingProxy := $global.Bind.HasFrontingProxy }}
@@ -755,7 +753,7 @@ frontend _front_http
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $fgroup.HasVarNamespace }}
+{{- if $frontend.HasVarNamespace }}
     http-request set-var(txn.namespace) 
         {{- "" }} var(req.base),map_beg({{ $fgroup.VarNamespaceMap.MatchFile }},-)
 {{- if $fgroup.VarNamespaceMap.HasRegex }}
@@ -809,11 +807,10 @@ frontend {{ $frontend.Name }}
     mode http
 
 {{- /*------------------------------------*/}}
-{{- $bind := $frontend.Bind }}
-{{- if $bind.Socket }}
-    bind {{ $bind.Socket }}
-        {{- if $bind.ID }} id {{ $bind.ID }}{{ end }}
-        {{- if $bind.AcceptProxy }} accept-proxy{{ end }}
+{{- if $frontend.BindSocket }}
+    bind {{ $frontend.BindSocket }}
+        {{- if $frontend.BindID }} id {{ $frontend.BindID }}{{ end }}
+        {{- if $frontend.AcceptProxy }} accept-proxy{{ end }}
         {{- "" }} ssl alpn {{ $global.SSL.ALPN }}
         {{- "" }} crt-list {{ $fgroup.CrtList.MatchFile }}
         {{- "" }} ca-ignore-err all crt-ignore-err all
@@ -829,7 +826,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $frontend.HasTLSAuth $fgroup.HostBackendsMap.HasRegex $fgroup.HasVarNamespace $fgroup.HasMaxBody }}
+{{- if or $frontend.HasTLSAuth $fgroup.HostBackendsMap.HasRegex $frontend.HasVarNamespace $fgroup.HasMaxBody }}
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
     http-request set-var(req.hostbackend)
         {{- "" }} var(req.base),map_beg({{ $fgroup.HostBackendsMap.MatchFile }})
@@ -858,7 +855,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $fgroup.HasVarNamespace }}
+{{- if $frontend.HasVarNamespace }}
     http-request set-var(txn.namespace) 
         {{- "" }} var(req.base),map_beg({{ $fgroup.VarNamespaceMap.MatchFile }},-)
 {{- if $fgroup.VarNamespaceMap.HasRegex }}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -597,8 +597,8 @@ backend _error404
 # #   FRONTENDS
 # #
 #
-{{- $frontends := $fgroup.Frontends }}
-{{- if $fgroup.HasTCPProxy }}
+{{- $frontend := $fgroup.Frontend }}
+{{- if $fgroup.HasSSLPassthrough }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -641,31 +641,27 @@ listen _front__tls
 {{- if $fgroup.HasSSLPassthrough }}
     use_backend %[var(req.sslpassback)] if { var(req.sslpassback) -m found }
 {{- end }}
-{{- range $frontend := $frontends }}
 {{- if $frontend.Hosts }}
 {{- $bind := $frontend.Bind }}
     ## {{ $bind.Name }}
-    use-server _server{{ $bind.Name }} if { req.ssl_sni -i -f {{ $bind.UseServerList.MatchFile }} }
+    use-server _server{{ $bind.Name }} if { req.ssl_sni -i -f {{ $fgroup.UseServerList.MatchFile }} }
     server _server{{ $bind.Name }} {{ $bind.Socket }} send-proxy-v2 weight 0
-{{- end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
 {{- if $fgroup.SSLPassthroughMap.HasRegex }}
     use_backend %[var(req.sslpassback)] if { var(req.sslpassback) -m found }
 {{- end }}
-{{- range $frontend := $frontends }}
 {{- $bind := $frontend.Bind }}
-{{- if $bind.UseServerList.HasRegex }}
+{{- if $fgroup.UseServerList.HasRegex }}
     ## {{ $bind.Name }} wildcard
-    use-server _server{{ $bind.Name }}_wildcard if { req.ssl_sni -i -m reg -f {{ $bind.UseServerList.RegexFile }} }
+    use-server _server{{ $bind.Name }}_wildcard if { req.ssl_sni -i -m reg -f {{ $fgroup.UseServerList.RegexFile }} }
     server _server{{ $bind.Name }}_wildcard {{ $bind.Socket }} send-proxy-v2 weight 0
-{{- end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
     # default backend
-    server _default_server{{ $fgroup.DefaultBind.Name }} {{ $fgroup.DefaultBind.Socket }} send-proxy-v2
+    server _default_server{{ $frontend.Bind.Name }} {{ $frontend.Bind.Socket }} send-proxy-v2
 {{- end }}
 
 {{- $hasFrontingProxy := $global.Bind.HasFrontingProxy }}
@@ -676,15 +672,14 @@ listen _front__tls
 #
 frontend _front_http
     mode http
-{{- $frontingBind := $fgroup.ToHTTPBind }}
 {{- $hasPlainHTTPSocket := not $global.Bind.ShareHTTPPort }}
 {{- if and $global.Bind.HTTPBind $hasPlainHTTPSocket }}
     bind {{ $global.Bind.HTTPBind }}{{ if $global.Bind.AcceptProxy }} accept-proxy{{ end }}
 {{- end }}
-{{- if $frontingBind.Socket }}
-    bind {{ $frontingBind.Socket }}
-        {{- if and $hasPlainHTTPSocket $frontingBind.ID }} id {{ $frontingBind.ID }}{{ end }}
-        {{- if $frontingBind.AcceptProxy }} accept-proxy{{ end }}
+{{- if $global.Bind.FrontingBind }}
+    bind {{ $global.Bind.FrontingBind }}
+        {{- if and $hasPlainHTTPSocket $global.Bind.FrontingSockID }} id {{ $global.Bind.FrontingSockID }}{{ end }}
+        {{- if $global.Bind.AcceptProxy }} accept-proxy{{ end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -810,7 +805,6 @@ frontend _front_http
 # #
 #     HTTPS frontend
 #
-{{- range $frontend := $frontends }}
 frontend {{ $frontend.Name }}
     mode http
 
@@ -820,8 +814,8 @@ frontend {{ $frontend.Name }}
     bind {{ $bind.Socket }}
         {{- if $bind.ID }} id {{ $bind.ID }}{{ end }}
         {{- if $bind.AcceptProxy }} accept-proxy{{ end }}
-        {{- "" }} ssl alpn {{ $bind.ALPN }}
-        {{- "" }} crt-list {{ $bind.CrtList.MatchFile }}
+        {{- "" }} ssl alpn {{ $global.SSL.ALPN }}
+        {{- "" }} crt-list {{ $fgroup.CrtList.MatchFile }}
         {{- "" }} ca-ignore-err all crt-ignore-err all
 {{- end }}
 
@@ -835,30 +829,30 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $frontend.HasTLSAuth $frontend.HostBackendsMap.HasRegex $fgroup.HasVarNamespace $frontend.HasMaxBody }}
+{{- if or $frontend.HasTLSAuth $fgroup.HostBackendsMap.HasRegex $fgroup.HasVarNamespace $fgroup.HasMaxBody }}
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
     http-request set-var(req.hostbackend)
-        {{- "" }} var(req.base),map_beg({{ $frontend.HostBackendsMap.MatchFile }})
+        {{- "" }} var(req.base),map_beg({{ $fgroup.HostBackendsMap.MatchFile }})
 {{- else }}
     http-request set-var(req.hostbackend) base,lower,regsub(:[0-9]+/,/)
-        {{- "" }},map_beg({{ $frontend.HostBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fgroup.HostBackendsMap.MatchFile }})
 {{- end }}
-{{- if $frontend.HostBackendsMap.HasRegex }}
+{{- if $fgroup.HostBackendsMap.HasRegex }}
     http-request set-var(req.hostbackend)
-        {{- "" }} var(req.base),map_reg({{ $frontend.HostBackendsMap.RegexFile }})
+        {{- "" }} var(req.base),map_reg({{ $fgroup.HostBackendsMap.RegexFile }})
         {{- "" }} if !{ var(req.hostbackend) -m found }
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $frontend.HasTLSAuth $frontend.RootRedirMap.HasHost }}
+{{- if or $frontend.HasTLSAuth $fgroup.RootRedirMap.HasHost }}
     http-request set-var(req.host) hdr(host),lower,regsub(:[0-9]+$,)
 {{- end }}
-{{- if $frontend.RootRedirMap.HasHost }}
+{{- if $fgroup.RootRedirMap.HasHost }}
     http-request set-var(req.rootredir)
-        {{- "" }} var(req.host),map({{ $frontend.RootRedirMap.MatchFile }})
-{{- if $frontend.RootRedirMap.HasRegex }}
+        {{- "" }} var(req.host),map({{ $fgroup.RootRedirMap.MatchFile }})
+{{- if $fgroup.RootRedirMap.HasRegex }}
     http-request set-var(req.rootredir)
-        {{- "" }} var(req.host),map_reg({{ $frontend.RootRedirMap.RegexFile }}) if !{ var(req.rootredir) -m found }
+        {{- "" }} var(req.host),map_reg({{ $fgroup.RootRedirMap.RegexFile }}) if !{ var(req.rootredir) -m found }
 {{- end }}
     http-request redirect location %[var(req.rootredir)] if { path / } { var(req.rootredir) -m found }
 {{- end }}
@@ -882,8 +876,8 @@ frontend {{ $frontend.Name }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-Cert
 
 {{- /*------------------------------------*/}}
-{{- if $frontend.HasMaxBody }}
-    http-request set-var(req.maxbody) var(req.base),map_beg_int({{ $frontend.MaxBodySizeMap.MatchFile }},0)
+{{- if $fgroup.HasMaxBody }}
+    http-request set-var(req.maxbody) var(req.base),map_beg_int({{ $fgroup.MaxBodySizeMap.MatchFile }},0)
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -891,61 +885,61 @@ frontend {{ $frontend.Name }}
 {{- $mandatory := $frontend.HasTLSMandatory }}
     acl tls-has-crt ssl_c_used
 {{- if $mandatory }}
-    acl tls-need-crt ssl_fc_sni -i -f {{ $frontend.TLSNoCrtErrorList.MatchFile }}
-{{- if $frontend.TLSNoCrtErrorList.HasRegex }}
-    acl tls-need-crt ssl_fc_sni -i -m reg -f {{ $frontend.TLSNoCrtErrorList.RegexFile }}
+    acl tls-need-crt ssl_fc_sni -i -f {{ $fgroup.TLSNoCrtErrorList.MatchFile }}
+{{- if $fgroup.TLSNoCrtErrorList.HasRegex }}
+    acl tls-need-crt ssl_fc_sni -i -m reg -f {{ $fgroup.TLSNoCrtErrorList.RegexFile }}
 {{- end }}
 {{- end }}
-    acl tls-host-need-crt var(req.host) -i -f {{ $frontend.TLSNoCrtErrorList.MatchFile }}
-{{- if $frontend.TLSNoCrtErrorList.HasRegex }}
-    acl tls-host-need-crt var(req.host) -i -m reg -f {{ $frontend.TLSNoCrtErrorList.RegexFile }}
+    acl tls-host-need-crt var(req.host) -i -f {{ $fgroup.TLSNoCrtErrorList.MatchFile }}
+{{- if $fgroup.TLSNoCrtErrorList.HasRegex }}
+    acl tls-host-need-crt var(req.host) -i -m reg -f {{ $fgroup.TLSNoCrtErrorList.RegexFile }}
 {{- end }}
     acl tls-has-invalid-crt ssl_c_ca_err gt 0
     acl tls-has-invalid-crt ssl_c_err gt 0
-    acl tls-check-crt ssl_fc_sni -i -f {{ $frontend.TLSInvalidCrtErrorList.MatchFile }}
-{{- if $frontend.TLSInvalidCrtErrorList.HasRegex }}
-    acl tls-check-crt ssl_fc_sni -i -m reg -f {{ $frontend.TLSInvalidCrtErrorList.RegexFile }}
+    acl tls-check-crt ssl_fc_sni -i -f {{ $fgroup.TLSInvalidCrtErrorList.MatchFile }}
+{{- if $fgroup.TLSInvalidCrtErrorList.HasRegex }}
+    acl tls-check-crt ssl_fc_sni -i -m reg -f {{ $fgroup.TLSInvalidCrtErrorList.RegexFile }}
 {{- end }}
     http-request set-var(req.path) path
     http-request set-var(req.snibase) ssl_fc_sni,concat(,req.path),lower
-{{- if $frontend.SNIBackendsMap.HasRegex }}
+{{- if $fgroup.SNIBackendsMap.HasRegex }}
     http-request set-var(req.snibackend) var(req.snibase)
-        {{- "" }},map_beg({{ $frontend.SNIBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fgroup.SNIBackendsMap.MatchFile }})
     http-request set-var(req.snibackend) var(req.snibase)
-        {{- "" }},map_reg({{ $frontend.SNIBackendsMap.RegexFile }})
+        {{- "" }},map_reg({{ $fgroup.SNIBackendsMap.RegexFile }})
         {{- "" }} if !{ var(req.snibackend) -m found }
     http-request set-var(req.snibackend) var(req.base)
-        {{- "" }},map_beg({{ $frontend.SNIBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fgroup.SNIBackendsMap.MatchFile }})
         {{- "" }} if !{ var(req.snibackend) -m found }
         {{- "" }} !tls-has-crt !tls-host-need-crt
     http-request set-var(req.snibackend) var(req.base)
-        {{- "" }},map_reg({{ $frontend.SNIBackendsMap.RegexFile }})
+        {{- "" }},map_reg({{ $fgroup.SNIBackendsMap.RegexFile }})
         {{- "" }} if !{ var(req.snibackend) -m found }
         {{- "" }} !tls-has-crt !tls-host-need-crt
 {{- else }}
     http-request set-var(req.snibackend) var(req.snibase)
-        {{- "" }},map_beg({{ $frontend.SNIBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fgroup.SNIBackendsMap.MatchFile }})
     http-request set-var(req.snibackend) var(req.base)
-        {{- "" }},map_beg({{ $frontend.SNIBackendsMap.MatchFile }})
+        {{- "" }},map_beg({{ $fgroup.SNIBackendsMap.MatchFile }})
         {{- "" }} if !{ var(req.snibackend) -m found }
         {{- "" }} !tls-has-crt !tls-host-need-crt
 {{- end }}
 {{- if $mandatory }}
     http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower
-        {{- "" }},map({{ $frontend.TLSNoCrtErrorPagesMap.MatchFile }},_internal)
+        {{- "" }},map({{ $fgroup.TLSNoCrtErrorPagesMap.MatchFile }},_internal)
         {{- "" }} if !tls-has-crt tls-need-crt
-{{- if $frontend.TLSNoCrtErrorPagesMap.HasRegex }}
+{{- if $fgroup.TLSNoCrtErrorPagesMap.HasRegex }}
     http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower
-        {{- "" }},map_reg({{ $frontend.TLSNoCrtErrorPagesMap.RegexFile }},_internal)
+        {{- "" }},map_reg({{ $fgroup.TLSNoCrtErrorPagesMap.RegexFile }},_internal)
         {{- "" }} if { var(req.tls_nocrt_redir) _internal }
 {{- end }}
 {{- end }}
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower
-        {{- "" }},map({{ $frontend.TLSInvalidCrtErrorPagesMap.MatchFile }},_internal)
+        {{- "" }},map({{ $fgroup.TLSInvalidCrtErrorPagesMap.MatchFile }},_internal)
         {{- "" }} if tls-has-invalid-crt tls-check-crt
-{{- if $frontend.TLSInvalidCrtErrorPagesMap.HasRegex }}
+{{- if $fgroup.TLSInvalidCrtErrorPagesMap.HasRegex }}
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower
-        {{- "" }},map_reg({{ $frontend.TLSInvalidCrtErrorPagesMap.RegexFile }},_internal)
+        {{- "" }},map_reg({{ $fgroup.TLSInvalidCrtErrorPagesMap.RegexFile }},_internal)
         {{- "" }} if { var(req.tls_invalidcrt_redir) _internal }
 {{- end }}
 {{- if and $mandatory $frontend.HasNoCrtErrorPage }}
@@ -964,7 +958,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $frontend.HasMaxBody }}
+{{- if $fgroup.HasMaxBody }}
     http-request use-service lua.send-413 if
         {{- "" }} !{ var(req.maxbody) 0 } { req.body_size,sub(req.maxbody) gt 0 }
 {{- end }}
@@ -991,7 +985,6 @@ frontend {{ $frontend.Name }}
         {{- "" }} if { var(req.snibackend) -m found }
 {{- end }}
 {{- template "defaultbackend" map $cfg }}
-{{- end }}
 
 {{- end }}{{/* if $fgroup */}}
 


### PR DESCRIPTION
Frontend group was used to group all frontends, binds and their related map files into a single entity. The need of a list of frontends doesn't exist anymore, so all inner entities and funcs are being moved on behalf of simplicity and cohesion, which will simplify future improvements. Further details in the message of the commits. There are no functionality changes.