### PR TITLE
Partial build of backend maps

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -316,7 +316,7 @@ func (c *config) WriteBackendMaps() error {
 		return nil
 	}
 	mapBuilder := hatypes.CreateMaps()
-	for _, backend := range c.backends.Items() {
+	for _, backend := range c.backends.ItemsAdd() {
 		if backend.NeedACL() {
 			mapsPrefix := c.options.mapsDir + "/_back_" + backend.ID
 			pathsMap := mapBuilder.AddMap(mapsPrefix + "_idpath.map")


### PR DESCRIPTION
Backend maps don't share state with other backends, so only added/changed backends need to be rebuilt.