### PR TITLE
TCP Services : SSL : Optionally Verify Client

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -229,6 +229,7 @@ The value of the ConfigMap entry is a colon separated list of the following argu
 1. `<out-proxy>`, optional, should be defined as `PROXY` or `PROXY-V2` if the upstream service expect connections using the PROXY protocol v2. Use `PROXY-V1` instead if the upstream service only support v1 protocol. Leave empty to connect without using the PROXY protocol.
 1. `<namespace/secret-name>`, optional, used to configure SSL/TLS over the TCP connection. Secret should have `tls.crt` and `tls.key` pair used on TLS handshake. Leave empty to not use ssl-offload.
 1. `<check-interval>`, added in v0.10, optional and defaults to `2s`, configures a TCP check interval. Declare `-` (one single dash) as the time to disable it. Valid time is a number and a mandatory suffix: `us`, `ms`, `s`, `m`, `h` or `d`.
+1. `<namespace/secret-name>`, added in v0.10, optional, used to configure SSL/TLS client verification over the TCP connection. Secret should have `ca.crt` and optional `ca.crl`. Leave empty to not use ssl client verification.
 
 Optional fields can be skipped using consecutive colons.
 
@@ -242,16 +243,18 @@ data:
   "8000": "system-prod/http:8000::PROXY-V1"
   "9900": "system-prod/admin:9900:PROXY::system-prod/tcp-9900"
   "9990": "system-prod/admin:9999::PROXY-V2"
+  "9995": "system-prod/admin:9900:::system-prod/tcp-9995::system-prod/tcp-9995-ca"
   "9999": "system-prod/admin:9999:PROXY:PROXY"
 ```
 
-HAProxy will listen 6 new ports:
+HAProxy will listen 7 new ports:
 
 * `3306` will proxy to a `mysql` service on `default` namespace. Check interval is disabled.
 * `5432` will proxy to a `pgsql` service on `default` namespace. Check interval is defined to run on every second.
 * `8000` will proxy to `http` service, port `8000`, on the `system-prod` namespace. The upstream service will expect connections using the PROXY protocol but it only supports v1.
 * `9900` will proxy to `admin` service, port `9900`, on the `system-prod` namespace. Clients should connect using the PROXY protocol v1 or v2. Upcoming connections should be encrypted, HAProxy will ssl-offload data using crt/key provided by `system-prod/tcp-9900` secret.
 * `9990` and `9999` will proxy to the same `admin` service and `9999` port and the upstream service will expect connections using the PROXY protocol v2. The HAProxy frontend, however, will only expect PROXY protocol v1 or v2 on it's port `9999`.
+* `9995` will proxy to `admin` service, port `9900`, on the `system-prod` namespace. Upcoming connections should be encrypted, HAProxy will ssl-offload data using crt/key provided by `system-prod/tcp-9995` secret. Furthermore, clients must present a certificate that will be valid under the certificate authority (and optional certificate revocation list) provded in the `system-prod/tcp-9995-ca` secret. 
 
 Note: Check interval was added in v0.10 and defaults to `2s`. All declared services has check interval enabled, except `3306` which disabled it.
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1
 	github.com/spf13/pflag v1.0.5
-	github.com/stretchr/testify v1.5.1
+	github.com/stretchr/testify v1.5.1 // indirect
 	golang.org/x/crypto v0.0.0-20190820162420-60c769a6c586
 	golang.org/x/net v0.0.0-20191004110552-13f9640d40b9 // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 // indirect

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1190,6 +1190,37 @@ listen _tcp_pq_5432
     mode tcp
     server srv001 172.17.0.2:5432 check port 5432 inter 2s send-proxy`,
 		},
+		// 4
+		{
+			doconfig: func(c *testConfig) {
+				b := c.config.AcquireTCPBackend("pq", 5432)
+				b.AddEndpoint("172.17.0.2", 5432)
+				b.SSL.Filename = "/var/haproxy/ssl/pq.pem"
+				b.SSL.CAFilename = "/var/haproxy/ssl/pqca.pem"
+				b.ProxyProt.EncodeVersion = "v2"
+			},
+			expected: `
+listen _tcp_pq_5432
+    bind :5432 ssl crt /var/haproxy/ssl/pq.pem ca-file /var/haproxy/ssl/pqca.pem verify required
+    mode tcp
+    server srv001 172.17.0.2:5432 send-proxy-v2`,
+		},
+		// 5
+		{
+			doconfig: func(c *testConfig) {
+				b := c.config.AcquireTCPBackend("pq", 5432)
+				b.AddEndpoint("172.17.0.2", 5432)
+				b.SSL.Filename = "/var/haproxy/ssl/pq.pem"
+				b.SSL.CAFilename = "/var/haproxy/ssl/pqca.pem"
+				b.SSL.CRLFilename = "/var/haproxy/ssl/pqcrl.pem"
+				b.ProxyProt.EncodeVersion = "v2"
+			},
+			expected: `
+listen _tcp_pq_5432
+    bind :5432 ssl crt /var/haproxy/ssl/pq.pem ca-file /var/haproxy/ssl/pqca.pem verify required crl-file /var/haproxy/ssl/pqcrl.pem
+    mode tcp
+    server srv001 172.17.0.2:5432 send-proxy-v2`,
+		},
 	}
 	for _, test := range testCases {
 		c := setup(t)

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -219,7 +219,9 @@ type TCPEndpoint struct {
 
 // TCPSSL ...
 type TCPSSL struct {
-	Filename string
+	Filename    string
+	CAFilename  string
+	CRLFilename string
 }
 
 // TCPProxyProt ...

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -172,7 +172,11 @@ userlist {{ $userlist.Name }}
 listen _tcp_{{ $backend.Name }}_{{ $backend.Port }}
 {{- $ssl := $backend.SSL }}
     bind {{ $global.Bind.TCPBindIP }}:{{ $backend.Port }}
-        {{- if $ssl.Filename }} ssl crt {{ $ssl.Filename }}{{ end }}
+        {{- if $ssl.Filename }} ssl crt {{ $ssl.Filename }}
+            {{- if $ssl.CAFilename }} ca-file {{ $ssl.CAFilename }} verify required
+                {{- if $ssl.CRLFilename }} crl-file {{ $ssl.CRLFilename }}{{ end }}
+            {{- end }}
+        {{- end }}
         {{- if $backend.ProxyProt.Decode }} accept-proxy{{ end }}
     mode tcp
 


### PR DESCRIPTION
Hello again @jcmoraisjr ,

I would like to propose a tentative implementation of ssl client verification for tcp services.
Currently we have a second instance of HAProxy whose sole job is to do ssl-offload AND verifying the client, ensuring the certificate presented by the client is indeed signed by the provided CA.

If we can do that ssl verification of the client directly at the ingress controller level, it would simplify things for us 😄 .

Let me know what you think !