### PR TITLE
Host scope tls-alpn and ssl-options

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -211,7 +211,8 @@ The table below describes all supported configuration keys.
 | [`ssl-headers-prefix`](#auth-tls)                    | prefix                                  | Global  | `X-SSL`            |
 | [`ssl-mode-async`](#ssl-engine)                      | [true\|false]                           | Global  | `false`            |
 | [`ssl-options`](#ssl-options)                        | space-separated list                    | Global  | [see description](#ssl-options) |
-| [`ssl-options-backend`](#ssl-options)                | space-separated list                    | Global  | [see description](#ssl-options) |
+| [`ssl-options-backend`](#ssl-options)                | space-separated list                    | Backend | [see description](#ssl-options) |
+| [`ssl-options-host`](#ssl-options)                   | space-separated list                    | Host    | [see description](#ssl-options) |
 | [`ssl-passthrough`](#ssl-passthrough)                | [true\|false]                           | Host    |                    |
 | [`ssl-passthrough-http-port`](#ssl-passthrough)      | backend port                            | Host    |                    |
 | [`ssl-redirect`](#ssl-redirect)                      | [true\|false]                           | Backend | `true`             |
@@ -236,7 +237,7 @@ The table below describes all supported configuration keys.
 | [`timeout-server-fin`](#timeout)                     | time with suffix                        | Backend | `50s`              |
 | [`timeout-stop`](#timeout)                           | time with suffix                        | Global  | no timeout         |
 | [`timeout-tunnel`](#timeout)                         | time with suffix                        | Backend | `1h`               |
-| [`tls-alpn`](#tls-alpn)                              | TLS ALPN advertisement                  | Global  | `h2,http/1.1`      |
+| [`tls-alpn`](#tls-alpn)                              | TLS ALPN advertisement                  | Host    | `h2,http/1.1`      |
 | [`use-chroot`](#security)                            | [true\|false]                           | Global  | `false`            |
 | [`use-cpu-map`](#cpu-map)                            | [true\|false]                           | Global  | `true`             |
 | [`use-forwarded-proto`](#fronting-proxy-port)        | [true\|false]                           | Global  | `true`             |
@@ -1537,18 +1538,20 @@ Reference:
 |-----------------------|-----------|---------|-------|
 | `ssl-options`         | `Global`  |         |       |
 | `ssl-options-backend` | `Backend` |         | v0.9  |
+| `ssl-options-host`    | `Host`    |         | v0.11 |
 
 Define a space-separated list of options on SSL/TLS connections.
 
-* `ssl-options`: Options for frontend connections - HAProxy being the server
-* `ssl-options-backend`: Default options for backend server connections - HAProxy being the client
+* `ssl-options`: Default options for all the TLS frontend connections - HAProxy being the server
+* `ssl-options-backend`: Options for backend server connections - HAProxy being the client
+* `ssl-options-host`: Options for TLS frontend connections - HAProxy being the server. This acts as a host scoped override to options defined in `ssl-options` and supports everything that HAProxy supports in the `crt-list`.
 
-Default values:
+Default values for `ssl-options` and `ssl-options-backend`:
 
 * v0.9 and newer: `no-sslv3 no-tlsv10 no-tlsv11 no-tls-tickets`
 * up to v0.8: `no-sslv3 no-tls-tickets`
 
-Supported options:
+Supported options for `ssl-options` and `ssl-options-backend`:
 
 * `force-sslv3`: Enforces use of SSLv3 only
 * `force-tlsv10`: Enforces use of TLSv1.0 only
@@ -1560,12 +1563,16 @@ Supported options:
 * `no-tlsv11`: Disables support for TLSv1.1
 * `no-tlsv12`: Disables support for TLSv1.2
 
-New supported options since v0.9:
+New supported options since v0.9 for `ssl-options` and `ssl-options-backend`:
 
 * `force-tlsv13`: Enforces use of TLSv1.3 only
 * `no-tlsv13`: Disables support for TLSv1.3
 * `ssl-max-ver <SSLv3|TLSv1.0|TLSv1.1|TLSv1.2|TLSv1.3>`: Enforces the use of a SSL/TLS version or lower
 * `ssl-min-ver <SSLv3|TLSv1.0|TLSv1.1|TLSv1.2|TLSv1.3>`: Enforces the use of a SSL/TLS version or upper
+
+See also:
+
+* https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#5.1-crt-list
 
 ---
 
@@ -1733,10 +1740,12 @@ See also:
 
 | Configuration key | Scope    | Default       | Since |
 |-------------------|----------|---------------|-------|
-| `tls-alpn`        | `Global` | `h2,http/1.1` | v0.8  |
+| `tls-alpn`        | `Host`   | `h2,http/1.1` | v0.8  |
 
 Defines the TLS ALPN extension advertisement. The default value is `h2,http/1.1` which enables
 HTTP/2 on the client side.
+
+`tls-alpn` was `Global` scope up to v0.10.
 
 See also:
 

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -741,9 +741,7 @@ func (c *updater) buildBackendSSL(d *backData) {
 	if cfg := d.mapper.Get(ingtypes.BackSSLCipherSuitesBackend); cfg.Source != nil {
 		d.backend.Server.CipherSuites = cfg.Value
 	}
-	if cfg := d.mapper.Get(ingtypes.BackSSLOptionsBackend); cfg.Source != nil {
-		d.backend.Server.Options = cfg.Value
-	}
+	d.backend.Server.Options = d.mapper.Get(ingtypes.BackSSLOptionsBackend).Value
 }
 
 func (c *updater) buildBackendSSLRedirect(d *backData) {

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -181,12 +181,11 @@ func (c *updater) buildGlobalTimeout(d *globalData) {
 
 func (c *updater) buildGlobalSSL(d *globalData) {
 	ssl := &d.global.SSL
+	ssl.ALPN = d.mapper.Get(ingtypes.HostTLSALPN).Value
 	ssl.Ciphers = d.mapper.Get(ingtypes.HostSSLCiphers).Value
 	ssl.CipherSuites = d.mapper.Get(ingtypes.HostSSLCipherSuites).Value
-	ssl.Options = d.mapper.Get(ingtypes.GlobalSSLOptions).Value
 	ssl.BackendCiphers = d.mapper.Get(ingtypes.BackSSLCiphersBackend).Value
 	ssl.BackendCipherSuites = d.mapper.Get(ingtypes.BackSSLCipherSuitesBackend).Value
-	ssl.BackendOptions = d.mapper.Get(ingtypes.BackSSLOptionsBackend).Value
 	if sslDHParam := d.mapper.Get(ingtypes.GlobalSSLDHParam).Value; sslDHParam != "" {
 		if dhFile, err := c.cache.GetDHSecretPath("", sslDHParam); err == nil {
 			ssl.DHParam.Filename = dhFile.Filename
@@ -196,8 +195,10 @@ func (c *updater) buildGlobalSSL(d *globalData) {
 	}
 	ssl.DHParam.DefaultMaxSize = d.mapper.Get(ingtypes.GlobalSSLDHDefaultMaxSize).Int()
 	ssl.Engine = d.mapper.Get(ingtypes.GlobalSSLEngine).Value
-	ssl.ModeAsync = d.mapper.Get(ingtypes.GlobalSSLModeAsync).Bool()
 	ssl.HeadersPrefix = d.mapper.Get(ingtypes.GlobalSSLHeadersPrefix).Value
+	ssl.ModeAsync = d.mapper.Get(ingtypes.GlobalSSLModeAsync).Bool()
+	ssl.Options = d.mapper.Get(ingtypes.GlobalSSLOptions).Value
+	ssl.RedirectCode = d.mapper.Get(ingtypes.GlobalSSLRedirectCode).Int()
 }
 
 func (c *updater) buildGlobalHTTPStoHTTP(d *globalData) {

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -105,4 +105,8 @@ func (c *updater) buildHostTLSConfig(d *hostData) {
 	if cfg := d.mapper.Get(ingtypes.HostSSLCipherSuites); cfg.Source != nil {
 		d.host.TLS.CipherSuites = cfg.Value
 	}
+	if cfg := d.mapper.Get(ingtypes.HostTLSALPN); cfg.Source != nil {
+		d.host.TLS.ALPN = cfg.Value
+	}
+	d.host.TLS.Options = d.mapper.Get(ingtypes.HostSSLOptionsHost).Value
 }

--- a/pkg/converters/ingress/annotations/host_test.go
+++ b/pkg/converters/ingress/annotations/host_test.go
@@ -158,6 +158,46 @@ func TestTLSConfig(t *testing.T) {
 				CipherSuites: "some-cipher-suite-2:some-cipher-suite-3",
 			},
 		},
+		// 14
+		{
+			annDefault: map[string]string{
+				ingtypes.HostTLSALPN: "h2,http/1.1",
+			},
+			expected: hatypes.HostTLSConfig{},
+		},
+		// 15
+		{
+			annDefault: map[string]string{
+				ingtypes.HostTLSALPN: "h2,http/1.1",
+			},
+			ann: map[string]string{
+				ingtypes.HostTLSALPN: "h2",
+			},
+			expected: hatypes.HostTLSConfig{
+				ALPN: "h2",
+			},
+		},
+		// 16
+		{
+			annDefault: map[string]string{
+				ingtypes.HostSSLOptionsHost: "ssl-min-ver TLSv1.2",
+			},
+			expected: hatypes.HostTLSConfig{
+				Options: "ssl-min-ver TLSv1.2",
+			},
+		},
+		// 17
+		{
+			annDefault: map[string]string{
+				ingtypes.HostSSLOptionsHost: "ssl-min-ver TLSv1.2",
+			},
+			ann: map[string]string{
+				ingtypes.HostSSLOptionsHost: "ssl-min-ver TLSv1.0 ssl-max-ver TLSv1.2",
+			},
+			expected: hatypes.HostTLSConfig{
+				Options: "ssl-min-ver TLSv1.0 ssl-max-ver TLSv1.2",
+			},
+		},
 	}
 	source := &Source{Namespace: "system", Name: "ing1", Type: "ingress"}
 	for i, test := range testCases {

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -112,8 +112,6 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.DrainSupport.Redispatch = mapper.Get(ingtypes.GlobalDrainSupportRedispatch).Bool()
 	d.global.Cookie.Key = mapper.Get(ingtypes.GlobalCookieKey).Value
 	d.global.LoadServerState = mapper.Get(ingtypes.GlobalLoadServerState).Bool()
-	d.global.SSL.ALPN = mapper.Get(ingtypes.GlobalTLSALPN).Value
-	d.global.SSL.RedirectCode = mapper.Get(ingtypes.GlobalSSLRedirectCode).Int()
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseChroot = mapper.Get(ingtypes.GlobalUseChroot).Bool()
 	d.global.UseHAProxyUser = mapper.Get(ingtypes.GlobalUseHAProxyUser).Bool()

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -33,6 +33,8 @@ func createDefaults() map[string]string {
 		types.HostAuthTLSStrict:   "false",
 		types.HostSSLCiphers:      defaultSSLCiphers,
 		types.HostSSLCipherSuites: defaultSSLCipherSuites,
+		types.HostSSLOptionsHost:  "",
+		types.HostTLSALPN:         "h2,http/1.1",
 		//
 		types.BackBackendServerNaming:    "sequence",
 		types.BackBackendServerSlotsInc:  "1",
@@ -94,7 +96,6 @@ func createDefaults() map[string]string {
 		types.GlobalTimeoutClient:                "50s",
 		types.GlobalTimeoutClientFin:             "50s",
 		types.GlobalTimeoutStop:                  "10m",
-		types.GlobalTLSALPN:                      "h2,http/1.1",
 		types.GlobalUseCpuMap:                    "true",
 		types.GlobalUseForwardedProto:            "true",
 		types.GlobalUseHTX:                       "true",

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -28,8 +28,10 @@ const (
 	HostServerAliasRegex       = "server-alias-regex"
 	HostSSLCiphers             = "ssl-ciphers"
 	HostSSLCipherSuites        = "ssl-cipher-suites"
+	HostSSLOptionsHost         = "ssl-options-host"
 	HostSSLPassthrough         = "ssl-passthrough"
 	HostSSLPassthroughHTTPPort = "ssl-passthrough-http-port"
+	HostTLSALPN                = "tls-alpn"
 	HostVarNamespace           = "var-namespace"
 )
 
@@ -46,8 +48,10 @@ var (
 		HostServerAliasRegex:       {},
 		HostSSLCiphers:             {},
 		HostSSLCipherSuites:        {},
+		HostSSLOptionsHost:         {},
 		HostSSLPassthrough:         {},
 		HostSSLPassthroughHTTPPort: {},
+		HostTLSALPN:                {},
 		HostVarNamespace:           {},
 	}
 )

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -85,7 +85,6 @@ const (
 	GlobalTimeoutClient                = "timeout-client"
 	GlobalTimeoutClientFin             = "timeout-client-fin"
 	GlobalTimeoutStop                  = "timeout-stop"
-	GlobalTLSALPN                      = "tls-alpn"
 	GlobalUseChroot                    = "use-chroot"
 	GlobalUseCpuMap                    = "use-cpu-map"
 	GlobalUseForwardedProto            = "use-forwarded-proto"

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -258,13 +258,21 @@ func (c *config) WriteFrontendMaps() error {
 		if crtFile == "" {
 			crtFile = c.frontend.DefaultCert
 		}
-		if crtFile != c.frontend.DefaultCert || tls.CAFilename != "" || tls.Ciphers != "" || tls.CipherSuites != "" {
-			// has custom cert, tls auth, ciphers or ciphersuites
+		if crtFile != c.frontend.DefaultCert ||
+			tls.ALPN != "" ||
+			tls.CAFilename != "" ||
+			tls.Ciphers != "" ||
+			tls.CipherSuites != "" ||
+			tls.Options != "" {
+			// has custom tls config
 			//
 			// TODO optimization: distinct hostnames that shares crt, ca and crl
 			// can be combined into a single line. Note that this is usually the exception.
 			// TODO this NEED its own template file.
 			var bindConf = make([]string, 0, 20)
+			if tls.ALPN != "" {
+				bindConf = append(bindConf, "alpn", tls.ALPN)
+			}
 			if tls.CAFilename != "" {
 				bindConf = append(bindConf, "ca-file", tls.CAFilename, "verify", "optional")
 				if tls.CRLFilename != "" {
@@ -276,6 +284,9 @@ func (c *config) WriteFrontendMaps() error {
 			}
 			if tls.CipherSuites != "" {
 				bindConf = append(bindConf, "ciphersuites", tls.CipherSuites)
+			}
+			if tls.Options != "" {
+				bindConf = append(bindConf, tls.Options)
 			}
 
 			var crtListEntry string

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -121,7 +121,6 @@ type SSLConfig struct {
 	ALPN                string
 	BackendCiphers      string
 	BackendCipherSuites string
-	BackendOptions      string
 	Ciphers             string // TLS up to 1.2
 	CipherSuites        string // TLS 1.3
 	DHParam             DHParamConfig
@@ -352,6 +351,7 @@ type HostAliasConfig struct {
 
 // HostTLSConfig ...
 type HostTLSConfig struct {
+	ALPN             string
 	CAErrorPage      string
 	CAFilename       string
 	CAHash           string
@@ -360,6 +360,7 @@ type HostTLSConfig struct {
 	CipherSuites     string
 	CRLFilename      string
 	CRLHash          string
+	Options          string
 	TLSCommonName    string
 	TLSFilename      string
 	TLSHash          string

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -119,9 +119,6 @@ global
 {{- if $global.SSL.BackendCipherSuites }}
     ssl-default-server-ciphersuites {{ $global.SSL.BackendCipherSuites }}
 {{- end }}
-{{- if $global.SSL.BackendOptions }}
-    ssl-default-server-options {{ $global.SSL.BackendOptions }}
-{{- end }}
 {{- range $snippet := $global.CustomConfig }}
     {{ $snippet }}
 {{- end }}


### PR DESCRIPTION
This is a second PR to close #573. I'm not entirely happy with the documentation of ssl-options, but this is the best I could come up with for now. Also I think it would make sense to deprecate/remove the no-tls* and force-tls* options in favor of ssl-min-ver and ssl-max-ver.