### PR TITLE
add disable-pod-list command-line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -23,6 +23,7 @@ The following command-line options are supported:
 | [`--buckets-response-time`](#buckets-response-time)     | float64 slice           | `.0005,.001,.002,.005,.01` | v0.10 |
 | [`--default-backend-service`](#default-backend-service) | namespace/servicename      | haproxy's 404 page      |       |
 | [`--default-ssl-certificate`](#default-ssl-certificate) | namespace/secretname       | fake, auto generated    |       |
+| [`--disable-pod-list`](#disable-pod-list)               | [true\|false]              | `false`                 | v0.11 |
 | [`--healthz-port`](#stats)                              | port number                | `10254`                 |       |
 | [`--ignore-ingress-without-class`](#ignore-ingress-without-class)| [true\|false]     | `false`                 | v0.10 |
 | [`--ingress-class`](#ingress-class)                     | name                       | `haproxy`               |       |
@@ -104,6 +105,14 @@ resources using TLS configuration doesn't provide it's own certificate.
 
 This is a mandatory argument used in the [deployment](https://github.com/jcmoraisjr/haproxy-ingress/tree/master/examples/deployment) and
 [TLS termination](https://github.com/jcmoraisjr/haproxy-ingress/tree/master/examples/tls-termination) example pages.
+
+---
+
+## --disable-pod-list
+
+Since v0.11
+
+Disables in memory pod list and also pod watch for changes. Pod list and watch is used by `drain-support` option, which will not work if pod list is disabled. Blue/green also uses pod list if enabled, otherwise k8s api is called if needed. The default value is `false`, which means pods will be watched and listed in memory.
 
 ---
 

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -634,6 +634,11 @@ balance - or a group selection based on http header or cookie value - blue/green
 Both blue/green configurations can be used together: if the http header or cookie isn't provided
 or doesn't match a group, the blue/green balance will be used.
 
+Blue/green reads endpoint weight from the pod lister. However the `--disable-pod-list`
+command-line option can be safely used to save some memory on clusters with a huge amount of
+pods. If pod list is disabled, pods are read straight from the k8s api, only when needed,
+without changing blue/green behavior.
+
 See below the description of the two blue/green configuration options.
 
 **Blue/green balance**
@@ -701,6 +706,7 @@ uses the chosen load balance algorithm.
 See also:
 
 * [example]({{% relref "../examples/blue-green" %}}) page.
+* [disable-pod-list]({{% relref "command-line/#disable-pod-list" %}}) command-line option doc.
 * https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#5.2-weight (`weight` based balance)
 * https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#4-use-server (`use-server` based selector)
 
@@ -877,6 +883,10 @@ are in a not ready or terminating state.
 
 By default, sessions will be redispatched on a failed upstream connection once the target pod is terminated.
 You can control this behavior by setting `drain-support-redispatch` flag to `false` to instead return a 503 failure.
+
+See also:
+
+* [disable-pod-list]({{% relref "command-line/#disable-pod-list" %}}) command-line option doc.
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -68,6 +68,7 @@ type Configuration struct {
 	WaitBeforeShutdown      int
 	AllowCrossNamespace     bool
 	DisableNodeList         bool
+	DisablePodList          bool
 	AnnPrefix               string
 
 	AcmeServer              bool

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -148,6 +148,10 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		disableNodeList = flags.Bool("disable-node-list", false,
 			`Disable querying nodes. If --force-namespace-isolation is true, this should also be set.`)
 
+		disablePodList = flags.Bool("disable-pod-list", false,
+			`Defines if HAProxy Ingress should disable pod watch and in memory list. Pod list is
+		mandatory for drain-support (should not be disabled) and optional for blue/green.`)
+
 		updateStatusOnShutdown = flags.Bool("update-status-on-shutdown", true, `Indicates if the
 		ingress controller should update the Ingress status IP/hostname when the controller
 		is being stopped. Default is true`)
@@ -310,6 +314,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		WaitBeforeShutdown:        *waitBeforeShutdown,
 		AllowCrossNamespace:       *allowCrossNamespace,
 		DisableNodeList:           *disableNodeList,
+		DisablePodList:            *disablePodList,
 		UpdateStatusOnShutdown:    *updateStatusOnShutdown,
 		SortBackends:              *sortBackends,
 		UseNodeInternalIP:         *useNodeInternalIP,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -105,6 +105,7 @@ func (hc *HAProxyController) configController() {
 	hc.cache = createCache(
 		hc.logger, hc.cfg.Client, hc.controller, hc.tracker, hc.ingressQueue,
 		hc.cfg.WatchNamespace, hc.cfg.ForceNamespaceIsolation,
+		hc.cfg.DisablePodList,
 		hc.cfg.ResyncPeriod)
 	var acmeSigner acme.Signer
 	if hc.cfg.AcmeServer {

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -509,7 +509,7 @@ func (c *converter) addEndpoints(svc *api.Service, svcPort *api.ServicePort, bac
 		}
 		pods, err := c.cache.GetTerminatingPods(svc, convtypes.TrackingTarget{Backend: backend.BackendID()})
 		if err != nil {
-			return err
+			return fmt.Errorf("cannot fetch terminating pods on drain-support mode: %v", err)
 		}
 		for _, pod := range pods {
 			targetPort := convutils.FindContainerPort(pod, svcPort)


### PR DESCRIPTION
Pod listing and watching can be an expensive feature on big and noisy clusters. Listing and syncing pods in memory uses memory and watching them gives another reason to trigger the ingress parser.

Currently pod list is used in two features - blue/green and drain-support, and pod watch is only used by drain-support. Drain-support mode need pod list enabled and won't work if it's disabled. Blue/green on the other hand only uses pod listing to avoid bother k8s. If pod list is disabled, blue/green will query pod labels straight to k8s.