### PR TITLE
Configure default crt on ingress parsing phase

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -142,7 +142,8 @@ func (hc *HAProxyController) configController() {
 		Tracker:          hc.tracker,
 		AnnotationPrefix: hc.cfg.AnnPrefix,
 		DefaultBackend:   hc.cfg.DefaultService,
-		DefaultSSLFile:   hc.createDefaultSSLFile(),
+		DefaultCrtSecret: hc.cfg.DefaultSSLCertificate,
+		FakeCrtFile:      hc.createFakeCrtFile(),
 		FakeCAFile:       hc.createFakeCAFile(),
 		AcmeTrackTLSAnn:  hc.cfg.AcmeTrackTLSAnn,
 	}
@@ -181,25 +182,14 @@ func (hc *HAProxyController) stopServices() {
 	}
 }
 
-func (hc *HAProxyController) createDefaultSSLFile() (tlsFile convtypes.CrtFile) {
-	if hc.cfg.DefaultSSLCertificate != "" {
-		// IMPLEMENT track hosts that uses this secret/crt
-		tlsFile, err := hc.cache.GetTLSSecretPath("", hc.cfg.DefaultSSLCertificate, convtypes.TrackingTarget{})
-		if err == nil {
-			return tlsFile
-		}
-		glog.Warningf("using auto generated fake certificate due to an error reading default TLS certificate: %v", err)
-	} else {
-		glog.Info("using auto generated fake certificate")
-	}
+func (hc *HAProxyController) createFakeCrtFile() (tlsFile convtypes.CrtFile) {
 	path, hash, crt := hc.controller.CreateDefaultSSLCertificate()
-	tlsFile = convtypes.CrtFile{
+	return convtypes.CrtFile{
 		Filename:   path,
 		SHA1Hash:   hash,
 		CommonName: crt.Subject.CommonName,
 		NotAfter:   crt.NotAfter,
 	}
-	return tlsFile
 }
 
 func (hc *HAProxyController) createFakeCAFile() (crtFile convtypes.CrtFile) {

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -19,7 +19,6 @@ package ingress
 import (
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/kylelemons/godebug/diff"
 	yaml "gopkg.in/yaml.v2"
@@ -1461,19 +1460,15 @@ func (c *testConfig) Sync(ing ...*networking.Ingress) {
 			ingtypes.BackInitialWeight: "100",
 		}
 	}
+	c.cache.SecretTLSPath["system/default"] = "/tls/tls-default.pem"
 	conv := NewIngressConverter(
 		&ingtypes.ConverterOptions{
-			Cache:          c.cache,
-			Logger:         c.logger,
-			Tracker:        c.tracker,
-			DefaultConfig:  defaultConfig,
-			DefaultBackend: "system/default",
-			DefaultSSLFile: convtypes.CrtFile{
-				Filename:   "/tls/tls-default.pem",
-				SHA1Hash:   "1",
-				CommonName: "localhost.localdomain",
-				NotAfter:   time.Now().AddDate(0, 0, 30),
-			},
+			Cache:            c.cache,
+			Logger:           c.logger,
+			Tracker:          c.tracker,
+			DefaultConfig:    defaultConfig,
+			DefaultBackend:   "system/default",
+			DefaultCrtSecret: "system/default",
 			AnnotationPrefix: "ingress.kubernetes.io",
 		},
 		c.hconfig,

--- a/pkg/converters/ingress/types/options.go
+++ b/pkg/converters/ingress/types/options.go
@@ -28,7 +28,8 @@ type ConverterOptions struct {
 	Tracker          convtypes.Tracker
 	DefaultConfig    func() map[string]string
 	DefaultBackend   string
-	DefaultSSLFile   convtypes.CrtFile
+	DefaultCrtSecret string
+	FakeCrtFile      convtypes.CrtFile
 	FakeCAFile       convtypes.CrtFile
 	AnnotationPrefix string
 	AcmeTrackTLSAnn  bool

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -165,7 +165,7 @@ func (c *config) WriteFrontendMaps() error {
 		CrtList:       mapBuilder.AddMap(mapsDir + "/_front001_bind_crt.list"),
 		UseServerList: mapBuilder.AddMap(mapsDir + "/_front001_use_server.list"),
 	}
-	fmaps.CrtList.AppendItem(c.frontend.DefaultCert)
+	fmaps.CrtList.AppendItem(c.frontend.DefaultCrtFile)
 	// Some maps use yes/no answers instead of a list with found/missing keys
 	// This approach avoid overlap:
 	//  1. match with path_beg/map_beg, /path has a feature and a declared /path/sub doesn't have
@@ -256,9 +256,9 @@ func (c *config) WriteFrontendMaps() error {
 		tls := host.TLS
 		crtFile := tls.TLSFilename
 		if crtFile == "" {
-			crtFile = c.frontend.DefaultCert
+			crtFile = c.frontend.DefaultCrtFile
 		}
-		if crtFile != c.frontend.DefaultCert ||
+		if crtFile != c.frontend.DefaultCrtFile ||
 			tls.ALPN != "" ||
 			tls.CAFilename != "" ||
 			tls.Ciphers != "" ||

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2938,7 +2938,7 @@ func setupOptions(options testOptions) *testConfig {
 		t.Errorf("error parsing map.tmpl: %v", err)
 	}
 	config := instance.Config().(*config)
-	config.frontend.DefaultCert = "/var/haproxy/ssl/certs/default.pem"
+	config.frontend.DefaultCrtFile = "/var/haproxy/ssl/certs/default.pem"
 	c := &testConfig{
 		t:        t,
 		logger:   logger,

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -292,7 +292,9 @@ type Frontend struct {
 	BindSocket  string
 	BindID      int
 	AcceptProxy bool
-	DefaultCert string
+	//
+	DefaultCrtFile string
+	DefaultCrtHash string
 }
 
 // Hosts ...


### PR DESCRIPTION
Default certificate was being configured during controller startup, which creates a read-only and never-change state. This configuration was moved to the ingress parsing phase, so every new sync will check if a missing secret was created or the secret was changed.