### PR TITLE
Add host lookup with hash table

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -563,7 +563,7 @@ func (c *updater) buildBackendOAuth(d *backData) {
 }
 
 func (c *updater) findBackend(namespace, uriPrefix string) *hatypes.HostBackend {
-	for _, host := range c.haproxy.Hosts().Items {
+	for _, host := range c.haproxy.Hosts().Items() {
 		for _, path := range host.Paths {
 			if strings.TrimRight(path.Path, "/") == uriPrefix && path.Backend.Namespace == namespace {
 				return &path.Backend

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -180,7 +180,7 @@ func (c *converter) syncIngress(ing *extensions.Ingress) {
 
 func (c *converter) syncAnnotations() {
 	c.updater.UpdateGlobalConfig(c.haproxy, c.globalConfig)
-	for _, host := range c.haproxy.Hosts().Items {
+	for _, host := range c.haproxy.Hosts().Items() {
 		if ann, found := c.hostAnnotations[host]; found {
 			c.updater.UpdateHostConfig(host, ann)
 		}

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -1362,7 +1362,7 @@ func convertHost(hafronts ...*hatypes.Host) []hostMock {
 }
 
 func (c *testConfig) compareConfigFront(expected string) {
-	c.compareText(_yamlMarshal(convertHost(c.hconfig.Hosts().Items...)), expected)
+	c.compareText(_yamlMarshal(convertHost(c.hconfig.Hosts().Items()...)), expected)
 }
 
 func (c *testConfig) compareConfigDefaultFront(expected string) {

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -77,7 +77,7 @@ func createConfig(options options) *config {
 		acme:         &hatypes.Acme{},
 		global:       &hatypes.Global{},
 		frontend:     &hatypes.Frontend{Name: "_front001"},
-		hosts:        &hatypes.Hosts{},
+		hosts:        hatypes.CreateHosts(),
 		backends:     hatypes.CreateBackends(),
 		mapsTemplate: mapsTemplate,
 		mapsDir:      options.mapsDir,
@@ -151,7 +151,7 @@ func (c *config) SyncConfig() {
 		c.frontend.BindSocket = c.global.Bind.HTTPSBind
 		c.frontend.AcceptProxy = c.global.Bind.AcceptProxy
 	}
-	for _, host := range c.hosts.Items {
+	for _, host := range c.hosts.Items() {
 		if host.SSLPassthrough {
 			// no action if ssl-passthrough
 			continue
@@ -215,7 +215,7 @@ func (c *config) WriteFrontendMaps() error {
 	//  1. match with path_beg/map_beg, /path has a feature and a declared /path/sub doesn't have
 	//  2. *.host.domain wildcard/alias/alias-regex has a feature and a declared sub.host.domain doesn't have
 	yesno := map[bool]string{true: "yes", false: "no"}
-	for _, host := range c.hosts.Items {
+	for _, host := range c.hosts.Items() {
 		if host.SSLPassthrough {
 			rootPath := host.FindPath("/")
 			if rootPath == nil {

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -327,14 +327,14 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 func (i *instance) updateCertExpiring() {
 	// TODO move to dynupdate when dynamic crt update is implemented
 	if i.oldConfig == nil {
-		for _, curHost := range i.curConfig.Hosts().Items {
+		for _, curHost := range i.curConfig.Hosts().Items() {
 			if curHost.TLS.HasTLS() {
 				i.metrics.SetCertExpireDate(curHost.Hostname, curHost.TLS.TLSCommonName, &curHost.TLS.TLSNotAfter)
 			}
 		}
 		return
 	}
-	for _, oldHost := range i.oldConfig.Hosts().Items {
+	for _, oldHost := range i.oldConfig.Hosts().Items() {
 		if !oldHost.TLS.HasTLS() {
 			continue
 		}
@@ -343,7 +343,7 @@ func (i *instance) updateCertExpiring() {
 			i.metrics.SetCertExpireDate(oldHost.Hostname, oldHost.TLS.TLSCommonName, nil)
 		}
 	}
-	for _, curHost := range i.curConfig.Hosts().Items {
+	for _, curHost := range i.curConfig.Hosts().Items() {
 		if !curHost.TLS.HasTLS() {
 			continue
 		}

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -279,7 +279,8 @@ type Frontend struct {
 
 // Hosts ...
 type Hosts struct {
-	Items       []*Host
+	itemslist   []*Host
+	itemsmap    map[string]*Host
 	defaultHost *Host
 }
 


### PR DESCRIPTION
The current implementation uses two data structures, a slice which saves the order and a map which saves the index. To be reviewed. A getter facade was also implemented in order to standardise access to the ordered data.