### PR TITLE
Update deprecated APIs in Docs

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -148,7 +148,7 @@ remove old configuration files. If `0`, the default value, a single `haproxy.cfg
 Some infrastructure tools like `external-DNS` relay in the ingress status to created access routes to the services exposed with ingress object.
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 ...
 status:

--- a/docs/content/en/docs/examples/blue-green.md
+++ b/docs/content/en/docs/examples/blue-green.md
@@ -79,7 +79,7 @@ Configure the ingress resource. No need to change the host below, `bluegreen.exa
 
 ```
 $ kubectl create -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/docs/content/en/docs/examples/metrics.md
+++ b/docs/content/en/docs/examples/metrics.md
@@ -79,7 +79,7 @@ Create the ingress which will expose Grafana. Change `HOST` below to a domain of
 ```
 HOST=grafana.192.168.1.1.nip.io
 kubectl create -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: grafana

--- a/docs/content/en/docs/examples/metrics/whoami-ingress.yaml
+++ b/docs/content/en/docs/examples/metrics/whoami-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/docs/content/en/docs/examples/modsecurity.md
+++ b/docs/content/en/docs/examples/modsecurity.md
@@ -86,7 +86,7 @@ No need to use a valid domain, `echo.domain` below is fine:
 
 ```console
 $ kubectl create -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -104,7 +104,7 @@ Obs.: `nip.io` is a convenient service which converts a valid domain name to any
 ```shell
 $ HOST=nginx.192.168.1.1.nip.io
 $ kubectl create -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: nginx

--- a/docs/haproxy-ingress.yaml
+++ b/docs/haproxy-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
   name: ingress-controller
   namespace: ingress-controller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: ingress-controller
@@ -42,6 +42,7 @@ rules:
       - watch
   - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:
@@ -57,12 +58,13 @@ rules:
       - patch
   - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses/status
     verbs:
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ingress-controller
@@ -99,7 +101,7 @@ rules:
       - create
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: ingress-controller
@@ -115,7 +117,7 @@ subjects:
     kind: User
     name: ingress-controller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ingress-controller

--- a/docs/static/resources/haproxy-ingress.yaml
+++ b/docs/static/resources/haproxy-ingress.yaml
@@ -9,7 +9,7 @@ metadata:
   name: ingress-controller
   namespace: ingress-controller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: ingress-controller
@@ -41,6 +41,7 @@ rules:
       - watch
   - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:
@@ -56,12 +57,13 @@ rules:
       - patch
   - apiGroups:
       - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses/status
     verbs:
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ingress-controller
@@ -98,7 +100,7 @@ rules:
       - create
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: ingress-controller
@@ -114,7 +116,7 @@ subjects:
     kind: User
     name: ingress-controller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ingress-controller

--- a/examples/auth/oauth/README.md
+++ b/examples/auth/oauth/README.md
@@ -62,7 +62,7 @@ After editing, create the oauth2-proxy deployment and service:
 
 ```
 $ kubectl create -f oauth2-proxy.yaml
-deployment.extensions "oauth2-proxy" created
+deployment.apps "oauth2-proxy" created
 service "oauth2-proxy" exposed
 ```
 
@@ -93,7 +93,7 @@ After editing, create the ingress resource:
 
 ```
 $ kubectl create -f app.yaml
-ingress.extensions "app" created
+ingress.networking.k8s.io/app created
 ```
 
 Fire a request to your domain and an optional `/uri`. Your OAuth2

--- a/examples/auth/oauth/app.yaml
+++ b/examples/auth/oauth/app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/examples/blue-green/README.md
+++ b/examples/blue-green/README.md
@@ -73,7 +73,7 @@ Configure the ingress resource. No need to change the host below, `bluegreen.exa
 
 ```
 $ kubectl create -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -107,7 +107,7 @@ From now the optional web app should be deployed. Deploy an ingress resource to 
 
 ```console
 $ kubectl --namespace=ingress-controller create -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: app

--- a/examples/deployment/haproxy-ingress.yaml
+++ b/examples/deployment/haproxy-ingress.yaml
@@ -1,5 +1,5 @@
 # see https://kubernetes.io/docs/reference/workloads-18-19
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/examples/modsecurity/README.md
+++ b/examples/modsecurity/README.md
@@ -80,7 +80,7 @@ No need to use a valid domain, `echo.domain` below is fine:
 
 ```console
 $ kubectl create -f - <<EOF
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   annotations:

--- a/examples/multi-tls/ingress-multi-tls.yaml
+++ b/examples/multi-tls/ingress-multi-tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: app

--- a/examples/rbac/ingress-controller-rbac.yml
+++ b/examples/rbac/ingress-controller-rbac.yml
@@ -10,7 +10,7 @@ metadata:
   name: ingress-controller
   namespace: ingress-controller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: ingress-controller
@@ -62,7 +62,7 @@ rules:
     verbs:
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: ingress-controller
@@ -99,7 +99,7 @@ rules:
       - create
       - update
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: ingress-controller
@@ -115,7 +115,7 @@ subjects:
     kind: User
     name: ingress-controller
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: ingress-controller

--- a/examples/tls-termination/ingress-tls-default.yaml
+++ b/examples/tls-termination/ingress-tls-default.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: app

--- a/examples/tls-termination/ingress-tls-foobar.yaml
+++ b/examples/tls-termination/ingress-tls-foobar.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: app

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -38,7 +38,7 @@ import (
 // NewCtrlIntf is a temporary interface used by this generic and now
 // deprecated controller to call functionality moved to the new controller.
 type NewCtrlIntf interface {
-	GetIngressList() ([]*extensions.Ingress, error)
+	GetIngressList() ([]*networking.Ingress, error)
 	GetSecret(name string) (*apiv1.Secret, error)
 	Notify()
 }
@@ -128,7 +128,7 @@ func newIngressController(config *Configuration) *GenericController {
 const IngressClassKey = "kubernetes.io/ingress.class"
 
 // IsValidClass ...
-func (ic *GenericController) IsValidClass(ing *extensions.Ingress) bool {
+func (ic *GenericController) IsValidClass(ing *networking.Ingress) bool {
 	ann, found := ing.Annotations[IngressClassKey]
 
 	if ic.cfg.IgnoreIngressWithoutClass {

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -234,7 +234,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 	}
 
 	if *watchNamespace != "" {
-		_, err = kubeClient.ExtensionsV1beta1().Ingresses(*watchNamespace).List(metav1.ListOptions{Limit: 1})
+		_, err = kubeClient.NetworkingV1beta1().Ingresses(*watchNamespace).List(metav1.ListOptions{Limit: 1})
 		if err != nil {
 			glog.Fatalf("no watchNamespace with name %v found: %v", *watchNamespace, err)
 		}

--- a/pkg/common/ingress/controller/status.go
+++ b/pkg/common/ingress/controller/status.go
@@ -30,7 +30,7 @@ import (
 
 	pool "gopkg.in/go-playground/pool.v3"
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -310,11 +310,11 @@ func (s *statusSync) updateStatus(newIngressPoint []apiv1.LoadBalancerIngress) e
 			continue
 		}
 
-		var callback func(*extensions.Ingress) []apiv1.LoadBalancerIngress
+		var callback func(*networking.Ingress) []apiv1.LoadBalancerIngress
 		if s.ic.cfg.Backend != nil {
 			callback = s.ic.cfg.Backend.UpdateIngressStatus
 		} else {
-			callback = func(*extensions.Ingress) []apiv1.LoadBalancerIngress { return nil }
+			callback = func(*networking.Ingress) []apiv1.LoadBalancerIngress { return nil }
 		}
 		batch.Queue(runUpdate(ing, newIngressPoint, s.ic.cfg.Client, callback))
 	}
@@ -325,9 +325,9 @@ func (s *statusSync) updateStatus(newIngressPoint []apiv1.LoadBalancerIngress) e
 	return nil
 }
 
-func runUpdate(ing *extensions.Ingress, status []apiv1.LoadBalancerIngress,
+func runUpdate(ing *networking.Ingress, status []apiv1.LoadBalancerIngress,
 	client clientset.Interface,
-	statusFunc func(*extensions.Ingress) []apiv1.LoadBalancerIngress) pool.WorkFunc {
+	statusFunc func(*networking.Ingress) []apiv1.LoadBalancerIngress) pool.WorkFunc {
 	return func(wu pool.WorkUnit) (interface{}, error) {
 		if wu.IsCancelled() {
 			return nil, nil
@@ -348,7 +348,7 @@ func runUpdate(ing *extensions.Ingress, status []apiv1.LoadBalancerIngress,
 			return true, nil
 		}
 
-		ingClient := client.ExtensionsV1beta1().Ingresses(ing.Namespace)
+		ingClient := client.NetworkingV1beta1().Ingresses(ing.Namespace)
 
 		currIng, err := ingClient.Get(ing.Name, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/pflag"
 	apiv1 "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/apiserver/pkg/server/healthz"
 )
 
@@ -53,7 +53,7 @@ type Controller interface {
 	// UpdateIngressStatus custom callback used to update the status in an Ingress rule
 	// This allows custom implementations
 	// If the function returns nil the standard functions will be executed.
-	UpdateIngressStatus(*extensions.Ingress) []apiv1.LoadBalancerIngress
+	UpdateIngressStatus(*networking.Ingress) []apiv1.LoadBalancerIngress
 }
 
 // BackendInfo returns information about the backend.

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -267,7 +267,7 @@ func (hc *HAProxyController) Notify() {
 
 // GetIngressList ...
 // implements oldcontroller.NewCtrlIntf
-func (hc *HAProxyController) GetIngressList() ([]*extensions.Ingress, error) {
+func (hc *HAProxyController) GetIngressList() ([]*networking.Ingress, error) {
 	return hc.listers.ingressLister.List(labels.Everything())
 }
 
@@ -316,7 +316,7 @@ func (hc *HAProxyController) UpdateConfigMap(cm *api.ConfigMap) {
 
 // IsValidClass ...
 // implements ListerEvents
-func (hc *HAProxyController) IsValidClass(ing *extensions.Ingress) bool {
+func (hc *HAProxyController) IsValidClass(ing *networking.Ingress) bool {
 	return hc.controller.IsValidClass(ing)
 }
 
@@ -337,7 +337,7 @@ func (hc *HAProxyController) Check(_ *http.Request) error {
 
 // UpdateIngressStatus custom callback used to update the status in an Ingress rule
 // If the function returns nil the standard functions will be executed.
-func (hc *HAProxyController) UpdateIngressStatus(*extensions.Ingress) []api.LoadBalancerIngress {
+func (hc *HAProxyController) UpdateIngressStatus(*networking.Ingress) []api.LoadBalancerIngress {
 	return nil
 }
 
@@ -381,7 +381,7 @@ func (hc *HAProxyController) syncIngress(item interface{}) {
 	hc.updateCount++
 	hc.logger.Info("starting HAProxy update id=%d", hc.updateCount)
 	timer := utils.NewTimer(hc.metrics.ControllerProcTime)
-	var ingress []*extensions.Ingress
+	var ingress []*networking.Ingress
 	il, err := hc.listers.ingressLister.List(labels.Everything())
 	if err != nil {
 		hc.logger.Error("error reading ingress list: %v", err)

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/annotations"
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
@@ -35,7 +35,7 @@ import (
 
 // Config ...
 type Config interface {
-	Sync(ingress []*extensions.Ingress)
+	Sync(ingress []*networking.Ingress)
 }
 
 // NewIngressConverter ...
@@ -81,14 +81,14 @@ type converter struct {
 	backendAnnotations map[*hatypes.Backend]*annotations.Mapper
 }
 
-func (c *converter) Sync(ingress []*extensions.Ingress) {
+func (c *converter) Sync(ingress []*networking.Ingress) {
 	for _, ing := range ingress {
 		c.syncIngress(ing)
 	}
 	c.syncAnnotations()
 }
 
-func (c *converter) syncIngress(ing *extensions.Ingress) {
+func (c *converter) syncIngress(ing *networking.Ingress) {
 	fullIngName := fmt.Sprintf("%s/%s", ing.Namespace, ing.Name)
 	source := &annotations.Source{
 		Namespace: ing.Namespace,
@@ -344,7 +344,7 @@ func (c *converter) readAnnotations(annotations map[string]string) (annHost, ann
 	return annHost, annBack
 }
 
-func readServiceNamePort(backend *extensions.IngressBackend) (string, string) {
+func readServiceNamePort(backend *networking.IngressBackend) (string, string) {
 	serviceName := backend.ServiceName
 	servicePort := backend.ServicePort.String()
 	return serviceName, servicePort

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/kylelemons/godebug/diff"
 	yaml "gopkg.in/yaml.v2"
 	api "k8s.io/api/core/v1"
-	extensions "k8s.io/api/extensions/v1beta1"
+	networking "k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -1127,7 +1127,7 @@ func (c *testConfig) teardown() {
 	c.logger.CompareLogging("")
 }
 
-func (c *testConfig) Sync(ing ...*extensions.Ingress) {
+func (c *testConfig) Sync(ing ...*networking.Ingress) {
 	c.SyncDef(map[string]string{}, ing...)
 }
 
@@ -1137,7 +1137,7 @@ var defaultBackendConfig = `
   - ip: 172.17.0.99
     port: 8080`
 
-func (c *testConfig) SyncDef(config map[string]string, ing ...*extensions.Ingress) {
+func (c *testConfig) SyncDef(config map[string]string, ing ...*networking.Ingress) {
 	defaultConfig := func() map[string]string {
 		return map[string]string{
 			ingtypes.BackInitialWeight: "100",
@@ -1212,11 +1212,11 @@ func (c *testConfig) createSecretTLS1(secretName string) {
 	c.cache.SecretTLSPath[secretName] = "/tls/" + secretName + ".pem"
 }
 
-func (c *testConfig) createIng1(name, hostname, path, service string) *extensions.Ingress {
+func (c *testConfig) createIng1(name, hostname, path, service string) *networking.Ingress {
 	sname := strings.Split(name, "/")
 	sservice := strings.Split(service, ":")
 	return c.createObject(`
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: ` + sname[1] + `
@@ -1229,20 +1229,20 @@ spec:
       - path: ` + path + `
         backend:
           serviceName: ` + sservice[0] + `
-          servicePort: ` + sservice[1]).(*extensions.Ingress)
+          servicePort: ` + sservice[1]).(*networking.Ingress)
 }
 
-func (c *testConfig) createIng1Ann(name, hostname, path, service string, ann map[string]string) *extensions.Ingress {
+func (c *testConfig) createIng1Ann(name, hostname, path, service string, ann map[string]string) *networking.Ingress {
 	ing := c.createIng1(name, hostname, path, service)
 	ing.SetAnnotations(ann)
 	return ing
 }
 
-func (c *testConfig) createIng2(name, service string) *extensions.Ingress {
+func (c *testConfig) createIng2(name, service string) *networking.Ingress {
 	sname := strings.Split(name, "/")
 	sservice := strings.Split(service, ":")
 	return c.createObject(`
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: ` + sname[1] + `
@@ -1250,24 +1250,24 @@ metadata:
 spec:
   backend:
     serviceName: ` + sservice[0] + `
-    servicePort: ` + sservice[1]).(*extensions.Ingress)
+    servicePort: ` + sservice[1]).(*networking.Ingress)
 }
 
-func (c *testConfig) createIng3(name string) *extensions.Ingress {
+func (c *testConfig) createIng3(name string) *networking.Ingress {
 	sname := strings.Split(name, "/")
 	return c.createObject(`
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: ` + sname[1] + `
   namespace: ` + sname[0] + `
 spec:
   rules:
-  - http:`).(*extensions.Ingress)
+  - http:`).(*networking.Ingress)
 }
 
-func (c *testConfig) createIngTLS1(name, hostname, path, service, secretHostName string) *extensions.Ingress {
-	tls := []extensions.IngressTLS{}
+func (c *testConfig) createIngTLS1(name, hostname, path, service, secretHostName string) *networking.Ingress {
+	tls := []networking.IngressTLS{}
 	for _, secret := range strings.Split(secretHostName, ";") {
 		ssecret := strings.Split(secret, ":")
 		hosts := []string{}
@@ -1279,7 +1279,7 @@ func (c *testConfig) createIngTLS1(name, hostname, path, service, secretHostName
 		if len(hosts) == 0 {
 			hosts = []string{hostname}
 		}
-		tls = append(tls, extensions.IngressTLS{
+		tls = append(tls, networking.IngressTLS{
 			Hosts:      hosts,
 			SecretName: ssecret[0],
 		})


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

This PR intends to start using the newer Ingress APIs instead of the deprecated ones. 

Instead of using extensions/v1beta1 it will use the newer networking.k8s.io/v1beta1

Right now I'm changing only the docs, there's a need of decision whether the older API will still be supported (as Ingress NGINX) or be fully deprecated in further versions.

Creating a Ingress resource with networking.k8s.io works fine in the current API and Ingress Controller (tested with v1.17.0) and the extensions/v1beta1 will be fully removed from Kubernetes API in version v1.22

# TODO

* [x] Decide if this PR is going also to change the behavior of Haproxy Ingress to support only the newer API version, otherwise check how to deal with both versions and print a warning to the user.