### PR TITLE
Add hostname and backend tracking on addIngress

### DIFF
--- a/pkg/converters/ingress/tracker/tracker.go
+++ b/pkg/converters/ingress/tracker/tracker.go
@@ -187,7 +187,7 @@ func validName(name string) {
 //     all ingress that references it should also be listed.
 //
 func (t *tracker) GetDirtyLinks(
-	oldIngressList []string,
+	oldIngressList, addIngressList []string,
 	oldServiceList, addServiceList []string,
 	oldSecretList, addSecretList []string,
 	addPodList []string,
@@ -225,6 +225,7 @@ func (t *tracker) GetDirtyLinks(
 		}
 	}
 	build(oldIngressList)
+	build(addIngressList)
 	//
 	for _, svcName := range oldServiceList {
 		for _, hostname := range t.getHostnamesByService(svcName) {

--- a/pkg/converters/ingress/tracker/tracker_test.go
+++ b/pkg/converters/ingress/tracker/tracker_test.go
@@ -83,6 +83,7 @@ func TestGetDirtyLinks(t *testing.T) {
 		trackedMissingBacks []backTracking
 		//
 		oldIngressList []string
+		addIngressList []string
 		oldServiceList []string
 		addServiceList []string
 		oldSecretList  []string
@@ -303,6 +304,7 @@ func TestGetDirtyLinks(t *testing.T) {
 		dirtyIngs, dirtyHosts, dirtyBacks, dirtyUsers, dirtyStorages :=
 			c.tracker.GetDirtyLinks(
 				test.oldIngressList,
+				test.addIngressList,
 				test.oldServiceList,
 				test.addServiceList,
 				test.oldSecretList,

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -68,7 +68,7 @@ type Tracker interface {
 	TrackBackend(rtype ResourceType, name string, backendID hatypes.BackendID)
 	TrackMissingOnHostname(rtype ResourceType, name, hostname string)
 	TrackStorage(rtype ResourceType, name, storage string)
-	GetDirtyLinks(oldIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers, dirtyStorages []string)
+	GetDirtyLinks(oldIngressList, addIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers, dirtyStorages []string)
 	DeleteHostnames(hostnames []string)
 	DeleteBackends(backends []hatypes.BackendID)
 	DeleteUserlists(userlists []string)


### PR DESCRIPTION
Ingress is the starting point of all object parsing and tracking. This model works well on object changing, adding a missing backend or secret, but once everything starts from ingress objects, AddIngress event wasn't being properly tracked. This commit adds existent hosts and backends as tracked by the new ingress, given the chance to be removed and reincluded during the partial parsing.