### PR TITLE
Add implicit starting boundary char in regex path match

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -1306,25 +1306,25 @@ See also:
 
 Defines how the path of an incoming request should match a declared path in the ingress object.
 
-* `path-type`: Configures the path type. Case insensitive, so `Begin` and `begin` configures the same path type option. The ingress spec has precedente, this option will only be used if the `pathType` attribute from the ingress spec is declared as `ImplementationSpecific` or is not declared.
+* `path-type`: Configures the path type. Case insensitive, so `Begin` and `begin` configures the same path type option. The ingress spec has priority, this option will only be used if the `pathType` attribute from the ingress spec is declared as `ImplementationSpecific` or is not declared.
 
 Supported `path-type` values:
 
 * `begin`: Case insensitive, matches the beginning of the path from the incoming request. This is the default value if not declared.
 * `exact`: Case sensitive, matches the whole path. Implements the `Exact` path type from the ingress spec.
 * `prefix`: Case sensitive, matches a whole subdirectory from the incoming path. A declared `/app` path matches `/app` and `/app/1` but does not match `/app1`. Implements the `Prefix` path type from the ingress spec.
-* `regex`: Case sensitive, matches the incoming path using POSIX extended regular expression. The regular expression is applied verbatim, so a declared `/app[0-9]+` will match `/app1/sub` and also `/sup/app1/sub`.
+* `regex`: Case sensitive, matches the incoming path using POSIX extended regular expression. The regular expression has an implicit start `^` and no ending `$` boundary, so a declared `/app[0-9]+/?` will match paths starting with this pattern. Add a trailing `$` if an exact match is desired.
 
 Request and match examples:
 
-| Path type | Request         | Match                               | Do not match                       |
-|-----------|-----------------|-------------------------------------|------------------------------------|
-| `exact`   | `/app`          | `/app`                              | `/App` <br/> `/app/` <br/> `/app1` |
-| `prefix`  | `/app`          | `/app` <br/> `/app/` <br/> `/app/1` | `/App` <br/> `/app1`               |
-| `begin`   | `/app`          | `/App` <br/> `/app` <br/> `/app/1` <br/> `/app1` | `/ap`                 |
-| `regex`   | `/app[0-9]+`    | `/app1` <br/> `/sup/app15` <br/> `/app25/sub` | `/App1` <br/> `/app/15`  |
-| `regex`   | `^/app[0-9]+$`  | `/app1` <br/> `/app15`       | `/App1` <br/> `/app15/` <br/> `/sup/app1` |
-| `regex`   | `^/app[0-9]+/?` | `/app1` <br/> `/app15/` <br/> `/app25/sub` | `/App15` <br/> `/app/25sub` |
+| Path type | Request        | Match                               | Do not match                        |
+|-----------|----------------|-------------------------------------|-------------------------------------|
+| `begin`   | `/app`         | `/App` <br/> `/app` <br/> `/app/1` <br/> `/app1` | `/ap`                  |
+| `exact`   | `/app`         | `/app`                              | `/App` <br/> `/app/` <br/> `/app1`  |
+| `prefix`  | `/app`         | `/app` <br/> `/app/` <br/> `/app/1` | `/App` <br/> `/app1`                |
+| `regex`   | `/app[0-9]+`   | `/app1` <br/> `/app15/sub` <br/> `/app25xx/sub` | `/App1` <br/> `/app/15` |
+| `regex`   | `/app[0-9]+$`  | `/app1` <br/> `/app15`              | `/App1` <br/> `/app15/`             |
+| `regex`   | `/app[0-9]+/?` | `/app1` <br/> `/app15/` <br/> `/app25/sub` | `/App15` <br/> `/app/25sub`  |
 
 ---
 

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -295,10 +295,10 @@ d1.local/api path02`,
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
 				h.FindPath("/app").Match = hatypes.MatchExact
 				h.FindPath("/path").Match = hatypes.MatchPrefix
-				h.FindPath("^/api/v[0-9]+/").Match = hatypes.MatchRegex
+				h.FindPath("/api/v[0-9]+/").Match = hatypes.MatchRegex
 				b.WhitelistHTTP = []*hatypes.BackendConfigWhitelist{
 					{
-						Paths:  createBackendPaths(b, "d1.local/app", "d1.local/api", "d1.local/path", "d1.local^/api/v[0-9]+/"),
+						Paths:  createBackendPaths(b, "d1.local/app", "d1.local/api", "d1.local/path", "d1.local/api/v[0-9]+/"),
 						Config: []string{"10.0.0.0/8", "192.168.0.0/16"},
 					},
 					{
@@ -307,19 +307,19 @@ d1.local/api path02`,
 					},
 				}
 			},
-			path: []string{"/", "/app", "/api", "/path", "^/api/v[0-9]+/"},
+			path: []string{"/", "/app", "/api", "/path", "/api/v[0-9]+/"},
 			expected: `
     # path01 = d1.local/
     # path03 = d1.local/api
+    # path05 = d1.local/api/v[0-9]+/
     # path02 = d1.local/app
     # path04 = d1.local/path
-    # path05 = d1.local^/api/v[0-9]+/
     http-request set-var(txn.pathID) var(req.base),map_str(/etc/haproxy/maps/_back_d1_app_8080_idpath__exact.map)
     http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_d1_app_8080_idpath__prefix.map) if !{ var(txn.pathID) -m found }
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map) if !{ var(txn.pathID) -m found }
     http-request set-var(txn.pathID) var(req.base),map_reg(/etc/haproxy/maps/_back_d1_app_8080_idpath__regex.map) if !{ var(txn.pathID) -m found }
     acl wlist_src0 src 10.0.0.0/8 192.168.0.0/16
-    http-request deny if { var(txn.pathID) path03 path02 path04 path05 } !wlist_src0
+    http-request deny if { var(txn.pathID) path03 path05 path02 path04 } !wlist_src0
     acl wlist_src1 src 172.17.0.0/16
     http-request deny if { var(txn.pathID) path01 } !wlist_src1`,
 			expFronts: "<<frontends-default-match-4>>",
@@ -859,7 +859,7 @@ func TestInstanceMatch(t *testing.T) {
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 	h := c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/app", hatypes.MatchPrefix)
-	h.AddPath(b, "^/api/v[0-9]+/", hatypes.MatchRegex)
+	h.AddPath(b, "/api/v[0-9]+/", hatypes.MatchRegex)
 	c.Update()
 
 	c.checkConfig(`

--- a/pkg/haproxy/types/maps_test.go
+++ b/pkg/haproxy/types/maps_test.go
@@ -106,7 +106,7 @@ func TestAddHostnamePathMapping(t *testing.T) {
 		// 3
 		{
 			hostname: "example.local",
-			path:     "^/path",
+			path:     "/path",
 			match:    MatchRegex,
 			expmatch: MatchRegex,
 			expected: "^example\\.local/path",
@@ -114,7 +114,7 @@ func TestAddHostnamePathMapping(t *testing.T) {
 		// 4
 		{
 			hostname: "example.local",
-			path:     "^/path[0-9]$",
+			path:     "/path[0-9]$",
 			match:    MatchRegex,
 			expmatch: MatchRegex,
 			expected: "^example\\.local/path[0-9]$",
@@ -125,12 +125,12 @@ func TestAddHostnamePathMapping(t *testing.T) {
 			path:     "/path/",
 			match:    MatchRegex,
 			expmatch: MatchRegex,
-			expected: "^example\\.local/.*/path/",
+			expected: "^example\\.local/path/",
 		},
 		// 6
 		{
 			hostname: "*.example.local",
-			path:     "^/.*path$",
+			path:     "/.*path$",
 			match:    MatchRegex,
 			expmatch: MatchRegex,
 			expected: "^[^.]+\\.example\\.local/.*path$",


### PR DESCRIPTION
The ingress path validation doesn't allow paths that doesn't start with a slash, so regex paths couldn't match the start of the string. Regex now behaves just like the `begin` match - it has an implicit starting `ˆ` match and no trailing `$`.