### PR TITLE
Add backend lookup with hash table

### DIFF
--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -17,13 +17,14 @@ limitations under the License.
 package types
 
 import (
-	"fmt"
 	"sort"
 )
 
 // CreateBackends ...
 func CreateBackends() *Backends {
-	return &Backends{}
+	return &Backends{
+		itemsmap: map[string]*Backend{},
+	}
 }
 
 // Items ...
@@ -37,6 +38,12 @@ func (b *Backends) AcquireBackend(namespace, name, port string) *Backend {
 		return backend
 	}
 	backend := createBackend(namespace, name, port)
+	// Store backends on slice and map data structure.
+	// The slice has the order and the map has the index.
+	// TODO current approach is using the double of the memory
+	// on behalf of speed. Map only is doable? Another approach?
+	// See also hosts.AcquireHost().
+	b.itemsmap[backend.ID] = backend
 	b.itemslist = append(b.itemslist, backend)
 	b.sortBackends()
 	return backend
@@ -44,12 +51,7 @@ func (b *Backends) AcquireBackend(namespace, name, port string) *Backend {
 
 // FindBackend ...
 func (b *Backends) FindBackend(namespace, name, port string) *Backend {
-	for _, b := range b.itemslist {
-		if b.Namespace == namespace && b.Name == name && b.Port == port {
-			return b
-		}
-	}
-	return nil
+	return b.itemsmap[buildID(namespace, name, port)]
 }
 
 // DefaultBackend ...
@@ -93,5 +95,5 @@ func createBackend(namespace, name, port string) *Backend {
 }
 
 func buildID(namespace, name, port string) string {
-	return fmt.Sprintf("%s_%s_%s", namespace, name, port)
+	return namespace + "_" + name + "_" + port
 }

--- a/pkg/haproxy/types/backends_test.go
+++ b/pkg/haproxy/types/backends_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -35,5 +36,23 @@ func TestBuildID(t *testing.T) {
 		if actual := buildID(test.namespace, test.name, test.port); actual != test.expected {
 			t.Errorf("expected '%s' but was '%s'", test.expected, actual)
 		}
+	}
+}
+
+func BenchmarkBuildIDFmt(b *testing.B) {
+	namespace := "default"
+	name := "app"
+	port := "8080"
+	for i := 0; i < b.N; i++ {
+		_ = fmt.Sprintf("%s_%s_%s", namespace, name, port)
+	}
+}
+
+func BenchmarkBuildIDConcat(b *testing.B) {
+	namespace := "default"
+	name := "app"
+	port := "8080"
+	for i := 0; i < b.N; i++ {
+		_ = namespace + "_" + name + "_" + port
 	}
 }

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -353,6 +353,7 @@ const (
 // Backends ...
 type Backends struct {
 	itemslist      []*Backend
+	itemsmap       map[string]*Backend
 	defaultBackend *Backend
 }
 


### PR DESCRIPTION
The current implementation uses two data structures, a slice which saves the order and a map which saves the index. To be reviewed. Same approach used on hosts.