### PR TITLE
Fix permission using watch-namespace

### DIFF
--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -234,7 +234,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 	}
 
 	if *watchNamespace != "" {
-		_, err = kubeClient.CoreV1().Namespaces().Get(*watchNamespace, metav1.GetOptions{})
+		_, err = kubeClient.ExtensionsV1beta1().Ingresses(*watchNamespace).List(metav1.ListOptions{Limit: 1})
 		if err != nil {
 			glog.Fatalf("no watchNamespace with name %v found: %v", *watchNamespace, err)
 		}


### PR DESCRIPTION
Command-line option `--watch-namespace` configures the controller to read and use ingress objects from a single namespace. This would require fewer permissions,however the launch process tries to read the specified namespace, and such reading requires cluster wide permission. The launch process was updated to read an ingress resource instead.