### PR TITLE
fix cleaning cache of changed objects

### DIFF
--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -653,6 +653,12 @@ func (c *k8scache) SwapChangedObjects() *convtypes.ChangedObjects {
 	c.secretsUpd = nil
 	c.secretsAdd = nil
 	//
+	// Services
+	//
+	c.servicesDel = nil
+	c.servicesUpd = nil
+	c.servicesAdd = nil
+	//
 	// Ingress
 	//
 	c.ingressesDel = nil


### PR DESCRIPTION
A list of changed objects is updated by Notify(), which listen events from informers. On every ingress parsing, this list is processed and cleared, waiting to be populated again on new events. The list of changed services wasn't being cleared, which means that every time any service was created or updated, the same hosts and backends tracked by that service was being synchronised and rewritten to disk every time any watched k8s object changes. Such "leak" would invalidate all the gains of partial parsing and backend-shards on a long running controller.