### PR TITLE
Improve parsing time on big clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/huandu/xstrings v1.2.1 // indirect
 	github.com/imdario/mergo v0.3.5
+	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/kylelemons/godebug v1.1.0
 	github.com/mitchellh/copystructure v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,8 @@ github.com/huandu/xstrings v1.2.1 h1:v6IdmkCnDhJG/S0ivr58PeIfg+tyhqQYy4YsCsQ0Pdc
 github.com/huandu/xstrings v1.2.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
+github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a h1:zPPuIq2jAWWPTrGt70eK/BSch+gFAGrNzecsoENgu2o=
+github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a/go.mod h1:yL958EeXv8Ylng6IfnvG4oflryUi3vgA3xPs9hmII1s=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v0.0.0-20180612202835-f2b4162afba3/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=

--- a/pkg/common/ingress/controller/backend_ssl.go
+++ b/pkg/common/ingress/controller/backend_ssl.go
@@ -43,7 +43,6 @@ func (ic *GenericController) SyncSecret(key string) {
 	cert, err := ic.getPemCertificate(secret)
 	if err != nil {
 		glog.V(3).Infof("syncing a non ca/crt secret %v", key)
-		ic.newctrl.Notify()
 		return
 	}
 
@@ -59,7 +58,6 @@ func (ic *GenericController) SyncSecret(key string) {
 		ic.sslCertTracker.Update(key, cert)
 		// this update must trigger an update
 		// (like an update event from a change in Ingress)
-		ic.newctrl.Notify()
 		return
 	}
 
@@ -67,7 +65,6 @@ func (ic *GenericController) SyncSecret(key string) {
 	ic.sslCertTracker.Add(key, cert)
 	// this update must trigger an update
 	// (like an update event from a change in Ingress)
-	ic.newctrl.Notify()
 }
 
 // getPemCertificate receives a secret, and creates a ingress.SSLCert as return.

--- a/pkg/common/ingress/controller/backend_ssl.go
+++ b/pkg/common/ingress/controller/backend_ssl.go
@@ -61,7 +61,7 @@ func (ic *GenericController) SyncSecret(key string) {
 		return
 	}
 
-	glog.Infof("adding secret %v to the local store", key)
+	glog.V(3).Infof("adding secret %v to the local store", key)
 	ic.sslCertTracker.Add(key, cert)
 	// this update must trigger an update
 	// (like an update event from a change in Ingress)

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -40,7 +40,6 @@ import (
 type NewCtrlIntf interface {
 	GetIngressList() ([]*extensions.Ingress, error)
 	GetSecret(name string) (*apiv1.Secret, error)
-	Notify()
 }
 
 // GenericController holds the boilerplate code required to build an Ingress controlller.

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -195,6 +195,13 @@ func (ic GenericController) GetFullResourceName(name, currentNamespace string) s
 	return name
 }
 
+// UpdateSecret ...
+func (ic GenericController) UpdateSecret(key string) {
+	if _, found := ic.sslCertTracker.Get(key); found {
+		ic.SyncSecret(key)
+	}
+}
+
 // DeleteSecret ...
 func (ic GenericController) DeleteSecret(key string) {
 	ic.sslCertTracker.DeleteAll(key)

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -595,6 +595,7 @@ func (c *k8scache) Notify(old, cur interface{}) {
 			} else {
 				c.secretsUpd = append(c.secretsUpd, secret)
 			}
+			c.controller.UpdateSecret(fmt.Sprintf("%s/%s", secret.Namespace, secret.Name))
 		case *api.ConfigMap:
 			cm := cur.(*api.ConfigMap)
 			key := fmt.Sprintf("%s/%s", cm.Namespace, cm.Name)

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -219,7 +219,7 @@ func (c *k8scache) GetEndpoints(service *api.Service) (*api.Endpoints, error) {
 
 // GetTerminatingPods returns the pods that are terminating and belong
 // (based on the Spec.Selector) to the supplied service.
-func (c *k8scache) GetTerminatingPods(service *api.Service) (pl []*api.Pod, err error) {
+func (c *k8scache) GetTerminatingPods(service *api.Service, track convtypes.TrackingTarget) (pl []*api.Pod, err error) {
 	// converting the service selector to slice of string
 	// in order to create the full match selector
 	var ls []string
@@ -236,6 +236,8 @@ func (c *k8scache) GetTerminatingPods(service *api.Service) (pl []*api.Pod, err 
 		return nil, err
 	}
 	for _, p := range list {
+		// all pods need to be tracked despite of the terminating status
+		c.tracker.Track(false, track, convtypes.PodType, p.Namespace+"/"+p.Name)
 		if isTerminatingPod(service, p) {
 			pl = append(pl, p)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -327,6 +327,7 @@ func (hc *HAProxyController) syncIngress(item interface{}) {
 	// configmap converters
 	//
 	if hc.cfg.TCPConfigMapName != "" {
+		// TODO parses only when tcpconfigmap changes
 		tcpConfigmap, err := hc.cache.GetConfigMap(hc.cfg.TCPConfigMapName)
 		if err == nil && tcpConfigmap != nil {
 			tcpSvcConverter := configmapconverter.NewTCPServicesConverter(

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,18 +20,13 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"sort"
 	"time"
 
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	api "k8s.io/api/core/v1"
 	extensions "k8s.io/api/extensions/v1beta1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes/scheme"
-	typedv1 "k8s.io/client-go/kubernetes/typed/core/v1"
-	"k8s.io/client-go/tools/record"
 
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/acme"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/ingress"
@@ -39,6 +34,7 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/common/net/ssl"
 	configmapconverter "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/configmap"
 	ingressconverter "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/tracker"
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy"
@@ -61,8 +57,6 @@ type HAProxyController struct {
 	controller        *controller.GenericController
 	cfg               *controller.Configuration
 	configMap         *api.ConfigMap
-	recorder          record.EventRecorder
-	listers           *listers
 	converterOptions  *ingtypes.ConverterOptions
 	reloadStrategy    *string
 	maxOldConfigFiles *int
@@ -105,21 +99,11 @@ func (hc *HAProxyController) configController() {
 	hc.controller.SetNewCtrl(hc)
 	hc.logger = &logger{depth: 1}
 	hc.metrics = createMetrics(hc.cfg.BucketsResponseTime)
-	eventBroadcaster := record.NewBroadcaster()
-	eventBroadcaster.StartLogging(hc.logger.Info)
-	watchNamespace := hc.cfg.WatchNamespace
-	eventBroadcaster.StartRecordingToSink(&typedv1.EventSinkImpl{
-		Interface: hc.cfg.Client.CoreV1().Events(watchNamespace),
-	})
-	hc.recorder = eventBroadcaster.NewRecorder(scheme.Scheme, api.EventSource{
-		Component: "ingress-controller",
-	})
-	hc.listers = createListers(
-		hc, hc.logger, hc.recorder, hc.cfg.Client,
-		watchNamespace, hc.cfg.ForceNamespaceIsolation,
-		hc.cfg.ResyncPeriod)
-	hc.cache = newCache(hc.cfg.Client, hc.listers, hc.controller)
 	hc.ingressQueue = utils.NewRateLimitingQueue(hc.cfg.RateLimitUpdate, hc.syncIngress)
+	hc.cache = createCache(
+		hc.logger, hc.cfg.Client, hc.controller, hc.ingressQueue,
+		hc.cfg.WatchNamespace, hc.cfg.ForceNamespaceIsolation,
+		hc.cfg.ResyncPeriod)
 	var acmeSigner acme.Signer
 	if hc.cfg.AcmeServer {
 		electorID := fmt.Sprintf("%s-%s", hc.cfg.AcmeElectionID, hc.cfg.IngressClass)
@@ -150,6 +134,7 @@ func (hc *HAProxyController) configController() {
 	hc.converterOptions = &ingtypes.ConverterOptions{
 		Logger:           hc.logger,
 		Cache:            hc.cache,
+		Tracker:          tracker.NewTracker(),
 		AnnotationPrefix: hc.cfg.AnnPrefix,
 		DefaultBackend:   hc.cfg.DefaultService,
 		DefaultSSLFile:   hc.createDefaultSSLFile(),
@@ -159,7 +144,7 @@ func (hc *HAProxyController) configController() {
 }
 
 func (hc *HAProxyController) startServices() {
-	hc.listers.RunAsync(hc.stopCh)
+	hc.cache.RunAsync(hc.stopCh)
 	go hc.ingressQueue.Run()
 	if hc.cfg.StatsCollectProcPeriod.Milliseconds() > 0 {
 		go wait.Until(func() {
@@ -258,66 +243,16 @@ func (hc *HAProxyController) Stop() error {
 	return err
 }
 
-// Notify ...
-// implements ListerEvents
-// implements oldcontroller.NewCtrlIntf
-func (hc *HAProxyController) Notify() {
-	hc.ingressQueue.Notify()
-}
-
 // GetIngressList ...
 // implements oldcontroller.NewCtrlIntf
 func (hc *HAProxyController) GetIngressList() ([]*extensions.Ingress, error) {
-	return hc.listers.ingressLister.List(labels.Everything())
+	return hc.cache.GetIngressList()
 }
 
 // GetSecret ...
 // implements oldcontroller.NewCtrlIntf
 func (hc *HAProxyController) GetSecret(name string) (*api.Secret, error) {
 	return hc.cache.GetSecret(name)
-}
-
-// UpdateSecret ...
-// implements ListerEvents
-func (hc *HAProxyController) UpdateSecret(key string) {
-	hc.controller.SyncSecret(key)
-}
-
-// DeleteSecret ...
-// implements ListerEvents
-func (hc *HAProxyController) DeleteSecret(key string) {
-	hc.controller.DeleteSecret(key)
-	hc.ingressQueue.Notify()
-}
-
-// AddConfigMap ...
-// implements ListerEvents
-func (hc *HAProxyController) AddConfigMap(cm *api.ConfigMap) {
-	key := fmt.Sprintf("%s/%s", cm.Namespace, cm.Name)
-	if key == hc.cfg.ConfigMapName {
-		hc.logger.InfoV(2, "adding configmap %v to backend", key)
-		hc.configMap = cm
-	}
-}
-
-// UpdateConfigMap ...
-// implements ListerEvents
-func (hc *HAProxyController) UpdateConfigMap(cm *api.ConfigMap) {
-	key := fmt.Sprintf("%s/%s", cm.Namespace, cm.Name)
-	if key == hc.cfg.ConfigMapName {
-		hc.logger.InfoV(2, "updating configmap backend (%v)", key)
-		hc.configMap = cm
-	}
-	if key == hc.cfg.ConfigMapName || key == hc.cfg.TCPConfigMapName {
-		hc.recorder.Eventf(cm, api.EventTypeNormal, "UPDATE", fmt.Sprintf("ConfigMap %v", key))
-		hc.ingressQueue.Notify()
-	}
-}
-
-// IsValidClass ...
-// implements ListerEvents
-func (hc *HAProxyController) IsValidClass(ing *extensions.Ingress) bool {
-	return hc.controller.IsValidClass(ing)
 }
 
 // Name provides the complete name of the controller
@@ -381,35 +316,11 @@ func (hc *HAProxyController) syncIngress(item interface{}) {
 	hc.updateCount++
 	hc.logger.Info("starting HAProxy update id=%d", hc.updateCount)
 	timer := utils.NewTimer(hc.metrics.ControllerProcTime)
-	var ingress []*extensions.Ingress
-	il, err := hc.listers.ingressLister.List(labels.Everything())
-	if err != nil {
-		hc.logger.Error("error reading ingress list: %v", err)
-		return
-	}
-	for _, ing := range il {
-		if hc.controller.IsValidClass(ing) {
-			ingress = append(ingress, ing)
-		}
-	}
-	sort.Slice(ingress, func(i, j int) bool {
-		i1 := ingress[i]
-		i2 := ingress[j]
-		if i1.CreationTimestamp != i2.CreationTimestamp {
-			return i1.CreationTimestamp.Before(&i2.CreationTimestamp)
-		}
-		return i1.Namespace+"/"+i1.Name < i2.Namespace+"/"+i2.Name
-	})
-	var globalConfig map[string]string
-	if hc.configMap != nil {
-		globalConfig = hc.configMap.Data
-	}
 	ingConverter := ingressconverter.NewIngressConverter(
 		hc.converterOptions,
 		hc.instance.Config(),
-		globalConfig,
 	)
-	ingConverter.Sync(ingress)
+	ingConverter.Sync()
 	timer.Tick("parse_ingress")
 
 	//

--- a/pkg/converters/configmap/tcpservices.go
+++ b/pkg/converters/configmap/tcpservices.go
@@ -51,6 +51,8 @@ type tcpSvcConverter struct {
 var regexValidTime = regexp.MustCompile(`^[0-9]+(us|ms|s|m|h|d)$`)
 
 func (c *tcpSvcConverter) Sync(tcpservices map[string]string) {
+	c.haproxy.TCPBackends().RemoveAll()
+
 	// map[key]value is:
 	// - key   => port to expose
 	// - value => <service-name>:<port>:[<PROXY>]:[<PROXY[-<V1|V2>]]:<secret-name-cert>:check-interval:<secret-name-ca>
@@ -116,7 +118,7 @@ func (c *tcpSvcConverter) Sync(tcpservices map[string]string) {
 			}
 		}
 		servicename := fmt.Sprintf("%s_%s", service.Namespace, service.Name)
-		backend := c.haproxy.AcquireTCPBackend(servicename, publicport)
+		backend := c.haproxy.TCPBackends().Acquire(servicename, publicport)
 		for _, addr := range addrs {
 			backend.AddEndpoint(addr.IP, addr.Port)
 		}

--- a/pkg/converters/configmap/tcpservices.go
+++ b/pkg/converters/configmap/tcpservices.go
@@ -91,7 +91,7 @@ func (c *tcpSvcConverter) Sync(tcpservices map[string]string) {
 		}
 		var crtfile convtypes.CrtFile
 		if svc.secretTLS != "" {
-			crtfile, err = c.cache.GetTLSSecretPath("", svc.secretTLS)
+			crtfile, err = c.cache.GetTLSSecretPath("", svc.secretTLS, convtypes.TrackingTarget{})
 			if err != nil {
 				c.logger.Warn("skipping TCP service on public port %d: %v", publicport, err)
 				continue
@@ -99,7 +99,7 @@ func (c *tcpSvcConverter) Sync(tcpservices map[string]string) {
 		}
 		var cafile, crlfile convtypes.File
 		if svc.secretCA != "" {
-			cafile, crlfile, err = c.cache.GetCASecretPath("", svc.secretCA)
+			cafile, crlfile, err = c.cache.GetCASecretPath("", svc.secretCA, convtypes.TrackingTarget{})
 			if err != nil {
 				c.logger.Warn("skipping TCP service on public port %d: %v", publicport, err)
 				continue

--- a/pkg/converters/configmap/tcpservices_test.go
+++ b/pkg/converters/configmap/tcpservices_test.go
@@ -296,7 +296,7 @@ func TestTCPSvcSync(t *testing.T) {
 		c.cache.SecretCAPath = test.secretCAMock
 		c.cache.SecretCRLPath = test.secretCRLMock
 		NewTCPServicesConverter(c.logger, c.haproxy, c.cache).Sync(test.services)
-		backends := c.haproxy.TCPBackends()
+		backends := c.haproxy.TCPBackends().BuildSortedItems()
 		for _, b := range backends {
 			for _, ep := range b.Endpoints {
 				ep.Target = ""

--- a/pkg/converters/configmap/tcpservices_test.go
+++ b/pkg/converters/configmap/tcpservices_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	conv_helper "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/helper_test"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/tracker"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy"
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 	types_helper "github.com/jcmoraisjr/haproxy-ingress/pkg/types/helper_test"
@@ -319,10 +320,11 @@ type testConfig struct {
 
 func setup(t *testing.T) *testConfig {
 	logger := types_helper.NewLoggerMock(t)
+	tracker := tracker.NewTracker()
 	c := &testConfig{
 		t:       t,
 		logger:  logger,
-		cache:   conv_helper.NewCacheMock(),
+		cache:   conv_helper.NewCacheMock(tracker),
 		haproxy: haproxy.CreateInstance(logger, haproxy.InstanceOptions{}).Config(),
 	}
 	return c

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -106,7 +106,7 @@ func (c *CacheMock) GetEndpoints(service *api.Service) (*api.Endpoints, error) {
 }
 
 // GetTerminatingPods ...
-func (c *CacheMock) GetTerminatingPods(service *api.Service) ([]*api.Pod, error) {
+func (c *CacheMock) GetTerminatingPods(service *api.Service, track convtypes.TrackingTarget) ([]*api.Pod, error) {
 	serviceName := service.Namespace + "/" + service.Name
 	if pods, found := c.TermPodList[serviceName]; found {
 		return pods, nil

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -91,7 +91,7 @@ func (c *updater) buildBackendAuthHTTP(d *backData) {
 				secretName = authSecret.Source.Namespace + "/" + secretName
 			}
 			listName := strings.Replace(secretName, "/", "_", 1)
-			userlist := c.haproxy.FindUserlist(listName)
+			userlist := c.haproxy.Userlists().Find(listName)
 			if userlist == nil {
 				userb, err := c.cache.GetSecretContent(authSecret.Source.Namespace, authSecret.Value, "auth")
 				if err != nil {
@@ -103,7 +103,7 @@ func (c *updater) buildBackendAuthHTTP(d *backData) {
 				for _, err := range errs {
 					c.logger.Warn("ignoring malformed usr/passwd on secret '%s', declared on %v: %v", secretName, authSecret.Source, err)
 				}
-				userlist = c.haproxy.AddUserlist(listName, users)
+				userlist = c.haproxy.Userlists().Replace(listName, users)
 				if len(users) == 0 {
 					c.logger.Warn("userlist on %v for basic authentication is empty", authSecret.Source)
 				}

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
 	ingutils "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/utils"
+	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
 )
@@ -93,7 +93,11 @@ func (c *updater) buildBackendAuthHTTP(d *backData) {
 			listName := strings.Replace(secretName, "/", "_", 1)
 			userlist := c.haproxy.Userlists().Find(listName)
 			if userlist == nil {
-				userb, err := c.cache.GetSecretContent(authSecret.Source.Namespace, authSecret.Value, "auth")
+				userb, err := c.cache.GetSecretContent(
+					authSecret.Source.Namespace,
+					authSecret.Value, "auth",
+					convtypes.TrackingTarget{Backend: d.backend.BackendID()},
+				)
 				if err != nil {
 					c.logger.Error("error reading basic authentication on %v: %v", authSecret.Source, err)
 					return nil
@@ -639,7 +643,11 @@ func (c *updater) buildBackendProtocol(d *backData) {
 		return
 	}
 	if crt := d.mapper.Get(ingtypes.BackSecureCrtSecret); crt.Value != "" {
-		if crtFile, err := c.cache.GetTLSSecretPath(crt.Source.Namespace, crt.Value); err == nil {
+		if crtFile, err := c.cache.GetTLSSecretPath(
+			crt.Source.Namespace,
+			crt.Value,
+			convtypes.TrackingTarget{Backend: d.backend.BackendID()},
+		); err == nil {
 			d.backend.Server.CrtFilename = crtFile.Filename
 			d.backend.Server.CrtHash = crtFile.SHA1Hash
 		} else {
@@ -647,7 +655,11 @@ func (c *updater) buildBackendProtocol(d *backData) {
 		}
 	}
 	if ca := d.mapper.Get(ingtypes.BackSecureVerifyCASecret); ca.Value != "" {
-		if caFile, crlFile, err := c.cache.GetCASecretPath(ca.Source.Namespace, ca.Value); err == nil {
+		if caFile, crlFile, err := c.cache.GetCASecretPath(
+			ca.Source.Namespace,
+			ca.Value,
+			convtypes.TrackingTarget{Backend: d.backend.BackendID()},
+		); err == nil {
 			d.backend.Server.CAFilename = caFile.Filename
 			d.backend.Server.CAHash = caFile.SHA1Hash
 			d.backend.Server.CRLFilename = crlFile.Filename
@@ -711,7 +723,7 @@ var epNamingRegex = regexp.MustCompile(`^(seq(uence)?|pod|ip)$`)
 
 func (c *updater) buildBackendServerNaming(d *backData) {
 	// Only warning here. d.backend.EpNaming should be updated before backend.AcquireEndpoint()
-	naming := d.mapper.Get(types.BackBackendServerNaming)
+	naming := d.mapper.Get(ingtypes.BackBackendServerNaming)
 	if !epNamingRegex.MatchString(naming.Value) {
 		c.logger.Warn("ignoring invalid naming type '%s' on %s, using 'seq' instead", naming.Value, naming.Source)
 	}

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -96,7 +96,10 @@ func (c *updater) buildBackendAuthHTTP(d *backData) {
 				userb, err := c.cache.GetSecretContent(
 					authSecret.Source.Namespace,
 					authSecret.Value, "auth",
-					convtypes.TrackingTarget{Backend: d.backend.BackendID()},
+					convtypes.TrackingTarget{
+						Backend:  d.backend.BackendID(),
+						Userlist: listName,
+					},
 				)
 				if err != nil {
 					c.logger.Error("error reading basic authentication on %v: %v", authSecret.Source, err)

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -105,7 +105,7 @@ func TestAffinity(t *testing.T) {
 		// 8
 		{
 			ann: map[string]string{
-				ingtypes.BackAffinity:             "cookie",
+				ingtypes.BackAffinity:              "cookie",
 				ingtypes.BackSessionCookieKeywords: "nocache",
 			},
 			expCookie:  hatypes.Cookie{Name: "INGRESSCOOKIE", Strategy: "insert", Dynamic: false, Keywords: "nocache"},
@@ -315,7 +315,7 @@ usr2::clearpwd2`)}},
 		c.cache.SecretContent = test.secrets
 		d := c.createBackendMappingData("default/app", test.source, test.annDefault, test.ann, test.paths)
 		u.buildBackendAuthHTTP(d)
-		userlists := u.haproxy.Userlists()
+		userlists := u.haproxy.Userlists().BuildSortedItems()
 		c.compareObjects("userlists", i, userlists, test.expUserlists)
 		if test.expConfig != nil {
 			c.compareObjects("auth http", i, d.backend.AuthHTTP, test.expConfig)

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -46,10 +46,10 @@ func (c *updater) buildGlobalAcme(d *globalData) {
 	d.acmeData.Endpoint = endpoint
 	d.acmeData.Expiring = time.Duration(d.mapper.Get(ingtypes.GlobalAcmeExpiring).Int()) * 24 * time.Hour
 	d.acmeData.TermsAgreed = termsAgreed
-	d.acme.Prefix = "/.well-known/acme-challenge/"
-	d.acme.Socket = "/var/run/acme.sock"
-	d.acme.Enabled = true
-	d.acme.Shared = d.mapper.Get(ingtypes.GlobalAcmeShared).Bool()
+	d.global.Acme.Prefix = "/.well-known/acme-challenge/"
+	d.global.Acme.Socket = "/var/run/acme.sock"
+	d.global.Acme.Enabled = true
+	d.global.Acme.Shared = d.mapper.Get(ingtypes.GlobalAcmeShared).Bool()
 }
 
 func (c *updater) buildGlobalBind(d *globalData) {

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
+	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
 )
@@ -146,7 +147,7 @@ func (c *updater) buildGlobalStats(d *globalData) {
 	d.global.Stats.BindIP = d.mapper.Get(ingtypes.GlobalBindIPAddrStats).Value
 	d.global.Stats.Port = d.mapper.Get(ingtypes.GlobalStatsPort).Int()
 	if tlsSecret := d.mapper.Get(ingtypes.GlobalStatsSSLCert).Value; tlsSecret != "" {
-		if tls, err := c.cache.GetTLSSecretPath("", tlsSecret); err == nil {
+		if tls, err := c.cache.GetTLSSecretPath("", tlsSecret, convtypes.TrackingTarget{}); err == nil {
 			d.global.Stats.TLSFilename = tls.Filename
 			d.global.Stats.TLSHash = tls.SHA1Hash
 		} else {

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -18,6 +18,7 @@ package annotations
 
 import (
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
+	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 )
 
 func (c *updater) buildHostAuthTLS(d *hostData) {
@@ -30,7 +31,11 @@ func (c *updater) buildHostAuthTLS(d *hostData) {
 		return
 	}
 	tls := &d.host.TLS
-	if cafile, crlfile, err := c.cache.GetCASecretPath(tlsSecret.Source.Namespace, tlsSecret.Value); err == nil {
+	if cafile, crlfile, err := c.cache.GetCASecretPath(
+		tlsSecret.Source.Namespace,
+		tlsSecret.Value,
+		convtypes.TrackingTarget{Hostname: d.host.Hostname},
+	); err == nil {
 		tls.CAFilename = cafile.Filename
 		tls.CAHash = cafile.SHA1Hash
 		tls.CRLFilename = crlfile.Filename

--- a/pkg/converters/ingress/annotations/mapper.go
+++ b/pkg/converters/ingress/annotations/mapper.go
@@ -311,6 +311,11 @@ func (cv *ConfigValue) Int64() int64 {
 	return value
 }
 
+// FullName ...
+func (s *Source) FullName() string {
+	return s.Namespace + "/" + s.Name
+}
+
 // String ...
 func (m *Map) String() string {
 	return fmt.Sprintf("%+v", *m)
@@ -318,5 +323,5 @@ func (m *Map) String() string {
 
 // String ...
 func (s *Source) String() string {
-	return s.Type + " '" + s.Namespace + "/" + s.Name + "'"
+	return s.Type + " '" + s.FullName() + "'"
 }

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -54,7 +54,6 @@ type updater struct {
 
 type globalData struct {
 	acmeData *hatypes.AcmeData
-	acme     *hatypes.Acme
 	global   *hatypes.Global
 	mapper   *Mapper
 }
@@ -102,7 +101,6 @@ func (c *updater) splitCIDR(cidrlist *ConfigValue) []string {
 func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mapper) {
 	d := &globalData{
 		acmeData: haproxyConfig.AcmeData(),
-		acme:     haproxyConfig.Acme(),
 		global:   haproxyConfig.Global(),
 		mapper:   mapper,
 	}

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -41,6 +41,7 @@ func NewUpdater(haproxy haproxy.Config, options *ingtypes.ConverterOptions) Upda
 		haproxy: haproxy,
 		logger:  options.Logger,
 		cache:   options.Cache,
+		tracker: options.Tracker,
 		fakeCA:  options.FakeCAFile,
 	}
 }
@@ -49,6 +50,7 @@ type updater struct {
 	haproxy haproxy.Config
 	logger  types.Logger
 	cache   convtypes.Cache
+	tracker convtypes.Tracker
 	fakeCA  convtypes.CrtFile
 }
 

--- a/pkg/converters/ingress/annotations/updater_test.go
+++ b/pkg/converters/ingress/annotations/updater_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	conv_helper "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/helper_test"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/tracker"
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy"
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
@@ -44,15 +45,18 @@ type testConfig struct {
 	t       *testing.T
 	haproxy haproxy.Config
 	cache   *conv_helper.CacheMock
+	tracker convtypes.Tracker
 	logger  *types_helper.LoggerMock
 }
 
 func setup(t *testing.T) *testConfig {
 	logger := &types_helper.LoggerMock{T: t}
+	tracker := tracker.NewTracker()
 	return &testConfig{
 		t:       t,
 		haproxy: haproxy.CreateInstance(logger, haproxy.InstanceOptions{}).Config(),
-		cache:   &conv_helper.CacheMock{},
+		cache:   conv_helper.NewCacheMock(tracker),
+		tracker: tracker,
 		logger:  logger,
 	}
 }
@@ -66,6 +70,7 @@ func (c *testConfig) createUpdater() *updater {
 		haproxy: c.haproxy,
 		cache:   c.cache,
 		logger:  c.logger,
+		tracker: c.tracker,
 		fakeCA: convtypes.CrtFile{
 			Filename: fakeCAFilename,
 			SHA1Hash: fakeCAHash,

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -58,7 +58,7 @@ func NewIngressConverter(options *ingtypes.ConverterOptions, haproxy haproxy.Con
 		hostAnnotations:    map[*hatypes.Host]*annotations.Mapper{},
 		backendAnnotations: map[*hatypes.Backend]*annotations.Mapper{},
 	}
-	haproxy.ConfigDefaultX509Cert(options.DefaultSSLFile.Filename)
+	haproxy.Frontend().DefaultCert = options.DefaultSSLFile.Filename
 	if options.DefaultBackend != "" {
 		if backend, err := c.addBackend(&annotations.Source{}, "*/", options.DefaultBackend, "", map[string]string{}); err == nil {
 			haproxy.Backends().SetDefaultBackend(backend)

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -18,6 +18,8 @@ package ingress
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -35,57 +37,213 @@ import (
 
 // Config ...
 type Config interface {
-	Sync(ingress []*extensions.Ingress)
+	Sync()
 }
 
 // NewIngressConverter ...
-func NewIngressConverter(options *ingtypes.ConverterOptions, haproxy haproxy.Config, globalConfig map[string]string) Config {
+func NewIngressConverter(options *ingtypes.ConverterOptions, haproxy haproxy.Config) Config {
 	if options.DefaultConfig == nil {
 		options.DefaultConfig = createDefaults
+	}
+	changed := options.Cache.SwapChangedObjects()
+	// IMPLEMENT
+	// config option to allow partial parsing
+	// cache also need to know if partial parsing is enabled
+	needFullSync := options.Cache.NeedFullSync() || globalConfigNeedFullSync(changed)
+	globalConfig := changed.GlobalCur
+	if changed.GlobalNew != nil {
+		globalConfig = changed.GlobalNew
 	}
 	defaultConfig := options.DefaultConfig()
 	for key, value := range globalConfig {
 		defaultConfig[key] = value
 	}
-	c := &converter{
+	return &converter{
 		haproxy:            haproxy,
 		options:            options,
+		changed:            changed,
 		logger:             options.Logger,
 		cache:              options.Cache,
+		tracker:            options.Tracker,
 		mapBuilder:         annotations.NewMapBuilder(options.Logger, options.AnnotationPrefix+"/", defaultConfig),
 		updater:            annotations.NewUpdater(haproxy, options),
 		globalConfig:       annotations.NewMapBuilder(options.Logger, "", defaultConfig).NewMapper(),
 		hostAnnotations:    map[*hatypes.Host]*annotations.Mapper{},
 		backendAnnotations: map[*hatypes.Backend]*annotations.Mapper{},
+		needFullSync:       needFullSync,
 	}
-	haproxy.Frontend().DefaultCert = options.DefaultSSLFile.Filename
-	if options.DefaultBackend != "" {
-		if backend, err := c.addBackend(&annotations.Source{}, "*/", options.DefaultBackend, "", map[string]string{}); err == nil {
-			haproxy.Backends().SetDefaultBackend(backend)
-		} else {
-			c.logger.Error("error reading default service: %v", err)
-		}
-	}
-	return c
 }
 
 type converter struct {
 	haproxy            haproxy.Config
 	options            *ingtypes.ConverterOptions
+	changed            *convtypes.ChangedObjects
 	logger             types.Logger
 	cache              convtypes.Cache
+	tracker            convtypes.Tracker
 	mapBuilder         *annotations.MapBuilder
 	updater            annotations.Updater
 	globalConfig       *annotations.Mapper
 	hostAnnotations    map[*hatypes.Host]*annotations.Mapper
 	backendAnnotations map[*hatypes.Backend]*annotations.Mapper
+	needFullSync       bool
 }
 
-func (c *converter) Sync(ingress []*extensions.Ingress) {
-	for _, ing := range ingress {
+func (c *converter) Sync() {
+	if c.needFullSync {
+		c.haproxy.Clear()
+	}
+	c.haproxy.Frontend().DefaultCert = c.options.DefaultSSLFile.Filename
+	if c.options.DefaultBackend != "" {
+		if backend, err := c.addBackend(&annotations.Source{}, "*", "/", c.options.DefaultBackend, "", map[string]string{}); err == nil {
+			c.haproxy.Backends().SetDefaultBackend(backend)
+		} else {
+			c.logger.Error("error reading default service: %v", err)
+		}
+	}
+	if c.needFullSync {
+		c.syncFull()
+	} else {
+		c.syncPartial()
+	}
+}
+
+func globalConfigNeedFullSync(changed *convtypes.ChangedObjects) bool {
+	// Currently if a global is changed, all the ingress objects are parsed again.
+	// This need to be done due to:
+	//
+	//   1. Default host and backend annotations. If a default value
+	//      changes, such default may impact any ingress object;
+	//   2. At the time of this writing, the following global
+	//      configuration keys are used during annotation parsing:
+	//        * GlobalDNSResolvers
+	//        * GlobalDrainSupport
+	//        * GlobalNoTLSRedirectLocations
+	//
+	// This might be improved after implement a way to guarantee that a global
+	// is just a haproxy global, default or frontend config.
+	cur, new := changed.GlobalCur, changed.GlobalNew
+	return new != nil && !reflect.DeepEqual(cur, new)
+}
+
+func (c *converter) syncFull() {
+	ingList, err := c.cache.GetIngressList()
+	if err != nil {
+		c.logger.Error("error reading ingress list: %v", err)
+		return
+	}
+	sortIngress(ingList)
+	for _, ing := range ingList {
 		c.syncIngress(ing)
 	}
-	c.syncAnnotations()
+	c.fullSyncAnnotations()
+}
+
+func (c *converter) syncPartial() {
+	// conventions:
+	//
+	//   * del, upd, add: events from the listers
+	//   * old, new:      old state (deleted, before change) and new state (after change, added)
+	//   * dirty:         has impact due to a direct or indirect change
+	//
+
+	// helper funcs
+	ing2names := func(ings []*extensions.Ingress) []string {
+		inglist := make([]string, len(ings))
+		for i, ing := range ings {
+			inglist[i] = ing.Namespace + "/" + ing.Name
+		}
+		return inglist
+	}
+	svc2names := func(services []*api.Service) []string {
+		serviceList := make([]string, len(services))
+		for i, service := range services {
+			serviceList[i] = service.Namespace + "/" + service.Name
+		}
+		return serviceList
+	}
+	secret2names := func(secrets []*api.Secret) []string {
+		secretList := make([]string, len(secrets))
+		for i, secret := range secrets {
+			secretList[i] = secret.Namespace + "/" + secret.Name
+		}
+		return secretList
+	}
+
+	// remove changed/deleted data
+	delIngNames := ing2names(c.changed.IngressesDel)
+	updIngNames := ing2names(c.changed.IngressesUpd)
+	oldIngNames := append(delIngNames, updIngNames...)
+	delSvcNames := svc2names(c.changed.ServicesDel)
+	updSvcNames := svc2names(c.changed.ServicesUpd)
+	addSvcNames := svc2names(c.changed.ServicesAdd)
+	oldSvcNames := append(delSvcNames, updSvcNames...)
+	delSecretNames := secret2names(c.changed.SecretsDel)
+	updSecretNames := secret2names(c.changed.SecretsUpd)
+	addSecretNames := secret2names(c.changed.SecretsAdd)
+	oldSecretNames := append(delSecretNames, updSecretNames...)
+	dirtyIngs, dirtyHosts, dirtyBacks :=
+		c.tracker.GetDirtyLinks(oldIngNames, oldSvcNames, addSvcNames, oldSecretNames, addSecretNames)
+	c.tracker.DeleteHostnames(dirtyHosts)
+	c.tracker.DeleteBackends(dirtyBacks)
+	c.haproxy.Hosts().RemoveAll(dirtyHosts)
+	c.haproxy.Backends().RemoveAll(dirtyBacks)
+
+	// merge dirty and added ingress objects into a single list
+	ingMap := make(map[string]*extensions.Ingress)
+	for _, ing := range dirtyIngs {
+		ingMap[ing] = nil
+	}
+	for _, ing := range delIngNames {
+		delete(ingMap, ing)
+	}
+	for _, ing := range c.changed.IngressesAdd {
+		ingMap[ing.Namespace+"/"+ing.Name] = ing
+	}
+	ingList := make([]*extensions.Ingress, 0, len(ingMap))
+	for name, ing := range ingMap {
+		if ing == nil {
+			var err error
+			ing, err = c.cache.GetIngress(name)
+			if err != nil {
+				c.logger.Warn("ignoring ingress '%s': %v", name, err)
+				ing = nil
+			}
+		}
+		if ing != nil {
+			ingList = append(ingList, ing)
+		}
+	}
+
+	// reinclude changed/added data
+	sortIngress(ingList)
+	for _, ing := range ingList {
+		c.syncIngress(ing)
+	}
+	for _, ep := range c.changed.Endpoints {
+		if err := c.applyEndpoints(ep); err != nil {
+			c.logger.Warn("skipping apply endpoint '%s/%s' update: %v", ep.Namespace, ep.Name, err)
+		}
+	}
+	if c.globalConfig.Get(ingtypes.GlobalDrainSupport).Bool() {
+		for _, pod := range c.changed.Pods {
+			if err := c.applyPod(pod); err != nil {
+				c.logger.Warn("skipping apply pod '%s/%s' update: %v", pod.Namespace, pod.Name, err)
+			}
+		}
+	}
+	c.partialSyncAnnotations(dirtyHosts, dirtyBacks)
+}
+
+func sortIngress(ingress []*extensions.Ingress) {
+	sort.Slice(ingress, func(i, j int) bool {
+		i1 := ingress[i]
+		i2 := ingress[j]
+		if i1.CreationTimestamp != i2.CreationTimestamp {
+			return i1.CreationTimestamp.Before(&i2.CreationTimestamp)
+		}
+		return i1.Namespace+"/"+i1.Name < i2.Namespace+"/"+i2.Name
+	})
 }
 
 func (c *converter) syncIngress(ing *extensions.Ingress) {
@@ -123,7 +281,7 @@ func (c *converter) syncIngress(ing *extensions.Ingress) {
 			}
 			svcName, svcPort := readServiceNamePort(&path.Backend)
 			fullSvcName := ing.Namespace + "/" + svcName
-			backend, err := c.addBackend(source, hostname+uri, fullSvcName, svcPort, annBack)
+			backend, err := c.addBackend(source, hostname, uri, fullSvcName, svcPort, annBack)
 			if err != nil {
 				c.logger.Warn("skipping backend config of ingress '%s': %v", fullIngName, err)
 				continue
@@ -132,7 +290,7 @@ func (c *converter) syncIngress(ing *extensions.Ingress) {
 			sslpassthrough, _ := strconv.ParseBool(annHost[ingtypes.HostSSLPassthrough])
 			sslpasshttpport := annHost[ingtypes.HostSSLPassthroughHTTPPort]
 			if sslpassthrough && sslpasshttpport != "" {
-				if _, err := c.addBackend(source, hostname+uri, fullSvcName, sslpasshttpport, annBack); err != nil {
+				if _, err := c.addBackend(source, hostname, uri, fullSvcName, sslpasshttpport, annBack); err != nil {
 					c.logger.Warn("skipping http port config of ssl-passthrough on %v: %v", source, err)
 				}
 			}
@@ -140,7 +298,7 @@ func (c *converter) syncIngress(ing *extensions.Ingress) {
 		for _, tls := range ing.Spec.TLS {
 			for _, tlshost := range tls.Hosts {
 				if tlshost == hostname {
-					tlsPath := c.addTLS(source, tls.SecretName)
+					tlsPath := c.addTLS(source, tlshost, tls.SecretName)
 					if host.TLS.TLSHash == "" {
 						host.TLS.TLSFilename = tlsPath.Filename
 						host.TLS.TLSHash = tlsPath.SHA1Hash
@@ -178,7 +336,7 @@ func (c *converter) syncIngress(ing *extensions.Ingress) {
 	}
 }
 
-func (c *converter) syncAnnotations() {
+func (c *converter) fullSyncAnnotations() {
 	c.updater.UpdateGlobalConfig(c.haproxy, c.globalConfig)
 	for _, host := range c.haproxy.Hosts().Items() {
 		if ann, found := c.hostAnnotations[host]; found {
@@ -186,6 +344,22 @@ func (c *converter) syncAnnotations() {
 		}
 	}
 	for _, backend := range c.haproxy.Backends().Items() {
+		if ann, found := c.backendAnnotations[backend]; found {
+			c.updater.UpdateBackendConfig(backend, ann)
+		}
+	}
+}
+
+func (c *converter) partialSyncAnnotations(hosts []string, backends []hatypes.BackendID) {
+	c.updater.UpdateGlobalConfig(c.haproxy, c.globalConfig)
+	for _, hostname := range hosts {
+		host := c.haproxy.Hosts().FindHost(hostname)
+		if ann, found := c.hostAnnotations[host]; found {
+			c.updater.UpdateHostConfig(host, ann)
+		}
+	}
+	for _, backendID := range backends {
+		backend := c.haproxy.Backends().FindBackendID(backendID)
 		if ann, found := c.backendAnnotations[backend]; found {
 			c.updater.UpdateBackendConfig(backend, ann)
 		}
@@ -200,7 +374,7 @@ func (c *converter) addDefaultHostBackend(source *annotations.Source, fullSvcNam
 			return fmt.Errorf("path %s was already defined on default host", uri)
 		}
 	}
-	backend, err := c.addBackend(source, hostname+uri, fullSvcName, svcPort, annBack)
+	backend, err := c.addBackend(source, hostname, uri, fullSvcName, svcPort, annBack)
 	if err != nil {
 		return err
 	}
@@ -210,7 +384,9 @@ func (c *converter) addDefaultHostBackend(source *annotations.Source, fullSvcNam
 }
 
 func (c *converter) addHost(hostname string, source *annotations.Source, ann map[string]string) *hatypes.Host {
+	// TODO build a stronger tracking
 	host := c.haproxy.Hosts().AcquireHost(hostname)
+	c.tracker.TrackHostname(convtypes.IngressType, source.FullName(), hostname)
 	mapper, found := c.hostAnnotations[host]
 	if !found {
 		mapper = c.mapBuilder.NewMapper()
@@ -223,11 +399,14 @@ func (c *converter) addHost(hostname string, source *annotations.Source, ann map
 	return host
 }
 
-func (c *converter) addBackend(source *annotations.Source, hostpath, fullSvcName, svcPort string, ann map[string]string) (*hatypes.Backend, error) {
+func (c *converter) addBackend(source *annotations.Source, hostname, uri, fullSvcName, svcPort string, ann map[string]string) (*hatypes.Backend, error) {
+	// TODO build a stronger tracking
 	svc, err := c.cache.GetService(fullSvcName)
 	if err != nil {
+		c.tracker.TrackMissingOnHostname(convtypes.ServiceType, fullSvcName, hostname)
 		return nil, err
 	}
+	c.tracker.TrackHostname(convtypes.ServiceType, fullSvcName, hostname)
 	ssvcName := strings.Split(fullSvcName, "/")
 	namespace := ssvcName[0]
 	svcName := ssvcName[1]
@@ -241,6 +420,8 @@ func (c *converter) addBackend(source *annotations.Source, hostpath, fullSvcName
 		return nil, fmt.Errorf("port not found: '%s'", svcPort)
 	}
 	backend := c.haproxy.Backends().AcquireBackend(namespace, svcName, port.TargetPort.String())
+	c.tracker.TrackBackend(convtypes.IngressType, source.FullName(), backend.BackendID())
+	hostpath := hostname + uri
 	mapper, found := c.backendAnnotations[backend]
 	if !found {
 		// New backend, initialize with service annotations, giving precedence
@@ -285,12 +466,15 @@ func (c *converter) addBackend(source *annotations.Source, hostpath, fullSvcName
 	return backend, nil
 }
 
-func (c *converter) addTLS(source *annotations.Source, secretName string) convtypes.CrtFile {
+func (c *converter) addTLS(source *annotations.Source, hostname, secretName string) convtypes.CrtFile {
 	if secretName != "" {
+		fullName := source.Namespace + "/" + secretName
 		tlsFile, err := c.cache.GetTLSSecretPath(source.Namespace, secretName)
 		if err == nil {
+			c.tracker.TrackHostname(convtypes.SecretType, fullName, hostname)
 			return tlsFile
 		}
+		c.tracker.TrackMissingOnHostname(convtypes.SecretType, fullName, hostname)
 		c.logger.Warn("using default certificate due to an error reading secret '%s' on %s: %v", secretName, source, err)
 	}
 	return c.options.DefaultSSLFile
@@ -324,6 +508,28 @@ func (c *converter) addEndpoints(svc *api.Service, svcPort *api.ServicePort, bac
 			}
 		}
 	}
+	return nil
+}
+
+func (c *converter) applyEndpoints(endpoints *api.Endpoints) error {
+	svc, err := c.cache.GetService(fmt.Sprintf("%s/%s", endpoints.Namespace, endpoints.Name))
+	if err != nil {
+		return err
+	}
+	for _, port := range svc.Spec.Ports {
+		backend := c.haproxy.Backends().FindBackend(endpoints.Namespace, endpoints.Name, port.TargetPort.String())
+		if backend != nil {
+			backend.ClearEndpoints()
+			if err := c.addEndpoints(svc, &port, backend); err != nil {
+				c.logger.Warn("skipping backend '%s' update: %v", backend.ID, err)
+			}
+		}
+	}
+	return nil
+}
+
+func (c *converter) applyPod(pod *api.Pod) error {
+	// IMPLEMENT
 	return nil
 }
 

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -191,12 +191,14 @@ func (c *converter) syncPartial() {
 	updSecretNames := secret2names(c.changed.SecretsUpd)
 	addSecretNames := secret2names(c.changed.SecretsAdd)
 	oldSecretNames := append(delSecretNames, updSecretNames...)
-	dirtyIngs, dirtyHosts, dirtyBacks :=
+	dirtyIngs, dirtyHosts, dirtyBacks, dirtyUsers :=
 		c.tracker.GetDirtyLinks(oldIngNames, oldSvcNames, addSvcNames, oldSecretNames, addSecretNames)
 	c.tracker.DeleteHostnames(dirtyHosts)
 	c.tracker.DeleteBackends(dirtyBacks)
+	c.tracker.DeleteUserlists(dirtyUsers)
 	c.haproxy.Hosts().RemoveAll(dirtyHosts)
 	c.haproxy.Backends().RemoveAll(dirtyBacks)
+	c.haproxy.Userlists().RemoveAll(dirtyUsers)
 	if len(dirtyHosts) > 0 || len(dirtyBacks) > 0 {
 		c.logger.InfoV(2, "changed hosts: %v; backends: %v", dirtyHosts, dirtyBacks)
 	}

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -474,16 +474,14 @@ func (c *converter) addBackend(source *annotations.Source, hostname, uri, fullSv
 
 func (c *converter) addTLS(source *annotations.Source, hostname, secretName string) convtypes.CrtFile {
 	if secretName != "" {
-		fullName := secretName
-		if strings.Index(secretName, "/") == -1 {
-			fullName = source.Namespace + "/" + secretName
-		}
-		tlsFile, err := c.cache.GetTLSSecretPath(source.Namespace, secretName)
+		tlsFile, err := c.cache.GetTLSSecretPath(
+			source.Namespace,
+			secretName,
+			convtypes.TrackingTarget{Hostname: hostname},
+		)
 		if err == nil {
-			c.tracker.TrackHostname(convtypes.SecretType, fullName, hostname)
 			return tlsFile
 		}
-		c.tracker.TrackMissingOnHostname(convtypes.SecretType, fullName, hostname)
 		c.logger.Warn("using default certificate due to an error reading secret '%s' on %s: %v", secretName, source, err)
 	}
 	return c.options.DefaultSSLFile

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -1425,13 +1425,14 @@ type testConfig struct {
 
 func setup(t *testing.T) *testConfig {
 	logger := types_helper.NewLoggerMock(t)
+	tracker := tracker.NewTracker()
 	c := &testConfig{
 		t:       t,
 		decode:  scheme.Codecs.UniversalDeserializer().Decode,
 		hconfig: haproxy.CreateInstance(logger, haproxy.InstanceOptions{}).Config(),
-		cache:   conv_helper.NewCacheMock(),
+		cache:   conv_helper.NewCacheMock(tracker),
 		logger:  logger,
-		tracker: tracker.NewTracker(),
+		tracker: tracker,
 	}
 	c.createSvc1("system/default", "8080", "172.17.0.99")
 	return c

--- a/pkg/converters/ingress/tracker/tracker.go
+++ b/pkg/converters/ingress/tracker/tracker.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2020 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracker
+
+import (
+	"fmt"
+	"strings"
+
+	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
+	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
+)
+
+// NewTracker ...
+func NewTracker() convtypes.Tracker {
+	return &tracker{}
+}
+
+type (
+	stringStringMap  map[string]map[string]empty
+	stringBackendMap map[string]map[hatypes.BackendID]empty
+	backendStringMap map[hatypes.BackendID]map[string]empty
+	//
+	empty struct{}
+)
+
+type tracker struct {
+	ingressHostname stringStringMap
+	hostnameIngress stringStringMap
+	ingressBackend  stringBackendMap
+	backendIngress  backendStringMap
+	//
+	serviceHostname stringStringMap
+	hostnameService stringStringMap
+	//
+	secretHostname stringStringMap
+	hostnameSecret stringStringMap
+	//
+	serviceHostnameMissing stringStringMap
+	hostnameServiceMissing stringStringMap
+	//
+	secretHostnameMissing stringStringMap
+	hostnameSecretMissing stringStringMap
+}
+
+func (t *tracker) TrackHostname(rtype convtypes.ResourceType, name, hostname string) {
+	validName(name)
+	switch rtype {
+	case convtypes.IngressType:
+		addStringTracking(&t.ingressHostname, name, hostname)
+		addStringTracking(&t.hostnameIngress, hostname, name)
+	case convtypes.ServiceType:
+		addStringTracking(&t.serviceHostname, name, hostname)
+		addStringTracking(&t.hostnameService, hostname, name)
+	case convtypes.SecretType:
+		addStringTracking(&t.secretHostname, name, hostname)
+		addStringTracking(&t.hostnameSecret, hostname, name)
+	default:
+		panic(fmt.Errorf("unsupported resource type %d", rtype))
+	}
+}
+
+func (t *tracker) TrackBackend(rtype convtypes.ResourceType, name string, backendID hatypes.BackendID) {
+	validName(name)
+	switch rtype {
+	case convtypes.IngressType:
+		addStringBackendTracking(&t.ingressBackend, name, backendID)
+		addBackendStringTracking(&t.backendIngress, backendID, name)
+	default:
+		panic(fmt.Errorf("unsupported resource type %d", rtype))
+	}
+}
+
+func (t *tracker) TrackMissingOnHostname(rtype convtypes.ResourceType, name, hostname string) {
+	validName(name)
+	switch rtype {
+	case convtypes.ServiceType:
+		addStringTracking(&t.serviceHostnameMissing, name, hostname)
+		addStringTracking(&t.hostnameServiceMissing, hostname, name)
+	case convtypes.SecretType:
+		addStringTracking(&t.secretHostnameMissing, name, hostname)
+		addStringTracking(&t.hostnameSecretMissing, hostname, name)
+	default:
+		panic(fmt.Errorf("unsupported resource type %d", rtype))
+	}
+}
+
+func validName(name string) {
+	if len(strings.Split(name, "/")) != 2 {
+		panic(fmt.Errorf("invalid resource name: %s", name))
+	}
+}
+
+// GetDirtyLinks lists all hostnames and backendIDs that a
+// list of ingress touches directly or indirectly:
+//
+//   * when a hostname is listed, all other hostnames of all ingress that
+//     references it should also be listed;
+//   * when a backendID (service+port) is listed, all other backendIDs of
+//     all ingress that references it should also be listed.
+//
+func (t *tracker) GetDirtyLinks(
+	oldIngressList []string,
+	oldServiceList, addServiceList []string,
+	oldSecretList, addSecretList []string,
+) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID) {
+	ingsMap := make(map[string]empty)
+	hostsMap := make(map[string]empty)
+	backsMap := make(map[hatypes.BackendID]empty)
+
+	// recursively fill hostsMap and backsMap from ingress and secrets
+	// that directly or indirectly are referenced by them
+	var build func([]string)
+	build = func(ingNames []string) {
+		for _, ingName := range ingNames {
+			ingsMap[ingName] = empty{}
+			for _, hostname := range t.getHostnamesByIngress(ingName) {
+				if _, found := hostsMap[hostname]; !found {
+					hostsMap[hostname] = empty{}
+					build(t.getIngressByHostname(hostname))
+				}
+			}
+			for _, backend := range t.getBackendsByIngress(ingName) {
+				if _, found := backsMap[backend]; !found {
+					backsMap[backend] = empty{}
+					build(t.getIngressByBackend(backend))
+				}
+			}
+		}
+	}
+	build(oldIngressList)
+	//
+	for _, svcName := range oldServiceList {
+		for _, hostname := range t.getHostnamesByService(svcName) {
+			if _, found := hostsMap[hostname]; !found {
+				hostsMap[hostname] = empty{}
+				build(t.getIngressByHostname(hostname))
+			}
+		}
+	}
+	for _, svcName := range addServiceList {
+		for _, hostname := range t.getHostnamesByServiceMissing(svcName) {
+			if _, found := hostsMap[hostname]; !found {
+				hostsMap[hostname] = empty{}
+				build(t.getIngressByHostname(hostname))
+			}
+		}
+	}
+	//
+	for _, secretName := range oldSecretList {
+		for _, hostname := range t.getHostnamesBySecret(secretName) {
+			if _, found := hostsMap[hostname]; !found {
+				hostsMap[hostname] = empty{}
+				build(t.getIngressByHostname(hostname))
+			}
+		}
+	}
+	for _, secretName := range addSecretList {
+		for _, hostname := range t.getHostnamesBySecretMissing(secretName) {
+			if _, found := hostsMap[hostname]; !found {
+				hostsMap[hostname] = empty{}
+				build(t.getIngressByHostname(hostname))
+			}
+		}
+	}
+
+	// convert hostsMap and backsMap to slices
+	if len(ingsMap) > 0 {
+		dirtyIngs = make([]string, 0, len(ingsMap))
+		for ing := range ingsMap {
+			dirtyIngs = append(dirtyIngs, ing)
+		}
+	}
+	if len(hostsMap) > 0 {
+		dirtyHosts = make([]string, 0, len(hostsMap))
+		for host := range hostsMap {
+			dirtyHosts = append(dirtyHosts, host)
+		}
+	}
+	if len(backsMap) > 0 {
+		dirtyBacks = make([]hatypes.BackendID, 0, len(backsMap))
+		for back := range backsMap {
+			dirtyBacks = append(dirtyBacks, back)
+		}
+	}
+	return dirtyIngs, dirtyHosts, dirtyBacks
+}
+
+func (t *tracker) DeleteHostnames(hostnames []string) {
+	for _, hostname := range hostnames {
+		for ing := range t.hostnameIngress[hostname] {
+			deleteStringTracking(&t.ingressHostname, ing, hostname)
+		}
+		deleteStringMapKey(&t.hostnameIngress, hostname)
+		for service := range t.hostnameService[hostname] {
+			deleteStringTracking(&t.serviceHostname, service, hostname)
+		}
+		deleteStringMapKey(&t.hostnameService, hostname)
+		for service := range t.hostnameServiceMissing[hostname] {
+			deleteStringTracking(&t.serviceHostnameMissing, service, hostname)
+		}
+		deleteStringMapKey(&t.hostnameServiceMissing, hostname)
+		for secret := range t.hostnameSecret[hostname] {
+			deleteStringTracking(&t.secretHostname, secret, hostname)
+		}
+		deleteStringMapKey(&t.hostnameSecret, hostname)
+		for secret := range t.hostnameSecretMissing[hostname] {
+			deleteStringTracking(&t.secretHostnameMissing, secret, hostname)
+		}
+		deleteStringMapKey(&t.hostnameSecretMissing, hostname)
+	}
+}
+
+func (t *tracker) DeleteBackends(backends []hatypes.BackendID) {
+	for _, backend := range backends {
+		for ing := range t.backendIngress[backend] {
+			deleteStringBackendTracking(&t.ingressBackend, ing, backend)
+		}
+		deleteBackendStringMapKey(&t.backendIngress, backend)
+	}
+}
+
+func (t *tracker) getIngressByHostname(hostname string) []string {
+	if t.hostnameIngress == nil {
+		return nil
+	}
+	return getStringTracking(t.hostnameIngress[hostname])
+}
+
+func (t *tracker) getHostnamesByIngress(ingName string) []string {
+	if t.ingressHostname == nil {
+		return nil
+	}
+	return getStringTracking(t.ingressHostname[ingName])
+}
+
+func (t *tracker) getIngressByBackend(backendID hatypes.BackendID) []string {
+	if t.backendIngress == nil {
+		return nil
+	}
+	return getStringTracking(t.backendIngress[backendID])
+}
+
+func (t *tracker) getBackendsByIngress(ingName string) []hatypes.BackendID {
+	if t.ingressBackend == nil {
+		return nil
+	}
+	return getBackendTracking(t.ingressBackend[ingName])
+}
+
+func (t *tracker) getHostnamesByService(serviceName string) []string {
+	if t.serviceHostname == nil {
+		return nil
+	}
+	return getStringTracking(t.serviceHostname[serviceName])
+}
+
+func (t *tracker) getHostnamesByServiceMissing(serviceName string) []string {
+	if t.serviceHostnameMissing == nil {
+		return nil
+	}
+	return getStringTracking(t.serviceHostnameMissing[serviceName])
+}
+
+func (t *tracker) getHostnamesBySecret(secretName string) []string {
+	if t.secretHostname == nil {
+		return nil
+	}
+	return getStringTracking(t.secretHostname[secretName])
+}
+
+func (t *tracker) getHostnamesBySecretMissing(secretName string) []string {
+	if t.secretHostnameMissing == nil {
+		return nil
+	}
+	return getStringTracking(t.secretHostnameMissing[secretName])
+}
+
+func addStringTracking(trackingRef *stringStringMap, key, value string) {
+	if *trackingRef == nil {
+		*trackingRef = stringStringMap{}
+	}
+	tracking := *trackingRef
+	trackingMap, found := tracking[key]
+	if !found {
+		trackingMap = map[string]empty{}
+		tracking[key] = trackingMap
+	}
+	trackingMap[value] = empty{}
+}
+
+func addBackendStringTracking(trackingRef *backendStringMap, key hatypes.BackendID, value string) {
+	if *trackingRef == nil {
+		*trackingRef = backendStringMap{}
+	}
+	tracking := *trackingRef
+	trackingMap, found := tracking[key]
+	if !found {
+		trackingMap = map[string]empty{}
+		tracking[key] = trackingMap
+	}
+	trackingMap[value] = empty{}
+}
+
+func addStringBackendTracking(trackingRef *stringBackendMap, key string, value hatypes.BackendID) {
+	if *trackingRef == nil {
+		*trackingRef = stringBackendMap{}
+	}
+	tracking := *trackingRef
+	trackingMap, found := tracking[key]
+	if !found {
+		trackingMap = map[hatypes.BackendID]empty{}
+		tracking[key] = trackingMap
+	}
+	trackingMap[value] = empty{}
+}
+
+func getStringTracking(tracking map[string]empty) []string {
+	stringList := make([]string, 0, len(tracking))
+	for value := range tracking {
+		stringList = append(stringList, value)
+	}
+	return stringList
+}
+
+func getBackendTracking(tracking map[hatypes.BackendID]empty) []hatypes.BackendID {
+	backendList := make([]hatypes.BackendID, 0, len(tracking))
+	for value := range tracking {
+		backendList = append(backendList, value)
+	}
+	return backendList
+}
+
+func deleteStringTracking(trackingRef *stringStringMap, key, value string) {
+	if *trackingRef == nil {
+		return
+	}
+	tracking := *trackingRef
+	trackingMap := tracking[key]
+	delete(trackingMap, value)
+	if len(trackingMap) == 0 {
+		delete(tracking, key)
+	}
+	if len(tracking) == 0 {
+		*trackingRef = nil
+	}
+}
+
+func deleteStringBackendTracking(trackingRef *stringBackendMap, key string, value hatypes.BackendID) {
+	if *trackingRef == nil {
+		return
+	}
+	tracking := *trackingRef
+	trackingMap := tracking[key]
+	delete(trackingMap, value)
+	if len(trackingMap) == 0 {
+		delete(tracking, key)
+	}
+	if len(tracking) == 0 {
+		*trackingRef = nil
+	}
+}
+
+func deleteStringMapKey(stringMap *stringStringMap, key string) {
+	delete(*stringMap, key)
+	if len(*stringMap) == 0 {
+		*stringMap = nil
+	}
+}
+
+func deleteBackendStringMapKey(backendMap *backendStringMap, key hatypes.BackendID) {
+	delete(*backendMap, key)
+	if len(*backendMap) == 0 {
+		*backendMap = nil
+	}
+}

--- a/pkg/converters/ingress/tracker/tracker.go
+++ b/pkg/converters/ingress/tracker/tracker.go
@@ -18,6 +18,7 @@ package tracker
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
@@ -183,18 +184,23 @@ func (t *tracker) GetDirtyLinks(
 		for ing := range ingsMap {
 			dirtyIngs = append(dirtyIngs, ing)
 		}
+		sort.Strings(dirtyIngs)
 	}
 	if len(hostsMap) > 0 {
 		dirtyHosts = make([]string, 0, len(hostsMap))
 		for host := range hostsMap {
 			dirtyHosts = append(dirtyHosts, host)
 		}
+		sort.Strings(dirtyHosts)
 	}
 	if len(backsMap) > 0 {
 		dirtyBacks = make([]hatypes.BackendID, 0, len(backsMap))
 		for back := range backsMap {
 			dirtyBacks = append(dirtyBacks, back)
 		}
+		sort.Slice(dirtyBacks, func(i, j int) bool {
+			return dirtyBacks[i].String() < dirtyBacks[j].String()
+		})
 	}
 	return dirtyIngs, dirtyHosts, dirtyBacks
 }

--- a/pkg/converters/ingress/tracker/tracker_test.go
+++ b/pkg/converters/ingress/tracker/tracker_test.go
@@ -1,0 +1,466 @@
+/*
+Copyright 2020 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracker
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
+	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
+)
+
+type hostTracking struct {
+	rtype    convtypes.ResourceType
+	name     string
+	hostname string
+}
+
+type backTracking struct {
+	rtype   convtypes.ResourceType
+	name    string
+	backend hatypes.BackendID
+}
+
+var (
+	back1a = hatypes.BackendID{
+		Namespace: "default",
+		Name:      "svc1",
+		Port:      "8080",
+	}
+	back1b = hatypes.BackendID{
+		Namespace: "default",
+		Name:      "svc1",
+		Port:      "8080",
+	}
+	back2a = hatypes.BackendID{
+		Namespace: "default",
+		Name:      "svc2",
+		Port:      "8080",
+	}
+	back2b = hatypes.BackendID{
+		Namespace: "default",
+		Name:      "svc2",
+		Port:      "8080",
+	}
+)
+
+func TestGetDirtyLinks(t *testing.T) {
+	testCases := []struct {
+		trackedHosts []hostTracking
+		trackedBacks []backTracking
+		//
+		trackedMissingHosts []hostTracking
+		//
+		oldIngressList []string
+		oldServiceList []string
+		addServiceList []string
+		oldSecretList  []string
+		addSecretList  []string
+		//
+		expDirtyIngs  []string
+		expDirtyHosts []string
+		expDirtyBacks []hatypes.BackendID
+	}{
+		// 0
+		{},
+		// 1
+		{
+			oldIngressList: []string{"default/ing1"},
+			expDirtyIngs:   []string{"default/ing1"},
+		},
+		// 2
+		{
+			oldServiceList: []string{"default/svc1"},
+		},
+		// 3
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+			},
+		},
+		// 4
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+			},
+			oldIngressList: []string{"default/ing1"},
+			expDirtyIngs:   []string{"default/ing1"},
+			expDirtyHosts:  []string{"domain1.local"},
+		},
+		// 5
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.ServiceType, "default/svc1", "domain1.local"},
+			},
+			oldServiceList: []string{"default/svc1"},
+			expDirtyIngs:   []string{"default/ing1"},
+			expDirtyHosts:  []string{"domain1.local"},
+		},
+		// 6
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.SecretType, "default/secret1", "domain1.local"},
+			},
+			oldSecretList: []string{"default/secret1"},
+			expDirtyIngs:  []string{"default/ing1"},
+			expDirtyHosts: []string{"domain1.local"},
+		},
+		// 7
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+			},
+			trackedMissingHosts: []hostTracking{
+				{convtypes.ServiceType, "default/svc1", "domain1.local"},
+			},
+			addServiceList: []string{"default/svc1"},
+			expDirtyIngs:   []string{"default/ing1"},
+			expDirtyHosts:  []string{"domain1.local"},
+		},
+		// 8
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+			},
+			trackedMissingHosts: []hostTracking{
+				{convtypes.SecretType, "default/secret1", "domain1.local"},
+			},
+			addSecretList: []string{"default/secret1"},
+			expDirtyIngs:  []string{"default/ing1"},
+			expDirtyHosts: []string{"domain1.local"},
+		},
+		// 9
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing2", "domain2.local"},
+			},
+			oldIngressList: []string{"default/ing1"},
+			expDirtyIngs:   []string{"default/ing1"},
+			expDirtyHosts:  []string{"domain1.local"},
+		},
+		// 10
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing2", "domain1.local"},
+				{convtypes.IngressType, "default/ing3", "domain2.local"},
+			},
+			oldIngressList: []string{"default/ing1"},
+			expDirtyIngs:   []string{"default/ing1", "default/ing2"},
+			expDirtyHosts:  []string{"domain1.local"},
+		},
+		// 11
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing2", "domain1.local"},
+				{convtypes.IngressType, "default/ing2", "domain2.local"},
+				{convtypes.IngressType, "default/ing3", "domain2.local"},
+			},
+			oldIngressList: []string{"default/ing1"},
+			expDirtyIngs:   []string{"default/ing1", "default/ing2", "default/ing3"},
+			expDirtyHosts:  []string{"domain1.local", "domain2.local"},
+		},
+		// 12
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing2", "domain2.local"},
+			},
+			trackedBacks: []backTracking{
+				{convtypes.IngressType, "default/ing1", back1a},
+			},
+			oldIngressList: []string{"default/ing1"},
+			expDirtyIngs:   []string{"default/ing1"},
+			expDirtyHosts:  []string{"domain1.local"},
+			expDirtyBacks:  []hatypes.BackendID{back1b},
+		},
+		// 13
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing2", "domain2.local"},
+				{convtypes.IngressType, "default/ing3", "domain3.local"},
+			},
+			trackedBacks: []backTracking{
+				{convtypes.IngressType, "default/ing1", back1a},
+				{convtypes.IngressType, "default/ing2", back2a},
+				{convtypes.IngressType, "default/ing3", back1b},
+			},
+			oldIngressList: []string{"default/ing1"},
+			expDirtyIngs:   []string{"default/ing1", "default/ing3"},
+			expDirtyHosts:  []string{"domain1.local", "domain3.local"},
+			expDirtyBacks:  []hatypes.BackendID{back1b},
+		},
+	}
+	for i, test := range testCases {
+		c := setup(t)
+		for _, trackedHost := range test.trackedHosts {
+			c.tracker.TrackHostname(trackedHost.rtype, trackedHost.name, trackedHost.hostname)
+		}
+		for _, trackedBack := range test.trackedBacks {
+			c.tracker.TrackBackend(trackedBack.rtype, trackedBack.name, trackedBack.backend)
+		}
+		for _, trackedMissingHost := range test.trackedMissingHosts {
+			c.tracker.TrackMissingOnHostname(trackedMissingHost.rtype, trackedMissingHost.name, trackedMissingHost.hostname)
+		}
+		dirtyIngs, dirtyHosts, dirtyBacks :=
+			c.tracker.GetDirtyLinks(
+				test.oldIngressList,
+				test.oldServiceList,
+				test.addServiceList,
+				test.oldSecretList,
+				test.addSecretList,
+			)
+		sort.Strings(dirtyIngs)
+		sort.Strings(dirtyHosts)
+		sort.Slice(dirtyBacks, func(i, j int) bool {
+			return dirtyBacks[i].String() < dirtyBacks[j].String()
+		})
+		c.compareObjects("dirty ingress", i, dirtyIngs, test.expDirtyIngs)
+		c.compareObjects("dirty hosts", i, dirtyHosts, test.expDirtyHosts)
+		c.compareObjects("dirty backs", i, dirtyBacks, test.expDirtyBacks)
+		c.teardown()
+	}
+}
+
+func TestDeleteHostnames(t *testing.T) {
+	testCases := []struct {
+		trackedHosts []hostTracking
+		//
+		trackedMissingHosts []hostTracking
+		//
+		deleteHostnames []string
+		//
+		expIngressHostname stringStringMap
+		expHostnameIngress stringStringMap
+		expServiceHostname stringStringMap
+		expHostnameService stringStringMap
+		expSecretHostname  stringStringMap
+		expHostnameSecret  stringStringMap
+		//
+		expServiceHostnameMissing stringStringMap
+		expHostnameServiceMissing stringStringMap
+		expSecretHostnameMissing  stringStringMap
+		expHostnameSecretMissing  stringStringMap
+	}{
+		// 0
+		{},
+		// 1
+		{
+			deleteHostnames: []string{"domain1.local"},
+		},
+		// 2
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+			},
+			expIngressHostname: stringStringMap{"default/ing1": {"domain1.local": empty{}}},
+			expHostnameIngress: stringStringMap{"domain1.local": {"default/ing1": empty{}}},
+		},
+		// 3
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+			},
+			deleteHostnames: []string{"domain1.local"},
+		},
+		// 4
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.ServiceType, "default/svc1", "domain1.local"},
+			},
+			deleteHostnames: []string{"domain1.local"},
+		},
+		// 5
+		{
+			trackedMissingHosts: []hostTracking{
+				{convtypes.ServiceType, "default/svc1", "domain1.local"},
+			},
+			deleteHostnames: []string{"domain1.local"},
+		},
+		// 6
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.SecretType, "default/secret1", "domain1.local"},
+			},
+			deleteHostnames: []string{"domain1.local"},
+		},
+		// 7
+		{
+			trackedMissingHosts: []hostTracking{
+				{convtypes.SecretType, "default/secret1", "domain1.local"},
+			},
+			deleteHostnames: []string{"domain1.local"},
+		},
+		// 8
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing1", "domain2.local"},
+			},
+			deleteHostnames: []string{"domain1.local", "domain2.local"},
+		},
+		// 9
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing1", "domain2.local"},
+			},
+			deleteHostnames:    []string{"domain1.local"},
+			expIngressHostname: stringStringMap{"default/ing1": {"domain2.local": empty{}}},
+			expHostnameIngress: stringStringMap{"domain2.local": {"default/ing1": empty{}}},
+		},
+		// 10
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing2", "domain1.local"},
+			},
+			deleteHostnames: []string{"domain1.local"},
+		},
+		// 11
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing2", "domain1.local"},
+			},
+			deleteHostnames: []string{"domain1.local", "domain2.local"},
+		},
+		// 12
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressType, "default/ing1", "domain1.local"},
+				{convtypes.IngressType, "default/ing1", "domain2.local"},
+				{convtypes.IngressType, "default/ing1", "domain3.local"},
+				{convtypes.ServiceType, "default/svc1", "domain1.local"},
+				{convtypes.ServiceType, "default/svc1", "domain2.local"},
+				{convtypes.ServiceType, "default/svc1", "domain3.local"},
+				{convtypes.SecretType, "default/secret1", "domain1.local"},
+				{convtypes.SecretType, "default/secret1", "domain2.local"},
+				{convtypes.SecretType, "default/secret1", "domain3.local"},
+			},
+			deleteHostnames:    []string{"domain1.local", "domain2.local"},
+			expIngressHostname: stringStringMap{"default/ing1": {"domain3.local": empty{}}},
+			expHostnameIngress: stringStringMap{"domain3.local": {"default/ing1": empty{}}},
+			expServiceHostname: stringStringMap{"default/svc1": {"domain3.local": empty{}}},
+			expHostnameService: stringStringMap{"domain3.local": {"default/svc1": empty{}}},
+			expSecretHostname:  stringStringMap{"default/secret1": {"domain3.local": empty{}}},
+			expHostnameSecret:  stringStringMap{"domain3.local": {"default/secret1": empty{}}},
+		},
+	}
+	for i, test := range testCases {
+		c := setup(t)
+		for _, trackedHost := range test.trackedHosts {
+			c.tracker.TrackHostname(trackedHost.rtype, trackedHost.name, trackedHost.hostname)
+		}
+		for _, trackedMissingHost := range test.trackedMissingHosts {
+			c.tracker.TrackMissingOnHostname(trackedMissingHost.rtype, trackedMissingHost.name, trackedMissingHost.hostname)
+		}
+		c.tracker.DeleteHostnames(test.deleteHostnames)
+		c.compareObjects("ingressHostname", i, c.tracker.ingressHostname, test.expIngressHostname)
+		c.compareObjects("hostnameIngress", i, c.tracker.hostnameIngress, test.expHostnameIngress)
+		c.compareObjects("serviceHostname", i, c.tracker.serviceHostname, test.expServiceHostname)
+		c.compareObjects("hostnameService", i, c.tracker.hostnameService, test.expHostnameService)
+		c.compareObjects("secretHostname", i, c.tracker.secretHostname, test.expSecretHostname)
+		c.compareObjects("hostnameSecret", i, c.tracker.hostnameSecret, test.expHostnameSecret)
+		c.compareObjects("serviceHostnameMissing", i, c.tracker.serviceHostnameMissing, test.expServiceHostnameMissing)
+		c.compareObjects("hostnameServiceMissing", i, c.tracker.hostnameServiceMissing, test.expHostnameServiceMissing)
+		c.compareObjects("secretHostnameMissing", i, c.tracker.secretHostnameMissing, test.expSecretHostnameMissing)
+		c.compareObjects("hostnameSecretMissing", i, c.tracker.hostnameSecretMissing, test.expHostnameSecretMissing)
+		c.teardown()
+	}
+}
+
+func TestDeleteBackends(t *testing.T) {
+	testCases := []struct {
+		trackedBacks []backTracking
+		//
+		deleteBackends []hatypes.BackendID
+		//
+		expIngressBackend stringBackendMap
+		expBackendIngress backendStringMap
+	}{
+		// 0
+		{},
+		// 1
+		{
+			deleteBackends: []hatypes.BackendID{back1b},
+		},
+		// 2
+		{
+			trackedBacks: []backTracking{
+				{convtypes.IngressType, "default/ing1", back1a},
+			},
+			expBackendIngress: backendStringMap{back1b: {"default/ing1": empty{}}},
+			expIngressBackend: stringBackendMap{"default/ing1": {back1b: empty{}}},
+		},
+		// 3
+		{
+			trackedBacks: []backTracking{
+				{convtypes.IngressType, "default/ing1", back1a},
+			},
+			deleteBackends: []hatypes.BackendID{back1b},
+		},
+		// 4
+		{
+			trackedBacks: []backTracking{
+				{convtypes.IngressType, "default/ing1", back1a},
+				{convtypes.IngressType, "default/ing2", back1a},
+				{convtypes.IngressType, "default/ing2", back2a},
+			},
+			deleteBackends:    []hatypes.BackendID{back1b},
+			expBackendIngress: backendStringMap{back2b: {"default/ing2": empty{}}},
+			expIngressBackend: stringBackendMap{"default/ing2": {back2b: empty{}}},
+		},
+	}
+	for i, test := range testCases {
+		c := setup(t)
+		for _, trackedBack := range test.trackedBacks {
+			c.tracker.TrackBackend(trackedBack.rtype, trackedBack.name, trackedBack.backend)
+		}
+		c.tracker.DeleteBackends(test.deleteBackends)
+		c.compareObjects("ingressBackend", i, c.tracker.ingressBackend, test.expIngressBackend)
+		c.compareObjects("backendIngress", i, c.tracker.backendIngress, test.expBackendIngress)
+		c.teardown()
+	}
+}
+
+type testConfig struct {
+	t       *testing.T
+	tracker *tracker
+}
+
+func setup(t *testing.T) *testConfig {
+	return &testConfig{
+		t:       t,
+		tracker: NewTracker().(*tracker),
+	}
+}
+
+func (c *testConfig) teardown() {}
+
+func (c *testConfig) compareObjects(name string, index int, actual, expected interface{}) {
+	if !reflect.DeepEqual(actual, expected) {
+		c.t.Errorf("%s on %d differs - expected: %v - actual: %v", name, index, expected, actual)
+	}
+}

--- a/pkg/converters/ingress/tracker/tracker_test.go
+++ b/pkg/converters/ingress/tracker/tracker_test.go
@@ -80,6 +80,7 @@ func TestGetDirtyLinks(t *testing.T) {
 		addServiceList []string
 		oldSecretList  []string
 		addSecretList  []string
+		addPodList     []string
 		//
 		expDirtyIngs  []string
 		expDirtyHosts []string
@@ -247,6 +248,17 @@ func TestGetDirtyLinks(t *testing.T) {
 			oldSecretList: []string{"default/secret1"},
 			expDirtyUsers: []string{"usr1"},
 		},
+		// 17
+		{
+			trackedBacks: []backTracking{
+				{convtypes.PodType, "default/pod1", back1a},
+				{convtypes.PodType, "default/pod2", back1a},
+				{convtypes.PodType, "default/pod3", back2a},
+				{convtypes.PodType, "default/pod4", back2a},
+			},
+			addPodList:    []string{"default/pod3"},
+			expDirtyBacks: []hatypes.BackendID{back2b},
+		},
 	}
 	for i, test := range testCases {
 		c := setup(t)
@@ -272,6 +284,7 @@ func TestGetDirtyLinks(t *testing.T) {
 				test.addServiceList,
 				test.oldSecretList,
 				test.addSecretList,
+				test.addPodList,
 			)
 		sort.Strings(dirtyIngs)
 		sort.Strings(dirtyHosts)

--- a/pkg/converters/ingress/types/options.go
+++ b/pkg/converters/ingress/types/options.go
@@ -25,6 +25,7 @@ import (
 type ConverterOptions struct {
 	Logger           types.Logger
 	Cache            convtypes.Cache
+	Tracker          convtypes.Tracker
 	DefaultConfig    func() map[string]string
 	DefaultBackend   string
 	DefaultSSLFile   convtypes.CrtFile

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -20,10 +20,15 @@ import (
 	"time"
 
 	api "k8s.io/api/core/v1"
+	extensions "k8s.io/api/extensions/v1beta1"
+
+	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 )
 
 // Cache ...
 type Cache interface {
+	GetIngress(ingressName string) (*extensions.Ingress, error)
+	GetIngressList() ([]*extensions.Ingress, error)
 	GetService(serviceName string) (*api.Service, error)
 	GetEndpoints(service *api.Service) (*api.Endpoints, error)
 	GetTerminatingPods(service *api.Service) ([]*api.Pod, error)
@@ -32,6 +37,36 @@ type Cache interface {
 	GetCASecretPath(defaultNamespace, secretName string) (ca, crl File, err error)
 	GetDHSecretPath(defaultNamespace, secretName string) (File, error)
 	GetSecretContent(defaultNamespace, secretName, keyName string) ([]byte, error)
+	SwapChangedObjects() *ChangedObjects
+	NeedFullSync() bool
+}
+
+// ChangedObjects ...
+type ChangedObjects struct {
+	//
+	GlobalCur, GlobalNew map[string]string
+	//
+	TCPConfigMapCur, TCPConfigMapNew map[string]string
+	//
+	IngressesDel, IngressesUpd, IngressesAdd []*extensions.Ingress
+	//
+	Endpoints []*api.Endpoints
+	//
+	ServicesDel, ServicesUpd, ServicesAdd []*api.Service
+	//
+	SecretsDel, SecretsUpd, SecretsAdd []*api.Secret
+	//
+	Pods []*api.Pod
+}
+
+// Tracker ...
+type Tracker interface {
+	TrackHostname(rtype ResourceType, name, hostname string)
+	TrackBackend(rtype ResourceType, name string, backendID hatypes.BackendID)
+	TrackMissingOnHostname(rtype ResourceType, name, hostname string)
+	GetDirtyLinks(oldIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID)
+	DeleteHostnames(hostnames []string)
+	DeleteBackends(backends []hatypes.BackendID)
 }
 
 // File ...
@@ -47,3 +82,17 @@ type CrtFile struct {
 	CommonName string
 	NotAfter   time.Time
 }
+
+// ResourceType ...
+type ResourceType int
+
+const (
+	// IngressType ...
+	IngressType ResourceType = iota
+
+	// ServiceType ...
+	ServiceType
+
+	// SecretType ...
+	SecretType
+)

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -65,15 +65,17 @@ type Tracker interface {
 	TrackHostname(rtype ResourceType, name, hostname string)
 	TrackBackend(rtype ResourceType, name string, backendID hatypes.BackendID)
 	TrackMissingOnHostname(rtype ResourceType, name, hostname string)
-	GetDirtyLinks(oldIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID)
+	GetDirtyLinks(oldIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers []string)
 	DeleteHostnames(hostnames []string)
 	DeleteBackends(backends []hatypes.BackendID)
+	DeleteUserlists(userlists []string)
 }
 
 // TrackingTarget ...
 type TrackingTarget struct {
 	Hostname string
 	Backend  hatypes.BackendID
+	Userlist string
 }
 
 // File ...

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -33,10 +33,10 @@ type Cache interface {
 	GetEndpoints(service *api.Service) (*api.Endpoints, error)
 	GetTerminatingPods(service *api.Service) ([]*api.Pod, error)
 	GetPod(podName string) (*api.Pod, error)
-	GetTLSSecretPath(defaultNamespace, secretName string) (CrtFile, error)
-	GetCASecretPath(defaultNamespace, secretName string) (ca, crl File, err error)
+	GetTLSSecretPath(defaultNamespace, secretName string, track TrackingTarget) (CrtFile, error)
+	GetCASecretPath(defaultNamespace, secretName string, track TrackingTarget) (ca, crl File, err error)
 	GetDHSecretPath(defaultNamespace, secretName string) (File, error)
-	GetSecretContent(defaultNamespace, secretName, keyName string) ([]byte, error)
+	GetSecretContent(defaultNamespace, secretName, keyName string, track TrackingTarget) ([]byte, error)
 	SwapChangedObjects() *ChangedObjects
 	NeedFullSync() bool
 }

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -61,12 +61,19 @@ type ChangedObjects struct {
 
 // Tracker ...
 type Tracker interface {
+	Track(isMissing bool, track TrackingTarget, rtype ResourceType, name string)
 	TrackHostname(rtype ResourceType, name, hostname string)
 	TrackBackend(rtype ResourceType, name string, backendID hatypes.BackendID)
 	TrackMissingOnHostname(rtype ResourceType, name, hostname string)
 	GetDirtyLinks(oldIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID)
 	DeleteHostnames(hostnames []string)
 	DeleteBackends(backends []hatypes.BackendID)
+}
+
+// TrackingTarget ...
+type TrackingTarget struct {
+	Hostname string
+	Backend  hatypes.BackendID
 }
 
 // File ...

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -65,10 +65,12 @@ type Tracker interface {
 	TrackHostname(rtype ResourceType, name, hostname string)
 	TrackBackend(rtype ResourceType, name string, backendID hatypes.BackendID)
 	TrackMissingOnHostname(rtype ResourceType, name, hostname string)
-	GetDirtyLinks(oldIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers []string)
+	TrackStorage(rtype ResourceType, name, storage string)
+	GetDirtyLinks(oldIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers, dirtyStorages []string)
 	DeleteHostnames(hostnames []string)
 	DeleteBackends(backends []hatypes.BackendID)
 	DeleteUserlists(userlists []string)
+	DeleteStorages(storages []string)
 }
 
 // TrackingTarget ...

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -31,7 +31,7 @@ type Cache interface {
 	GetIngressList() ([]*extensions.Ingress, error)
 	GetService(serviceName string) (*api.Service, error)
 	GetEndpoints(service *api.Service) (*api.Endpoints, error)
-	GetTerminatingPods(service *api.Service) ([]*api.Pod, error)
+	GetTerminatingPods(service *api.Service, track TrackingTarget) ([]*api.Pod, error)
 	GetPod(podName string) (*api.Pod, error)
 	GetTLSSecretPath(defaultNamespace, secretName string, track TrackingTarget) (CrtFile, error)
 	GetCASecretPath(defaultNamespace, secretName string, track TrackingTarget) (ca, crl File, err error)
@@ -65,7 +65,7 @@ type Tracker interface {
 	TrackHostname(rtype ResourceType, name, hostname string)
 	TrackBackend(rtype ResourceType, name string, backendID hatypes.BackendID)
 	TrackMissingOnHostname(rtype ResourceType, name, hostname string)
-	GetDirtyLinks(oldIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers []string)
+	GetDirtyLinks(oldIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers []string)
 	DeleteHostnames(hostnames []string)
 	DeleteBackends(backends []hatypes.BackendID)
 	DeleteUserlists(userlists []string)
@@ -104,4 +104,7 @@ const (
 
 	// SecretType ...
 	SecretType
+
+	// PodType ...
+	PodType
 )

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -104,7 +104,7 @@ func (c *config) SyncConfig() {
 		c.frontend.BindSocket = c.global.Bind.HTTPSBind
 		c.frontend.AcceptProxy = c.global.Bind.AcceptProxy
 	}
-	for _, host := range c.hosts.Items() {
+	for _, host := range c.hosts.ItemsAdd() {
 		if host.SSLPassthrough() {
 			// no action if ssl-passthrough
 			continue

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -369,6 +369,7 @@ func (c *config) Commit() {
 	c.backends.Commit()
 	c.tcpbackends.Commit()
 	c.userlists.Commit()
+	c.acmeData.Storages().Commit()
 }
 
 func (c *config) hasCommittedData() bool {

--- a/pkg/haproxy/config_test.go
+++ b/pkg/haproxy/config_test.go
@@ -65,11 +65,11 @@ func TestEqual(t *testing.T) {
 	if !c1.Equals(c2) {
 		t.Error("c1 and c2 should be equals (empty)")
 	}
-	c1.ConfigDefaultX509Cert("/var/default.pem")
+	c1.frontend.DefaultCert = "/var/default.pem"
 	if c1.Equals(c2) {
 		t.Error("c1 and c2 should not be equals (one default cert)")
 	}
-	c2.ConfigDefaultX509Cert("/var/default.pem")
+	c2.frontend.DefaultCert = "/var/default.pem"
 	if !c1.Equals(c2) {
 		t.Error("c1 and c2 should be equals (default cert)")
 	}

--- a/pkg/haproxy/config_test.go
+++ b/pkg/haproxy/config_test.go
@@ -105,3 +105,30 @@ func TestEqual(t *testing.T) {
 		t.Error("c1 and c2 should be equals (after building frontends)")
 	}
 }
+
+func TestClear(t *testing.T) {
+	c := createConfig(options{
+		mapsDir: "/tmp/maps",
+	})
+	c.Hosts().AcquireHost("app.local")
+	c.Backends().AcquireBackend("default", "app", "8080")
+	if c.mapsDir != "/tmp/maps" {
+		t.Error("expected mapsDir == /tmp/maps")
+	}
+	if len(c.Hosts().Items()) != 1 {
+		t.Error("expected len(hosts) == 1")
+	}
+	if len(c.Backends().Items()) != 1 {
+		t.Error("expected len(backends) == 1")
+	}
+	c.Clear()
+	if c.mapsDir != "/tmp/maps" {
+		t.Error("expected mapsDir == /tmp/maps")
+	}
+	if len(c.Hosts().Items()) != 0 {
+		t.Error("expected len(hosts) == 0")
+	}
+	if len(c.Backends().Items()) != 0 {
+		t.Error("expected len(backends) == 0")
+	}
+}

--- a/pkg/haproxy/config_test.go
+++ b/pkg/haproxy/config_test.go
@@ -59,53 +59,6 @@ func TestAcquireHostSame(t *testing.T) {
 	}
 }
 
-func TestEqual(t *testing.T) {
-	c1 := createConfig(options{})
-	c2 := createConfig(options{})
-	if !c1.Equals(c2) {
-		t.Error("c1 and c2 should be equals (empty)")
-	}
-	c1.frontend.DefaultCert = "/var/default.pem"
-	if c1.Equals(c2) {
-		t.Error("c1 and c2 should not be equals (one default cert)")
-	}
-	c2.frontend.DefaultCert = "/var/default.pem"
-	if !c1.Equals(c2) {
-		t.Error("c1 and c2 should be equals (default cert)")
-	}
-	b1 := c1.Backends().AcquireBackend("d", "app1", "8080")
-	c1.Backends().AcquireBackend("d", "app2", "8080")
-	if c1.Equals(c2) {
-		t.Error("c1 and c2 should not be equals (backends on one side)")
-	}
-	c2.Backends().AcquireBackend("d", "app2", "8080")
-	b2 := c2.Backends().AcquireBackend("d", "app1", "8080")
-	if !c1.Equals(c2) {
-		t.Error("c1 and c2 should be equals (with backends)")
-	}
-	h1 := c1.hosts.AcquireHost("d")
-	h1.AddPath(b1, "/")
-	if c1.Equals(c2) {
-		t.Error("c1 and c2 should not be equals (hosts on one side)")
-	}
-	h2 := c2.hosts.AcquireHost("d")
-	h2.AddPath(b2, "/")
-	if !c1.Equals(c2) {
-		t.Error("c1 and c2 should be equals (with hosts)")
-	}
-	err1 := c1.WriteFrontendMaps()
-	err2 := c2.WriteFrontendMaps()
-	if err1 != nil {
-		t.Errorf("error building c1: %v", err1)
-	}
-	if err2 != nil {
-		t.Errorf("error building c2: %v", err2)
-	}
-	if !c1.Equals(c2) {
-		t.Error("c1 and c2 should be equals (after building frontends)")
-	}
-}
-
 func TestClear(t *testing.T) {
 	c := createConfig(options{
 		mapsDir: "/tmp/maps",

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -223,7 +223,6 @@ func (i *instance) acmeUpdate() {
 func (i *instance) haproxyUpdate(timer *utils.Timer) {
 	// nil config, just ignore
 	if i.config == nil {
-		i.logger.Info("new configuration is empty")
 		return
 	}
 	//
@@ -235,7 +234,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 	defer i.config.Commit()
 	i.config.SyncConfig()
 	if err := i.config.WriteFrontendMaps(); err != nil {
-		i.logger.Error("error building configuration group: %v", err)
+		i.logger.Error("error building frontend maps: %v", err)
 		i.metrics.IncUpdateNoop()
 		return
 	}
@@ -246,13 +245,13 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 	}
 	updater := i.newDynUpdater()
 	updated := updater.update()
-	timer.Tick("gen_config")
+	timer.Tick("write_maps")
 	if !updated || updater.cmdCnt > 0 {
 		// only need to rewrtite config files if:
 		//   - !updated           - there are changes that cannot be dynamically applied
 		//   - updater.cmdCnt > 0 - there are changes that was dynamically applied
 		err := i.templates.Write(i.config)
-		timer.Tick("write_tmpl")
+		timer.Tick("write_config")
 		if err != nil {
 			i.logger.Error("error writing configuration: %v", err)
 			i.metrics.IncUpdateNoop()

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2392,7 +2392,7 @@ frontend _front_http
 		h = c.config.Hosts().AcquireHost("d1.local")
 		h.AddPath(b, "/")
 
-		acme := c.config.Acme()
+		acme := &c.config.Global().Acme
 		acme.Enabled = true
 		acme.Prefix = "/.acme"
 		acme.Socket = "/run/acme.sock"
@@ -2862,7 +2862,7 @@ func setup(t *testing.T) *testConfig {
 		mapsDir:      tempdir,
 	})
 	instance.curConfig = config
-	config.ConfigDefaultX509Cert("/var/haproxy/ssl/certs/default.pem")
+	config.frontend.DefaultCert = "/var/haproxy/ssl/certs/default.pem"
 	c := &testConfig{
 		t:          t,
 		logger:     logger,
@@ -2887,7 +2887,7 @@ func (c *testConfig) newConfig() Config {
 		mapsTemplate: c.instance.(*instance).mapsTemplate,
 		mapsDir:      c.tempdir,
 	})
-	config.ConfigDefaultX509Cert("/var/haproxy/ssl/certs/default.pem")
+	config.frontend.DefaultCert = "/var/haproxy/ssl/certs/default.pem"
 	c.configGlobal(config.Global())
 	return config
 }

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1137,7 +1137,7 @@ func TestInstanceTCPBackend(t *testing.T) {
 		// 0
 		{
 			doconfig: func(c *testConfig) {
-				b := c.config.AcquireTCPBackend("postgresql", 5432)
+				b := c.config.TCPBackends().Acquire("postgresql", 5432)
 				b.AddEndpoint("172.17.0.2", 5432)
 			},
 			expected: `
@@ -1149,7 +1149,7 @@ listen _tcp_postgresql_5432
 		// 1
 		{
 			doconfig: func(c *testConfig) {
-				b := c.config.AcquireTCPBackend("pq", 5432)
+				b := c.config.TCPBackends().Acquire("pq", 5432)
 				b.AddEndpoint("172.17.0.2", 5432)
 				b.AddEndpoint("172.17.0.3", 5432)
 				b.CheckInterval = "2s"
@@ -1164,7 +1164,7 @@ listen _tcp_pq_5432
 		// 2
 		{
 			doconfig: func(c *testConfig) {
-				b := c.config.AcquireTCPBackend("pq", 5432)
+				b := c.config.TCPBackends().Acquire("pq", 5432)
 				b.AddEndpoint("172.17.0.2", 5432)
 				b.SSL.Filename = "/var/haproxy/ssl/pq.pem"
 				b.ProxyProt.EncodeVersion = "v2"
@@ -1178,7 +1178,7 @@ listen _tcp_pq_5432
 		// 3
 		{
 			doconfig: func(c *testConfig) {
-				b := c.config.AcquireTCPBackend("pq", 5432)
+				b := c.config.TCPBackends().Acquire("pq", 5432)
 				b.AddEndpoint("172.17.0.2", 5432)
 				b.SSL.Filename = "/var/haproxy/ssl/pq.pem"
 				b.ProxyProt.Decode = true
@@ -1195,7 +1195,7 @@ listen _tcp_pq_5432
 		// 4
 		{
 			doconfig: func(c *testConfig) {
-				b := c.config.AcquireTCPBackend("pq", 5432)
+				b := c.config.TCPBackends().Acquire("pq", 5432)
 				b.AddEndpoint("172.17.0.2", 5432)
 				b.SSL.Filename = "/var/haproxy/ssl/pq.pem"
 				b.SSL.CAFilename = "/var/haproxy/ssl/pqca.pem"
@@ -1210,7 +1210,7 @@ listen _tcp_pq_5432
 		// 5
 		{
 			doconfig: func(c *testConfig) {
-				b := c.config.AcquireTCPBackend("pq", 5432)
+				b := c.config.TCPBackends().Acquire("pq", 5432)
 				b.AddEndpoint("172.17.0.2", 5432)
 				b.SSL.Filename = "/var/haproxy/ssl/pq.pem"
 				b.SSL.CAFilename = "/var/haproxy/ssl/pqca.pem"
@@ -2307,7 +2307,7 @@ userlist default_auth2
 		h.AddPath(b, "/admin")
 
 		for _, list := range test.lists {
-			c.config.AddUserlist(list.name, list.users)
+			c.config.Userlists().Replace(list.name, list.users)
 		}
 		b.AuthHTTP = []*hatypes.BackendConfigAuth{
 			{
@@ -2861,7 +2861,7 @@ func setup(t *testing.T) *testConfig {
 		mapsTemplate: instance.mapsTemplate,
 		mapsDir:      tempdir,
 	})
-	instance.curConfig = config
+	instance.config = config
 	config.frontend.DefaultCert = "/var/haproxy/ssl/certs/default.pem"
 	c := &testConfig{
 		t:          t,
@@ -2880,16 +2880,6 @@ func (c *testConfig) teardown() {
 	if err := os.RemoveAll(c.tempdir); err != nil {
 		c.t.Errorf("error removing tempdir: %v", err)
 	}
-}
-
-func (c *testConfig) newConfig() Config {
-	config := createConfig(options{
-		mapsTemplate: c.instance.(*instance).mapsTemplate,
-		mapsDir:      c.tempdir,
-	})
-	config.frontend.DefaultCert = "/var/haproxy/ssl/certs/default.pem"
-	c.configGlobal(config.Global())
-	return config
 }
 
 func (c *testConfig) configGlobal(global *hatypes.Global) {

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -29,6 +29,15 @@ func NewBackendPaths(paths ...*BackendPath) BackendPaths {
 	return b
 }
 
+// BackendID ...
+func (b *Backend) BackendID() BackendID {
+	return BackendID{
+		Namespace: b.Namespace,
+		Name:      b.Name,
+		Port:      b.Port,
+	}
+}
+
 // FindEndpoint ...
 func (b *Backend) FindEndpoint(target string) *Endpoint {
 	for _, endpoint := range b.Endpoints {
@@ -37,6 +46,11 @@ func (b *Backend) FindEndpoint(target string) *Endpoint {
 		}
 	}
 	return nil
+}
+
+// ClearEndpoints ...
+func (b *Backend) ClearEndpoints() {
+	b.Endpoints = nil
 }
 
 // AcquireEndpoint ...

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -48,11 +48,6 @@ func (b *Backend) FindEndpoint(target string) *Endpoint {
 	return nil
 }
 
-// ClearEndpoints ...
-func (b *Backend) ClearEndpoints() {
-	b.Endpoints = nil
-}
-
 // AcquireEndpoint ...
 func (b *Backend) AcquireEndpoint(ip string, port int, targetRef string) *Endpoint {
 	endpoint := b.FindEndpoint(fmt.Sprintf("%s:%d", ip, port))

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -31,6 +31,8 @@ func NewBackendPaths(paths ...*BackendPath) BackendPaths {
 
 // BackendID ...
 func (b *Backend) BackendID() BackendID {
+	// IMPLEMENT as pointer
+	// TODO immutable internal state
 	return BackendID{
 		Namespace: b.Namespace,
 		Name:      b.Name,

--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -28,8 +28,28 @@ func CreateBackends() *Backends {
 }
 
 // Items ...
-func (b *Backends) Items() []*Backend {
-	return b.itemslist
+func (b *Backends) Items() map[string]*Backend {
+	return b.itemsmap
+}
+
+// BuildSortedItems ...
+func (b *Backends) BuildSortedItems() []*Backend {
+	items := make([]*Backend, len(b.itemsmap))
+	var i int
+	for _, item := range b.itemsmap {
+		items[i] = item
+		i++
+	}
+	sort.Slice(items, func(i, j int) bool {
+		if items[i] == b.defaultBackend {
+			return false
+		}
+		if items[j] == b.defaultBackend {
+			return true
+		}
+		return items[i].ID < items[j].ID
+	})
+	return items
 }
 
 // AcquireBackend ...
@@ -38,20 +58,27 @@ func (b *Backends) AcquireBackend(namespace, name, port string) *Backend {
 		return backend
 	}
 	backend := createBackend(namespace, name, port)
-	// Store backends on slice and map data structure.
-	// The slice has the order and the map has the index.
-	// TODO current approach is using the double of the memory
-	// on behalf of speed. Map only is doable? Another approach?
-	// See also hosts.AcquireHost().
 	b.itemsmap[backend.ID] = backend
-	b.itemslist = append(b.itemslist, backend)
-	b.sortBackends()
 	return backend
 }
 
 // FindBackend ...
 func (b *Backends) FindBackend(namespace, name, port string) *Backend {
 	return b.itemsmap[buildID(namespace, name, port)]
+}
+
+// FindBackendID ...
+func (b *Backends) FindBackendID(backendID BackendID) *Backend {
+	return b.itemsmap[backendID.String()]
+}
+
+// RemoveAll ...
+func (b *Backends) RemoveAll(backendID []BackendID) {
+	for _, backend := range backendID {
+		delete(b.itemsmap, backend.String())
+	}
+	// IMPLEMENT
+	// track and remove unused userlist entries
 }
 
 // DefaultBackend ...
@@ -69,19 +96,13 @@ func (b *Backends) SetDefaultBackend(defaultBackend *Backend) {
 	if b.defaultBackend != nil {
 		b.defaultBackend.ID = "_default_backend"
 	}
-	b.sortBackends()
 }
 
-func (b *Backends) sortBackends() {
-	sort.Slice(b.itemslist, func(i, j int) bool {
-		if b.itemslist[i] == b.defaultBackend {
-			return false
-		}
-		if b.itemslist[j] == b.defaultBackend {
-			return true
-		}
-		return b.itemslist[i].ID < b.itemslist[j].ID
-	})
+func (b *BackendID) String() string {
+	if b.id == "" {
+		b.id = b.Namespace + "_" + b.Name + "_" + b.Port
+	}
+	return b.id
 }
 
 func createBackend(namespace, name, port string) *Backend {

--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -105,8 +105,6 @@ func (b *Backends) RemoveAll(backendID []BackendID) {
 			delete(b.items, id)
 		}
 	}
-	// IMPLEMENT
-	// track and remove unused userlist entries
 }
 
 // DefaultBackend ...

--- a/pkg/haproxy/types/global.go
+++ b/pkg/haproxy/types/global.go
@@ -47,10 +47,6 @@ func (dns *DNSNameserver) String() string {
 	return fmt.Sprintf("%+v", *dns)
 }
 
-func (u *Userlist) String() string {
-	return fmt.Sprintf("%+v", *u)
-}
-
 // ShareHTTPPort ...
 func (b GlobalBindConfig) ShareHTTPPort() bool {
 	return b.HasFrontingProxy() && b.HTTPBind == b.FrontingBind

--- a/pkg/haproxy/types/global.go
+++ b/pkg/haproxy/types/global.go
@@ -18,20 +18,106 @@ package types
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
+	"strings"
 )
 
-// AddDomains ...
-func (acme *AcmeData) AddDomains(storage string, domains []string) {
-	if acme.Certs == nil {
-		acme.Certs = map[string]map[string]struct{}{}
+// Storages ...
+func (acme *AcmeData) Storages() *AcmeStorages {
+	if acme.storages == nil {
+		acme.storages = &AcmeStorages{
+			items:    map[string]*AcmeCerts{},
+			itemsAdd: map[string]*AcmeCerts{},
+			itemsDel: map[string]*AcmeCerts{},
+		}
 	}
-	certs, found := acme.Certs[storage]
+	return acme.storages
+}
+
+// Acquire ...
+func (c *AcmeStorages) Acquire(name string) *AcmeCerts {
+	storage, found := c.items[name]
 	if !found {
-		certs = map[string]struct{}{}
-		acme.Certs[storage] = certs
+		storage = &AcmeCerts{
+			certs: map[string]struct{}{},
+		}
+		c.items[name] = storage
+		c.itemsAdd[name] = storage
 	}
+	return storage
+}
+
+// Updated ...
+func (c *AcmeStorages) Updated() bool {
+	c.shrink()
+	return len(c.itemsAdd) > 0 || len(c.itemsDel) > 0
+}
+
+// BuildAcmeStorages ...
+func (c *AcmeStorages) BuildAcmeStorages() []string {
+	return buildAcmeStorages(c.items)
+}
+
+// BuildAcmeStoragesAdd ...
+func (c *AcmeStorages) BuildAcmeStoragesAdd() []string {
+	c.shrink()
+	return buildAcmeStorages(c.itemsAdd)
+}
+
+// BuildAcmeStoragesDel ...
+func (c *AcmeStorages) BuildAcmeStoragesDel() []string {
+	c.shrink()
+	return buildAcmeStorages(c.itemsDel)
+}
+
+func buildAcmeStorages(items map[string]*AcmeCerts) []string {
+	storages := make([]string, len(items))
+	i := 0
+	for name := range items {
+		item := items[name]
+		certs := make([]string, len(item.certs))
+		j := 0
+		for cert := range item.certs {
+			certs[j] = cert
+			j++
+		}
+		sort.Strings(certs)
+		storages[i] = name + "," + strings.Join(certs, ",")
+		i++
+	}
+	return storages
+}
+
+func (c *AcmeStorages) shrink() {
+	for item, del := range c.itemsDel {
+		if add, found := c.itemsAdd[item]; found && reflect.DeepEqual(add, del) {
+			delete(c.itemsAdd, item)
+			delete(c.itemsDel, item)
+		}
+	}
+}
+
+// RemoveAll ...
+func (c *AcmeStorages) RemoveAll(names []string) {
+	for _, name := range names {
+		if item, found := c.items[name]; found {
+			c.itemsDel[name] = item
+			delete(c.items, name)
+		}
+	}
+}
+
+// Commit ...
+func (c *AcmeStorages) Commit() {
+	c.itemsAdd = map[string]*AcmeCerts{}
+	c.itemsDel = map[string]*AcmeCerts{}
+}
+
+// AddDomains ...
+func (c *AcmeCerts) AddDomains(domains []string) {
 	for _, domain := range domains {
-		certs[domain] = struct{}{}
+		c.certs[domain] = struct{}{}
 	}
 }
 

--- a/pkg/haproxy/types/tcpbackend.go
+++ b/pkg/haproxy/types/tcpbackend.go
@@ -18,7 +18,74 @@ package types
 
 import (
 	"fmt"
+	"reflect"
+	"sort"
 )
+
+// CreateTCPBackends ...
+func CreateTCPBackends() *TCPBackends {
+	return &TCPBackends{
+		items:    map[int]*TCPBackend{},
+		itemsAdd: map[int]*TCPBackend{},
+		itemsDel: map[int]*TCPBackend{},
+	}
+}
+
+// Acquire ...
+func (b *TCPBackends) Acquire(servicename string, port int) *TCPBackend {
+	if backend, found := b.items[port]; found {
+		backend.Name = servicename
+		return backend
+	}
+	backend := &TCPBackend{
+		Name: servicename,
+		Port: port,
+	}
+	b.items[port] = backend
+	b.itemsAdd[port] = backend
+	return backend
+}
+
+// BuildSortedItems ...
+func (b *TCPBackends) BuildSortedItems() []*TCPBackend {
+	items := make([]*TCPBackend, len(b.items))
+	var i int
+	for _, item := range b.items {
+		items[i] = item
+		i++
+	}
+	sort.Slice(items, func(i, j int) bool {
+		back1 := items[i]
+		back2 := items[j]
+		if back1.Name == back2.Name {
+			return back1.Port < back2.Port
+		}
+		return back1.Name < back2.Name
+	})
+	if len(items) == 0 {
+		return nil
+	}
+	return items
+}
+
+// Changed ...
+func (b *TCPBackends) Changed() bool {
+	return !reflect.DeepEqual(b.itemsAdd, b.itemsDel)
+}
+
+// Commit ...
+func (b *TCPBackends) Commit() {
+	b.itemsAdd = map[int]*TCPBackend{}
+	b.itemsDel = map[int]*TCPBackend{}
+}
+
+// RemoveAll ...
+func (b *TCPBackends) RemoveAll() {
+	for port, item := range b.items {
+		b.itemsDel[port] = item
+		delete(b.items, port)
+	}
+}
 
 // AddEndpoint ...
 func (b *TCPBackend) AddEndpoint(ip string, port int) *TCPEndpoint {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -49,6 +49,7 @@ type Global struct {
 	ModSecurity     ModSecurityConfig
 	Cookie          CookieConfig
 	DrainSupport    DrainConfig
+	Acme            Acme
 	ForwardFor      string
 	LoadServerState bool
 	AdminSocket     string
@@ -277,6 +278,7 @@ type Frontend struct {
 	BindSocket  string
 	BindID      int
 	AcceptProxy bool
+	DefaultCert string
 }
 
 // Hosts ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -200,6 +200,11 @@ type ModSecurityTimeoutConfig struct {
 	Processing string
 }
 
+// TCPBackends ...
+type TCPBackends struct {
+	items, itemsAdd, itemsDel map[int]*TCPBackend
+}
+
 // TCPBackend ...
 type TCPBackend struct {
 	Name          string
@@ -283,7 +288,8 @@ type Frontend struct {
 
 // Hosts ...
 type Hosts struct {
-	itemsmap    map[string]*Host
+	items, itemsAdd, itemsDel map[string]*Host
+	//
 	defaultHost *Host
 	//
 	sslPassthroughCount int
@@ -362,7 +368,8 @@ const (
 
 // Backends ...
 type Backends struct {
-	itemsmap       map[string]*Backend
+	items, itemsAdd, itemsDel map[string]*Backend
+	//
 	defaultBackend *Backend
 }
 
@@ -644,6 +651,11 @@ type WAF struct {
 	Mode string
 	// Which WAF Module should be used
 	Module string
+}
+
+// Userlists ...
+type Userlists struct {
+	items, itemsAdd, itemsDel map[string]*Userlist
 }
 
 // Userlist ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -22,11 +22,21 @@ import (
 
 // AcmeData ...
 type AcmeData struct {
-	Certs       map[string]map[string]struct{}
+	storages    *AcmeStorages
 	Emails      string
 	Endpoint    string
 	Expiring    time.Duration
 	TermsAgreed bool
+}
+
+// AcmeStorages ...
+type AcmeStorages struct {
+	items, itemsAdd, itemsDel map[string]*AcmeCerts
+}
+
+// AcmeCerts ...
+type AcmeCerts struct {
+	certs map[string]struct{}
 }
 
 // Acme ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -283,7 +283,6 @@ type Frontend struct {
 
 // Hosts ...
 type Hosts struct {
-	itemslist   []*Host
 	itemsmap    map[string]*Host
 	defaultHost *Host
 	//
@@ -363,9 +362,16 @@ const (
 
 // Backends ...
 type Backends struct {
-	itemslist      []*Backend
 	itemsmap       map[string]*Backend
 	defaultBackend *Backend
+}
+
+// BackendID ...
+type BackendID struct {
+	id        string
+	Namespace string
+	Name      string
+	Port      string
 }
 
 // Backend ...
@@ -373,6 +379,8 @@ type Backend struct {
 	//
 	// core config
 	//
+	// IMPLEMENT
+	// use BackendID
 	ID        string
 	Namespace string
 	Name      string

--- a/pkg/haproxy/types/userlist.go
+++ b/pkg/haproxy/types/userlist.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2020 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+)
+
+// CreateUserlists ...
+func CreateUserlists() *Userlists {
+	return &Userlists{
+		items:    map[string]*Userlist{},
+		itemsAdd: map[string]*Userlist{},
+		itemsDel: map[string]*Userlist{},
+	}
+}
+
+// Replace ...
+func (u *Userlists) Replace(name string, users []User) *Userlist {
+	userlist := &Userlist{
+		Name:  name,
+		Users: users,
+	}
+	sort.Slice(users, func(i, j int) bool {
+		return users[i].Name < users[j].Name
+	})
+	u.items[name] = userlist
+	u.itemsAdd[name] = userlist
+	return userlist
+}
+
+// Find ...
+func (u *Userlists) Find(name string) *Userlist {
+	return u.items[name]
+}
+
+// BuildSortedItems ...
+func (u *Userlists) BuildSortedItems() []*Userlist {
+	items := make([]*Userlist, len(u.items))
+	var i int
+	for _, item := range u.items {
+		items[i] = item
+		i++
+	}
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Name < items[j].Name
+	})
+	if len(items) == 0 {
+		return nil
+	}
+	return items
+}
+
+// Changed ...
+func (u *Userlists) Changed() bool {
+	return !reflect.DeepEqual(u.itemsAdd, u.itemsDel)
+}
+
+// Commit ...
+func (u *Userlists) Commit() {
+	u.itemsAdd = map[string]*Userlist{}
+	u.itemsDel = map[string]*Userlist{}
+}
+
+func (u *Userlist) String() string {
+	return fmt.Sprintf("%+v", *u)
+}

--- a/pkg/haproxy/types/userlist.go
+++ b/pkg/haproxy/types/userlist.go
@@ -67,6 +67,17 @@ func (u *Userlists) BuildSortedItems() []*Userlist {
 	return items
 }
 
+// RemoveAll ...
+func (u *Userlists) RemoveAll(userlists []string) {
+	for _, userlist := range userlists {
+		if item, found := u.items[userlist]; found {
+			u.itemsDel[userlist] = item
+			delete(u.items, userlist)
+		}
+	}
+
+}
+
 // Changed ...
 func (u *Userlists) Changed() bool {
 	return !reflect.DeepEqual(u.itemsAdd, u.itemsDel)

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -204,7 +204,8 @@ listen _tcp_{{ $backend.Name }}_{{ $backend.Port }}
 {{- end }}{{/* range TCPBackends */}}
 {{- end }}{{/* if has TCPBackend */}}
 
-{{- if $backends.Items }}
+{{- $backendItems := $backends.BuildSortedItems }}
+{{- if $backendItems }}
 
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -213,7 +214,7 @@ listen _tcp_{{ $backend.Name }}_{{ $backend.Port }}
 # #   BACKENDS
 # #
 #
-{{- range $backend := $backends.Items }}
+{{- range $backend := $backendItems }}
 backend {{ $backend.ID }}
     mode {{ if $backend.ModeTCP }}tcp{{ else }}http{{ end }}
 {{- if $backend.BalanceAlgorithm }}
@@ -553,7 +554,7 @@ backend {{ $backend.ID }}
 {{- end }}
 {{- end }}
 
-{{- end }}{{/* if has backends.Items */}}
+{{- end }}{{/* if backendItems */}}
 
 {{- define "backend" }}
     {{- $backend := .p1 }}

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -590,7 +590,7 @@ backend {{ $backend.ID }}
     {{- end }}
 {{- end }}
 
-{{- if $cfg.Acme.Enabled }}
+{{- if $global.Acme.Enabled }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -598,7 +598,7 @@ backend {{ $backend.ID }}
 #
 backend _acme_challenge
     mode http
-    server _acme_server unix@{{ $cfg.Acme.Socket }}
+    server _acme_server unix@{{ $global.Acme.Socket }}
 {{- end }}
 
 {{- if not $backends.DefaultBackend }}
@@ -731,15 +731,15 @@ frontend _front_http
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if $cfg.Acme.Enabled }}
-    acl acme-challenge path_beg {{ $cfg.Acme.Prefix }}
+{{- if $global.Acme.Enabled }}
+    acl acme-challenge path_beg {{ $global.Acme.Prefix }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
     http-request set-var(req.base) base,lower,regsub(:[0-9]+/,/)
 
 {{- /*------------------------------------*/}}
-{{- $acmeexclusive := and $cfg.Acme.Enabled (not $cfg.Acme.Shared) }}
+{{- $acmeexclusive := and $global.Acme.Enabled (not $global.Acme.Shared) }}
 {{- if not $frontingIgnoreProto }}
 {{- if $fmaps.HTTPSRedirMap.HasRegex }}
     http-request set-var(req.redir)
@@ -822,7 +822,7 @@ frontend _front_http
     use_backend _acme_challenge if acme-challenge
 {{- end }}
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
-{{- if and $cfg.Acme.Enabled $cfg.Acme.Shared }}
+{{- if and $global.Acme.Enabled $global.Acme.Shared }}
     use_backend _acme_challenge if acme-challenge
 {{- end }}
 

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -143,7 +143,7 @@ resolvers {{ $resolver.Name }}
 {{- end }}
 {{- end }}
 
-{{- $userlists := $cfg.Userlists }}
+{{- $userlists := $cfg.Userlists.BuildSortedItems }}
 {{- if $userlists }}
 
   # # # # # # # # # # # # # # # # # # #
@@ -158,7 +158,8 @@ userlist {{ $userlist.Name }}
 {{- end }}
 {{- end }}
 
-{{- if $cfg.TCPBackends }}
+{{- $tcpbackends := $cfg.TCPBackends.BuildSortedItems}}
+{{- if $tcpbackends }}
 
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -168,7 +169,7 @@ userlist {{ $userlist.Name }}
 # #
 #
 
-{{- range $backend := $cfg.TCPBackends }}
+{{- range $backend := $tcpbackends }}
 listen _tcp_{{ $backend.Name }}_{{ $backend.Port }}
 {{- $ssl := $backend.SSL }}
     bind {{ $global.Bind.TCPBindIP }}:{{ $backend.Port }}


### PR DESCRIPTION
Improves the time of object parsing on big k8s clusters - about 1000+ ingress objects which references 1000+ services - using an updatable haproxy model and a object<->model tracking.

The implementation follows this approach:

* track changes on each relevant object type - currently ingress, service, endpoint, secret, configmap, and also pod if drain-support is used;
* every object tracks a host and/or backend in the haproxy model;
* if the object is removed or updated, only the tracked host and/or backend is rebuilt;
* dynupdate doesn't compare old/cur state anymore, but instead dirty and new host/backend state.

Work in progress:

* [x] object<->model link tracker
* [x] tracker tests
* [x] partial converter parsing
* [x] converter tests
* [x] partial haproxy model parsing
* [x] haproxy model tests
* [x] dynupdate refactor
* [x] stronger tracking
* [x] cache read X notification concurrency
* [x] track ingress, domains and backends
* [x] track ingress' secrets
* [x] track annotation parsing
* [x] track userlist
* [x] track pods on drain support mode