### PR TITLE
add backend-shards command-line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -20,6 +20,7 @@ The following command-line options are supported:
 | [`--acme-track-tls-annotation`](#acme)                  | [true\|false]              | `false`                 | v0.9 |
 | [`--allow-cross-namespace`](#allow-cross-namespace)     | [true\|false]              | `false`                 |       |
 | [`--annotation-prefix`](#annotation-prefix)             | prefix without `/`         | `ingress.kubernetes.io` | v0.8  |
+| [`--backend-shards`](#backend-shards)                   | int                        | `0`                     | v0.11 |
 | [`--buckets-response-time`](#buckets-response-time)     | float64 slice           | `.0005,.001,.002,.005,.01` | v0.10 |
 | [`--default-backend-service`](#default-backend-service) | namespace/servicename      | haproxy's 404 page      |       |
 | [`--default-ssl-certificate`](#default-ssl-certificate) | namespace/secretname       | fake, auto generated    |       |
@@ -79,6 +80,16 @@ objects. The default value is `ingress.kubernetes.io` if not declared, which mea
 should be configured with the annotation name `ingress.kubernetes.io/ssl-redirect`. Annotations
 with other prefix are ignored. This allows using HAProxy Ingress with other ingress controllers
 that shares ingress and service objects without conflicting each other.
+
+---
+
+## --backend-shards
+
+Defines how much files should be used to configure the haproxy backends. The default value is
+0 (zero) which uses one single file to configure the whole haproxy process. Values greather than
+0 (zero) splits the backend configuration into separated files. Only files with changed backends
+are parsed and written to disk, reducing io and cpu usage on big clusters - about 1000 or more
+services.
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -94,6 +94,7 @@ type Configuration struct {
 	ElectionID             string
 	UpdateStatusOnShutdown bool
 
+	BackendShards             int
 	SortBackends              bool
 	IgnoreIngressWithoutClass bool
 }

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -152,6 +152,9 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		ingress controller should update the Ingress status IP/hostname when the controller
 		is being stopped. Default is true`)
 
+		backendShards = flags.Int("backend-shards", 0,
+			`Defines how much files should be used to configure the haproxy backends`)
+
 		sortBackends = flags.Bool("sort-backends", false,
 			`Defines if backends and it's endpoints should be sorted`)
 
@@ -311,6 +314,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		AllowCrossNamespace:       *allowCrossNamespace,
 		DisableNodeList:           *disableNodeList,
 		UpdateStatusOnShutdown:    *updateStatusOnShutdown,
+		BackendShards:             *backendShards,
 		SortBackends:              *sortBackends,
 		UseNodeInternalIP:         *useNodeInternalIP,
 		IgnoreIngressWithoutClass: *ignoreIngressWithoutClass,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -120,7 +120,9 @@ func (hc *HAProxyController) configController() {
 	instanceOptions := haproxy.InstanceOptions{
 		HAProxyCmd:        "haproxy",
 		ReloadCmd:         "/haproxy-reload.sh",
-		HAProxyConfigFile: "/etc/haproxy/haproxy.cfg",
+		HAProxyCfgDir:     "/etc/haproxy",
+		HAProxyMapsDir:    "/etc/haproxy/maps",
+		BackendShards:     hc.cfg.BackendShards,
 		AcmeSigner:        acmeSigner,
 		AcmeQueue:         hc.acmeQueue,
 		LeaderElector:     hc.leaderelector,

--- a/pkg/haproxy/config_test.go
+++ b/pkg/haproxy/config_test.go
@@ -65,7 +65,7 @@ func TestClear(t *testing.T) {
 	})
 	c.Hosts().AcquireHost("app.local")
 	c.Backends().AcquireBackend("default", "app", "8080")
-	if c.mapsDir != "/tmp/maps" {
+	if c.options.mapsDir != "/tmp/maps" {
 		t.Error("expected mapsDir == /tmp/maps")
 	}
 	if len(c.Hosts().Items()) != 1 {
@@ -75,7 +75,7 @@ func TestClear(t *testing.T) {
 		t.Error("expected len(backends) == 1")
 	}
 	c.Clear()
-	if c.mapsDir != "/tmp/maps" {
+	if c.options.mapsDir != "/tmp/maps" {
 		t.Error("expected mapsDir == /tmp/maps")
 	}
 	if len(c.Hosts().Items()) != 0 {

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -585,11 +585,10 @@ set server default_app_8080/srv002 weight 1`,
 	}
 	for i, test := range testCases {
 		c := setup(t)
-		instance := c.instance.(*instance)
 		if test.doconfig1 != nil {
 			test.doconfig1(c)
 		}
-		instance.config.Commit()
+		c.instance.config.Commit()
 		backendIDs := []types.BackendID{}
 		for _, backend := range c.config.Backends().Items() {
 			if backend != c.config.Backends().DefaultBackend() {
@@ -601,7 +600,7 @@ set server default_app_8080/srv002 weight 1`,
 			test.doconfig2(c)
 		}
 		var cmd string
-		dynUpdater := instance.newDynUpdater()
+		dynUpdater := c.instance.newDynUpdater()
 		dynUpdater.cmd = func(socket string, observer func(duration time.Duration), command ...string) ([]string, error) {
 			for _, c := range command {
 				cmd = cmd + c + "\n"

--- a/pkg/haproxy/types/backends_test.go
+++ b/pkg/haproxy/types/backends_test.go
@@ -18,8 +18,115 @@ package types
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 	"testing"
 )
+
+func TestBackendCrud(t *testing.T) {
+	testCases := []struct {
+		shardCnt  int
+		add       []string
+		del       []string
+		expected  []string
+		expAdd    []string
+		expDel    []string
+		expShards [][]string
+	}{
+		// 0
+		{},
+		// 1
+		{
+			add:      []string{"default_app_8080"},
+			expected: []string{"default_app_8080"},
+			expAdd:   []string{"default_app_8080"},
+		},
+		// 2
+		{
+			add:    []string{"default_app_8080"},
+			del:    []string{"default_app_8080"},
+			expAdd: []string{"default_app_8080"},
+			expDel: []string{"default_app_8080"},
+		},
+		// 3
+		{
+			add:      []string{"default_app1_8080", "default_app2_8080"},
+			del:      []string{"default_app1_8080"},
+			expected: []string{"default_app2_8080"},
+			expAdd:   []string{"default_app1_8080", "default_app2_8080"},
+			expDel:   []string{"default_app1_8080"},
+		},
+		// 4
+		{
+			shardCnt: 3,
+			add:      []string{"default_app1_8080", "default_app2_8080", "default_app3_8080", "default_app4_8080"},
+			expected: []string{"default_app1_8080", "default_app2_8080", "default_app3_8080", "default_app4_8080"},
+			expAdd:   []string{"default_app1_8080", "default_app2_8080", "default_app3_8080", "default_app4_8080"},
+			expShards: [][]string{
+				{"default_app2_8080"},
+				{"default_app1_8080", "default_app4_8080"},
+				{"default_app3_8080"},
+			},
+		},
+		// 5
+		{
+			shardCnt: 3,
+			add:      []string{"default_app1_8080", "default_app2_8080", "default_app3_8080", "default_app4_8080"},
+			del:      []string{"default_app1_8080", "default_app2_8080"},
+			expected: []string{"default_app3_8080", "default_app4_8080"},
+			expAdd:   []string{"default_app1_8080", "default_app2_8080", "default_app3_8080", "default_app4_8080"},
+			expDel:   []string{"default_app1_8080", "default_app2_8080"},
+			expShards: [][]string{
+				{},
+				{"default_app4_8080"},
+				{"default_app3_8080"},
+			},
+		},
+	}
+	toarray := func(items map[string]*Backend) []string {
+		if len(items) == 0 {
+			return nil
+		}
+		result := make([]string, len(items))
+		var i int
+		for item := range items {
+			result[i] = item
+			i++
+		}
+		sort.Strings(result)
+		return result
+	}
+	for i, test := range testCases {
+		c := setup(t)
+		backends := CreateBackends(test.shardCnt)
+		for _, add := range test.add {
+			p := strings.Split(add, "_")
+			backends.AcquireBackend(p[0], p[1], p[2])
+		}
+		var backendIDs []BackendID
+		for _, del := range test.del {
+			p := strings.Split(del, "_")
+			if b := backends.FindBackend(p[0], p[1], p[2]); b != nil {
+				backendIDs = append(backendIDs, b.BackendID())
+			}
+		}
+		backends.RemoveAll(backendIDs)
+		c.compareObjects("items", i, toarray(backends.items), test.expected)
+		c.compareObjects("itemsAdd", i, toarray(backends.itemsAdd), test.expAdd)
+		c.compareObjects("itemsDel", i, toarray(backends.itemsDel), test.expDel)
+		var shards [][]string
+		for _, shard := range backends.shards {
+			names := []string{}
+			for name := range shard {
+				names = append(names, name)
+			}
+			sort.Strings(names)
+			shards = append(shards, names)
+		}
+		c.compareObjects("shards", i, shards, test.expShards)
+		c.teardown()
+	}
+}
 
 func TestBuildID(t *testing.T) {
 	testCases := []struct {

--- a/pkg/haproxy/types/global_test.go
+++ b/pkg/haproxy/types/global_test.go
@@ -146,3 +146,21 @@ func TestShrink(t *testing.T) {
 		}
 	}
 }
+
+type testConfig struct {
+	t *testing.T
+}
+
+func setup(t *testing.T) *testConfig {
+	return &testConfig{
+		t: t,
+	}
+}
+
+func (c *testConfig) teardown() {}
+
+func (c *testConfig) compareObjects(name string, index int, actual, expected interface{}) {
+	if !reflect.DeepEqual(actual, expected) {
+		c.t.Errorf("%s on %d differs - expected: %v - actual: %v", name, index, expected, actual)
+	}
+}

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -381,6 +381,8 @@ type Backends struct {
 	items, itemsAdd, itemsDel map[string]*Backend
 	//
 	defaultBackend *Backend
+	shards         []map[string]*Backend
+	changedShards  map[int]bool
 }
 
 // BackendID ...
@@ -398,6 +400,7 @@ type Backend struct {
 	//
 	// IMPLEMENT
 	// use BackendID
+	shard     int
 	ID        string
 	Namespace string
 	Name      string

--- a/rootfs/etc/haproxy/template/haproxy.tmpl
+++ b/rootfs/etc/haproxy/template/haproxy.tmpl
@@ -6,12 +6,58 @@
 # #   This file is automatically updated, do not edit
 # #
 #
-{{- $cfg := . }}
-{{- $global := $cfg.Global }}
-{{- $backends := $cfg.Backends }}
-{{- $frontend := $cfg.Frontend }}
-{{- $fmaps := $frontend.Maps }}
-{{- $hosts := $cfg.Hosts }}
+
+{{- /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   *
+   *  TEMPLATE DECLARATIONS
+   *
+   *    1. main cfg
+   *    2. backend shards
+   *
+   */}}
+
+{{- if .Cfg }}
+    {{- $cfg := .Cfg }}
+    {{- $global := $cfg.Global }}
+    {{- $userlists := $cfg.Userlists.BuildSortedItems }}
+    {{- $tcpbackends := $cfg.TCPBackends.BuildSortedItems}}
+    {{- $backends := $cfg.Backends }}
+    {{- $backendItems := $backends.BuildSortedItems }}
+    {{- $frontend := $cfg.Frontend }}
+    {{- $fmaps := $frontend.Maps }}
+    {{- $hosts := $cfg.Hosts }}
+    {{- template "global" map $global }}
+    {{- if $global.DNS.Resolvers }}
+        {{- template "dnresolvers" map $global.DNS.Resolvers }}
+    {{- end }}
+    {{- if $userlists }}
+        {{- template "userlists" map $userlists }}
+    {{- end }}
+    {{- if $tcpbackends }}
+        {{- template "tcpbackends" map $global $tcpbackends }}
+    {{- end }}
+    {{- if $backendItems }}
+        {{- template "backends" map $global $backendItems true }}
+    {{- end }}
+    {{- template "backend-support" map $global $backends }}
+    {{- if $fmaps }}
+        {{- template "frontends" map $global $frontend $hosts $fmaps $backends.DefaultBackend }}
+    {{- end }}
+    {{- template "frontend-support" map $global }}
+{{- else if and .Global .Backends }}
+    {{- $global := .Global }}
+    {{- $backendItems := .Backends }}
+    {{- template "backends" map $global $backendItems false }}
+{{- end }}
+
+{{- /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+   *
+   *  TEMPLATE DEFINITIONS
+   *
+   */}}
+
+{{- define "global" }}
+{{- $global := .p1 }}
 global
     daemon
 {{- if $global.UseHAProxyUser }}
@@ -124,14 +170,17 @@ defaults
 {{- range $snippet := $global.CustomDefaults }}
     {{ $snippet }}
 {{- end }}
+{{- end }}{{/* define "global" */}}
 
-{{- if $global.DNS.Resolvers }}
+
+{{- define "dnresolvers" }}
+{{- $resolvers := .p1 }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
 #     DNS RESOLVERS
 #
-{{- range $resolver := $global.DNS.Resolvers }}
+{{- range $resolver := $resolvers }}
 resolvers {{ $resolver.Name }}
 {{- range $ns := $resolver.Nameservers }}
     nameserver {{ $ns.Name }} {{ $ns.Endpoint }}
@@ -141,10 +190,11 @@ resolvers {{ $resolver.Name }}
     hold valid            {{ $resolver.HoldValid }}
     timeout retry         {{ $resolver.TimeoutRetry }}
 {{- end }}
-{{- end }}
+{{- end }}{{/* define "dnresolvers" */}}
 
-{{- $userlists := $cfg.Userlists.BuildSortedItems }}
-{{- if $userlists }}
+
+{{- define "userlists" }}
+{{- $userlists := .p1 }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -156,10 +206,12 @@ userlist {{ $userlist.Name }}
     user {{ $user.Name }} {{ if not $user.Encrypted }}insecure-{{ end }}password {{ $user.Passwd }}
 {{- end }}
 {{- end }}
-{{- end }}
+{{- end }}{{/* define "userlists" */}}
 
-{{- $tcpbackends := $cfg.TCPBackends.BuildSortedItems}}
-{{- if $tcpbackends }}
+
+{{- define "tcpbackends" }}
+{{- $global := .p1 }}
+{{- $tcpbackends := .p2 }}
 
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -203,11 +255,14 @@ listen _tcp_{{ $backend.Name }}_{{ $backend.Port }}
 {{- end }}
 
 {{- end }}{{/* range TCPBackends */}}
-{{- end }}{{/* if has TCPBackend */}}
+{{- end }}{{/* define "tcpbackends" */}}
 
-{{- $backendItems := $backends.BuildSortedItems }}
-{{- if $backendItems }}
 
+{{- define "backends" }}
+{{- $global := .p1 }}
+{{- $backendItems := .p2 }}
+{{- $shared := .p3 }}
+{{- if $shared }}
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -215,6 +270,7 @@ listen _tcp_{{ $backend.Name }}_{{ $backend.Port }}
 # #   BACKENDS
 # #
 #
+{{- end }}
 {{- range $backend := $backendItems }}
 backend {{ $backend.ID }}
     mode {{ if $backend.ModeTCP }}tcp{{ else }}http{{ end }}
@@ -555,7 +611,7 @@ backend {{ $backend.ID }}
 {{- end }}
 {{- end }}
 
-{{- end }}{{/* if backendItems */}}
+{{- end }}{{/* define "backends" */}}
 
 {{- define "backend" }}
     {{- $backend := .p1 }}
@@ -592,6 +648,11 @@ backend {{ $backend.ID }}
     {{- end }}
 {{- end }}
 
+
+{{- define "backend-support" }}
+{{- $global := .p1 }}
+{{- $backends := .p2 }}
+
 {{- if $global.Acme.Enabled }}
 
   # # # # # # # # # # # # # # # # # # #
@@ -614,7 +675,15 @@ backend _error404
     http-request use-service lua.send-404
 {{- end }}
 
-{{- if $fmaps }}
+{{- end }}{{/* define "backend-support" */}}
+
+
+{{- define "frontends" }}
+{{- $global := .p1 }}
+{{- $frontend := .p2 }}
+{{- $hosts := .p3 }}
+{{- $fmaps := .p4 }}
+{{- $defaultbackend := .p5 }}
 
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -828,7 +897,7 @@ frontend _front_http
     use_backend _acme_challenge if acme-challenge
 {{- end }}
 
-{{- template "defaultbackend" map $cfg }}
+{{- template "defaultbackend" map $hosts $defaultbackend }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -1003,28 +1072,30 @@ frontend {{ $frontend.Name }}
     use_backend %[var(req.snibackend)]
         {{- "" }} if { var(req.snibackend) -m found }
 {{- end }}
-{{- template "defaultbackend" map $cfg }}
+{{- template "defaultbackend" map $hosts $defaultbackend }}
 
-{{- end }}{{/* if $fmaps */}}
+{{- end }}{{/* define "frontends" */}}
 
 {{- /*------------------------------------*/}}
 {{- /*------------------------------------*/}}
 {{- define "defaultbackend" }}
-{{- $cfg := .p1 }}
-{{- $backends := $cfg.Backends }}
-{{- $hosts := $cfg.Hosts }}
+{{- $hosts := .p1 }}
+{{- $defaultbackend := .p2 }}
 {{- if $hosts.DefaultHost }}
 {{- range $path := $hosts.DefaultHost.Paths }}
     use_backend {{ $path.Backend.ID }}
         {{- if ne $path.Path "/" }} if { path_beg {{ $path.Path }} }{{ end }}
 {{- end }}
 {{- end }}
-{{- if $backends.DefaultBackend }}
-    default_backend {{ $backends.DefaultBackend.ID }}
+{{- if $defaultbackend }}
+    default_backend {{ $defaultbackend.ID }}
 {{- else }}
     default_backend _error404
 {{- end }}
 {{- end }}
+
+{{- define "frontend-support" }}
+{{- $global := .p1 }}
 
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -1093,5 +1164,6 @@ backend spoe-modsecurity
 {{- range $i, $endpoint := $global.ModSecurity.Endpoints }}
     server modsec-spoa{{ $i }} {{ $endpoint }}
 {{- end }}
-
 {{- end }}
+
+{{- end }}{{/* define "frontend-support" */}}


### PR DESCRIPTION
Big clusters waste some time and cpu executing the haproxy template every time a configuration changes, even if such configuration is dinamically applied, leaving memory and disk configurations in sync. Most of the time is spent rebuilding all the referenced services, which is converted to haproxy backends.

Splitting the backends into smaller shards give haproxy ingress the ability to only update files that have changes to be applied, reducing io and cpu usage. The shard of a backend is chosen from the hash of its ID, so the same backend will always stay in the same shard provided that the number of shards isn't changed. Updating the number of shards will rebalance the backends.