### PR TITLE
Move max body size to the backend

### DIFF
--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -151,6 +151,16 @@ func (b *Backend) CreateConfigBool(value bool) []*BackendConfigBool {
 	}
 }
 
+// CreateConfigInt ...
+func (b *Backend) CreateConfigInt(value int64) []*BackendConfigInt {
+	return []*BackendConfigInt{
+		{
+			Paths:  NewBackendPaths(b.Paths...),
+			Config: value,
+		},
+	}
+}
+
 // HasCorsEnabled ...
 func (b *Backend) HasCorsEnabled() bool {
 	for _, cors := range b.Cors {
@@ -201,18 +211,6 @@ func (b *Backend) HasSSLRedirectPaths(paths *BackendPaths) bool {
 		}
 	}
 	return false
-}
-
-// MaxBodySizeHostpath ...
-func (b *Backend) MaxBodySizeHostpath(hostpath string) int64 {
-	for _, maxbodysize := range b.MaxBodySize {
-		for _, path := range maxbodysize.Paths.Items {
-			if path.Hostpath == hostpath {
-				return maxbodysize.Config
-			}
-		}
-	}
-	return 0
 }
 
 // NeedACL ...

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -122,11 +122,6 @@ func (hm *HostsMaps) AddMap(filename string) *HostsMap {
 	return hmap
 }
 
-// HasMaxBody ...
-func (f *Frontend) HasMaxBody() bool {
-	return f.Maps.MaxBodySizeMap.HasHost()
-}
-
 // String ...
 func (f *Frontend) String() string {
 	return fmt.Sprintf("%+v", *f)

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -255,7 +255,6 @@ type FrontendMaps struct {
 	VarNamespaceMap   *HostsMap
 	//
 	HostBackendsMap            *HostsMap
-	MaxBodySizeMap             *HostsMap
 	RootRedirMap               *HostsMap
 	SNIBackendsMap             *HostsMap
 	TLSInvalidCrtErrorList     *HostsMap

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -357,6 +357,16 @@ backend {{ $backend.ID }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- $needACL := gt (len $backend.MaxBodySize) 1 }}
+{{- range $maxbody := $backend.MaxBodySize }}
+{{- if $maxbody.Config }}
+    http-request use-service lua.send-413 if
+        {{- if $needACL }} { var(txn.pathID) {{ $maxbody.Paths.IDList }} }{{ end }}
+        {{- "" }} { req.body_size,sub({{ $maxbody.Config }}) gt 0 }
+{{- end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
 {{- if and $global.ModSecurity.Endpoints $backend.HasModsec }}
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
 {{- $needACL := gt (len $backend.WAF) 1 }}
@@ -828,7 +838,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $hosts.HasTLSAuth $fmaps.HostBackendsMap.HasRegex $hosts.HasVarNamespace $frontend.HasMaxBody }}
+{{- if or $hosts.HasTLSAuth $fmaps.HostBackendsMap.HasRegex $hosts.HasVarNamespace }}
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
     http-request set-var(req.hostbackend)
         {{- "" }} var(req.base),map_beg({{ $fmaps.HostBackendsMap.MatchFile }})
@@ -873,11 +883,6 @@ frontend {{ $frontend.Name }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-DN
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-SHA1
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-Cert
-
-{{- /*------------------------------------*/}}
-{{- if $frontend.HasMaxBody }}
-    http-request set-var(req.maxbody) var(req.base),map_beg_int({{ $fmaps.MaxBodySizeMap.MatchFile }},0)
-{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- if $hosts.HasTLSAuth }}
@@ -957,10 +962,6 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $frontend.HasMaxBody }}
-    http-request use-service lua.send-413 if
-        {{- "" }} !{ var(req.maxbody) 0 } { req.body_size,sub(req.maxbody) gt 0 }
-{{- end }}
 {{- if $hosts.HasTLSAuth }}
     http-request use-service lua.send-421 if
         {{- "" }} tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }


### PR DESCRIPTION
Some HTTP status code cannot be generated by haproxy, eg 413. Validations that needed to issue such codes should be implemented in the frontend, so a backend with a customised error code could be selected.

This limitation was removed since error-only backends were changed to Lua scripts. A Lua script allows to build the response payload, use any customised error code, and such codes are correctly assigned in log messages.