### PR TITLE
Server-alias doesn't not work on http:80 => 0.7.2 to 0.8.3 #565

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -263,6 +263,8 @@ func (c *config) WriteFrontendMaps() error {
 			}
 			if !hasSSLRedirect || c.global.Bind.HasFrontingProxy() {
 				fmaps.HTTPFrontsMap.AppendHostname(base, backendID)
+				fmaps.HTTPFrontsMap.AppendAliasName(aliasName, backendID)
+				fmaps.HTTPFrontsMap.AppendAliasRegex(aliasRegex, backendID)
 			}
 			var ns string
 			if host.VarNamespace {


### PR DESCRIPTION
I added the missing call functions if we don't have ssl redirect