### PR TITLE
shrink list of changed hosts and backends

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -40,6 +40,7 @@ type Config interface {
 	Backends() *hatypes.Backends
 	Userlists() *hatypes.Userlists
 	Clear()
+	Shrink()
 	Commit()
 }
 
@@ -349,6 +350,11 @@ func (c *config) Userlists() *hatypes.Userlists {
 func (c *config) Clear() {
 	config := createConfig(c.options)
 	*c = *config
+}
+
+func (c *config) Shrink() {
+	c.hosts.Shrink()
+	c.backends.Shrink()
 }
 
 func (c *config) Commit() {

--- a/pkg/haproxy/types/host_test.go
+++ b/pkg/haproxy/types/host_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2020 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+)
+
+func TestShrinkHosts(t *testing.T) {
+	app1 := &Host{Hostname: "app1.localdomain"}
+	app2 := &Host{Hostname: "app2.localdomain"}
+	testCases := []struct {
+		add, del       []*Host
+		expAdd, expDel []*Host
+	}{
+		// 0
+		{},
+		// 1
+		{
+			add:    []*Host{app1},
+			expAdd: []*Host{app1},
+		},
+		// 2
+		{
+			add: []*Host{app1},
+			del: []*Host{app1},
+		},
+		// 3
+		{
+			add:    []*Host{app1, app2},
+			del:    []*Host{app2},
+			expAdd: []*Host{app1},
+		},
+		// 4
+		{
+			add:    []*Host{app1},
+			del:    []*Host{app1, app2},
+			expDel: []*Host{app2},
+		},
+	}
+	for i, test := range testCases {
+		c := setup(t)
+		h := CreateHosts()
+		for _, add := range test.add {
+			h.itemsAdd[add.Hostname] = add
+		}
+		for _, del := range test.del {
+			h.itemsDel[del.Hostname] = del
+		}
+		expAdd := map[string]*Host{}
+		for _, add := range test.expAdd {
+			expAdd[add.Hostname] = add
+		}
+		expDel := map[string]*Host{}
+		for _, del := range test.expDel {
+			expDel[del.Hostname] = del
+		}
+		h.Shrink()
+		c.compareObjects("add", i, h.itemsAdd, expAdd)
+		c.compareObjects("del", i, h.itemsDel, expDel)
+		c.teardown()
+	}
+}


### PR DESCRIPTION
Partial ingress parse does its job tracking hosts and backends that could be impacted by a k8s update. However most of these hosts and backends may have been recreated without a single change, making conditional hosts map rebuild and backend shards configuration less optimized. Shrink consists of compare old and new state, removing hosts and backends without any change from the change tracking just before start resyncing model to disk.