### PR TITLE
Improve backend shrinking

### DIFF
--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -94,6 +94,7 @@ func backendsMatch(back1, back2 *Backend) bool {
 		return true
 	}
 	b1copy := *back1
+	b1copy.PathsMap = back2.PathsMap
 	b1copy.Endpoints = back2.Endpoints
 	if !reflect.DeepEqual(&b1copy, back2) {
 		return false


### PR DESCRIPTION
Changed backends behaves as old and new backends with the same name. The list of changed backends can be smaller removing old/new backend pair without changes.

The backend match wasn't taking care of `PathsMap` attribute which is changed and documented in the `config.WriteBackendMaps()`, and runs between two consecutive backend shrink.