### PR TITLE
Adds a GH Action to close stale issues

### DIFF
--- a/.github/workflows/closeissues.yaml
+++ b/.github/workflows/closeissues.yaml
@@ -1,0 +1,18 @@
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue got stale and will be closed in 7 days.'
+        stale-issue-label: 'lifecycle/stale'
+        exempt-issue-labels: 'lifecycle/backlog'
+        days-before-stale: 30
+        days-before-close: 7
+


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@gmail.com>

As proposed in #614 this GH Action can close stale issues. The parameters are configurable in the yaml.

This PR needs the creation of a label called "Stale" so the bot can mark stale issues after some inactive time.