### PR TITLE
Fix tracking and partial parsing of spec.backend

### DIFF
--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -150,7 +150,7 @@ func (c *converter) syncDefaultCrt() {
 
 func (c *converter) syncDefaultBackend() {
 	if c.options.DefaultBackend != "" {
-		if backend, err := c.addBackend(&annotations.Source{}, "*", "/", c.options.DefaultBackend, "", map[string]string{}); err == nil {
+		if backend, err := c.addBackend(&annotations.Source{}, hatypes.DefaultHost, "/", c.options.DefaultBackend, "", map[string]string{}); err == nil {
 			c.haproxy.Backends().SetDefaultBackend(backend)
 		} else {
 			c.logger.Error("error reading default service: %v", err)
@@ -364,7 +364,7 @@ func (c *converter) syncIngress(ing *networking.Ingress) {
 		}
 		hostname := rule.Host
 		if hostname == "" {
-			hostname = "*"
+			hostname = hatypes.DefaultHost
 		}
 		host := c.addHost(hostname, source, annHost)
 		for _, path := range rule.HTTP.Paths {
@@ -497,7 +497,7 @@ func (c *converter) readPathType(path networking.HTTPIngressPath, ann string) ha
 }
 
 func (c *converter) addDefaultHostBackend(source *annotations.Source, fullSvcName, svcPort string, annHost, annBack map[string]string) error {
-	hostname := "*"
+	hostname := hatypes.DefaultHost
 	uri := "/"
 	if fr := c.haproxy.Hosts().FindHost(hostname); fr != nil {
 		if fr.FindPath(uri) != nil {

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -728,7 +728,7 @@ func TestSyncBackendDefault(t *testing.T) {
 	c.Sync(c.createIng2("default/echo", "echo:8080"))
 
 	c.compareConfigDefaultFront(`
-hostname: '*'
+hostname: <default>
 paths:
 - path: /
   backend: default_echo_8080`)
@@ -777,15 +777,11 @@ func TestSyncDefaultBackendReusedPath1(t *testing.T) {
 	c.createSvc1("default/echo1", "8080", "172.17.0.11")
 	c.createSvc1("default/echo2", "8080", "172.17.0.12")
 	c.Sync(
-		c.createIng1("default/echo1", "'*'", "/", "echo1:8080"),
+		c.createIng1("default/echo1", hatypes.DefaultHost, "/", "echo1:8080"),
 		c.createIng2("default/echo2", "echo2:8080"),
 	)
 
-	c.compareConfigDefaultFront(`
-hostname: '*'
-paths:
-- path: /
-  backend: default_echo1_8080`)
+	c.compareConfigDefaultFront(defaultDefaultFrontendConfig)
 
 	c.compareConfigBack(`
 - id: default_echo1_8080
@@ -805,14 +801,10 @@ func TestSyncDefaultBackendReusedPath2(t *testing.T) {
 	c.createSvc1("default/echo2", "8080", "172.17.0.12")
 	c.Sync(
 		c.createIng2("default/echo1", "echo1:8080"),
-		c.createIng1("default/echo2", "'*'", "/", "echo2:8080"),
+		c.createIng1("default/echo2", hatypes.DefaultHost, "/", "echo2:8080"),
 	)
 
-	c.compareConfigDefaultFront(`
-hostname: '*'
-paths:
-- path: /
-  backend: default_echo1_8080`)
+	c.compareConfigDefaultFront(defaultDefaultFrontendConfig)
 
 	c.compareConfigBack(`
 - id: default_echo1_8080
@@ -840,7 +832,7 @@ func TestSyncEmptyHost(t *testing.T) {
 	c.Sync(c.createIng1("default/echo", "", "/", "echo:8080"))
 
 	c.compareConfigDefaultFront(`
-hostname: '*'
+hostname: <default>
 paths:
 - path: /
   backend: default_echo_8080`)
@@ -893,12 +885,7 @@ func TestSyncPartial(t *testing.T) {
 	secTLSDefault := [][]string{
 		{"default/tls1"},
 	}
-	expDefaultFrontDefault := `
-hostname: '*'
-paths:
-- path: /
-  backend: default_echo1_8080
-`
+	expDefaultFrontDefault := defaultDefaultFrontendConfig
 	expFrontDefault := `
 - hostname: echo.example.com
   paths:
@@ -1722,6 +1709,12 @@ func setup(t *testing.T) *testConfig {
 func (c *testConfig) teardown() {
 	c.logger.CompareLogging("")
 }
+
+var defaultDefaultFrontendConfig = `
+hostname: ` + hatypes.DefaultHost + `
+paths:
+- path: /
+  backend: default_echo1_8080`
 
 var defaultBackendConfig = `
 - id: _default_backend

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1390,7 +1390,7 @@ func TestInstanceDefaultHost(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
-	h = c.config.Hosts().AcquireHost("*")
+	h = c.config.Hosts().AcquireHost(hatypes.DefaultHost)
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
@@ -1513,7 +1513,7 @@ func TestInstanceStrictHostDefaultHost(t *testing.T) {
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h = c.config.Hosts().AcquireHost("*")
+	h = c.config.Hosts().AcquireHost(hatypes.DefaultHost)
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	c.config.Global().StrictHost = true

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -45,20 +45,13 @@ func (h *Hosts) AcquireHost(hostname string) *Host {
 		return host
 	}
 	host := h.createHost(hostname)
-	if host.Hostname != "*" {
-		h.items[hostname] = host
-		h.itemsAdd[hostname] = host
-	} else {
-		h.defaultHost = host
-	}
+	h.items[hostname] = host
+	h.itemsAdd[hostname] = host
 	return host
 }
 
 // FindHost ...
 func (h *Hosts) FindHost(hostname string) *Host {
-	if hostname == "*" && h.defaultHost != nil {
-		return h.defaultHost
-	}
 	return h.items[hostname]
 }
 
@@ -109,10 +102,13 @@ func (h *Hosts) createHost(hostname string) *Host {
 func (h *Hosts) BuildSortedItems() []*Host {
 	items := make([]*Host, len(h.items))
 	var i int
-	for _, item := range h.items {
-		items[i] = item
-		i++
+	for hostname, item := range h.items {
+		if hostname != "*" {
+			items[i] = item
+			i++
+		}
 	}
+	items = items[:i]
 	sort.Slice(items, func(i, j int) bool {
 		return items[i].Hostname < items[j].Hostname
 	})
@@ -139,7 +135,7 @@ func (h *Hosts) ItemsDel() map[string]*Host {
 
 // DefaultHost ...
 func (h *Hosts) DefaultHost() *Host {
-	return h.defaultHost
+	return h.items["*"]
 }
 
 // HasSSLPassthrough ...

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -103,7 +103,7 @@ func (h *Hosts) BuildSortedItems() []*Host {
 	items := make([]*Host, len(h.items))
 	var i int
 	for hostname, item := range h.items {
-		if hostname != "*" {
+		if hostname != DefaultHost {
 			items[i] = item
 			i++
 		}
@@ -135,7 +135,7 @@ func (h *Hosts) ItemsDel() map[string]*Host {
 
 // DefaultHost ...
 func (h *Hosts) DefaultHost() *Host {
-	return h.items["*"]
+	return h.items[DefaultHost]
 }
 
 // HasSSLPassthrough ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -298,6 +298,9 @@ type Frontend struct {
 	DefaultCrtHash string
 }
 
+// DefaultHost ...
+const DefaultHost = "<default>"
+
 // Hosts ...
 type Hosts struct {
 	items, itemsAdd, itemsDel map[string]*Host

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -302,8 +302,6 @@ type Frontend struct {
 type Hosts struct {
 	items, itemsAdd, itemsDel map[string]*Host
 	//
-	defaultHost *Host
-	//
 	sslPassthroughCount int
 }
 


### PR DESCRIPTION
Most of the tracking stuff was missing on Ingress.Spec.Backend, resulting in an inconsistent state and sometimes a broken config. Hosts.defaultHost pointer was also removed, now the default `*` host is part of the Hosts.items map and inherits all the Hosts' partial parsing implementation, eg RemoveAll, ItemsAdd and Shrink.