### PR TITLE
Improve time of frontend maps build

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -339,7 +339,7 @@ func (c *config) WriteBackendMaps() error {
 func writeMaps(maps *hatypes.HostsMaps, template *template.Config) error {
 	for _, hmap := range maps.Items {
 		if f, err := hmap.Filename(hatypes.MatchEmpty); err == nil {
-			if err := template.WriteOutput(hmap.Values(hatypes.MatchEmpty), f); err != nil {
+			if err := template.WriteOutput(hmap.BuildSortedValues(hatypes.MatchEmpty), f); err != nil {
 				return err
 			}
 		}
@@ -348,7 +348,7 @@ func writeMaps(maps *hatypes.HostsMaps, template *template.Config) error {
 			if err != nil {
 				return err
 			}
-			if err := template.WriteOutput(hmap.Values(match), filename); err != nil {
+			if err := template.WriteOutput(hmap.BuildSortedValues(match), filename); err != nil {
 				return err
 			}
 		}

--- a/pkg/haproxy/types/maps.go
+++ b/pkg/haproxy/types/maps.go
@@ -119,6 +119,11 @@ func (hm *HostsMap) addTarget(hostname, path, target string, match MatchType) {
 	}
 	values := hm.values[match]
 	values = append(values, entry)
+	hm.values[match] = values
+}
+
+func (hm *HostsMap) sortValues(match MatchType) {
+	values := hm.values[match]
 	if match == MatchRegex {
 		// Keep regexes in order from most to least specific, based on rule length
 		sort.Slice(values, func(i, j int) bool {
@@ -206,8 +211,9 @@ func (hm *HostsMap) MatchTypes() []MatchTypeHelper {
 	return helper
 }
 
-// Values ...
-func (hm *HostsMap) Values(match MatchType) []*HostsMapEntry {
+// BuildSortedValues ...
+func (hm *HostsMap) BuildSortedValues(match MatchType) []*HostsMapEntry {
+	hm.sortValues(match)
 	return hm.values[match]
 }
 


### PR DESCRIPTION
Frontend maps building still reads the whole model to update the map files. This was wasting an impressive amount of time sorting the maps on every insert - btw thank you `go tool pprof`. This commit moves the sort from every insert to just before usage. Time to build maps on a 5k domains cluster reduced from about 5000ms to 50ms.