### PR TITLE
Add wait-before-update command-line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -39,6 +39,7 @@ The following command-line options are supported:
 | [`--tcp-services-configmap`](#tcp-services-configmap)   | namespace/configmapname    | no tcp svc              |       |
 | [`--verify-hostname`](#verify-hostname)                 | [true\|false]              | `true`                  |       |
 | [`--wait-before-shutdown`](#wait-before-shutdown)       | seconds as integer         | `0`                     | v0.8  |
+| [`--wait-before-update`](#wait-before-update)           | duration                   | `200ms`                 | v0.11 |
 | [`--watch-namespace`](#watch-namespace)                 | namespace                  | all namespaces          |       |
 
 ---
@@ -297,6 +298,16 @@ the certificate declared in the `secretName` ignoring if the certificate is or i
 If argument `--wait-before-shutdown` is defined, controller will wait defined time in seconds
 before it starts shutting down components when SIGTERM was received. By default, it's 0, which means
 the controller starts shutting down itself right after signal was sent.
+
+---
+
+## --wait-before-update
+
+Since v0.11
+
+Defines the amount of time to wait before start a reconciliation event and update haproxy.
+The purpose of this delay is to group all the notifications of a batch update and apply pending
+changes in one single shot. The default value is `200ms`.
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -56,8 +56,9 @@ type GenericController struct {
 type Configuration struct {
 	Client clientset.Interface
 
-	RateLimitUpdate float32
-	ResyncPeriod    time.Duration
+	RateLimitUpdate  float32
+	ResyncPeriod     time.Duration
+	WaitBeforeUpdate time.Duration
 
 	DefaultService string
 	IngressClass   string

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -104,6 +104,10 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		Default is 0.5, which means wait 2 seconds between Ingress updates in order
 		to add more changes in a single reload`)
 
+		waitBeforeUpdate = flags.Duration("wait-before-update", 200*time.Millisecond,
+			`Amount of time to wait before start a reconciliation and update haproxy,
+		giving the time to receive all/most of the changes of a batch update.`)
+
 		resyncPeriod = flags.Duration("sync-period", 600*time.Second,
 			`Relist and confirm cloud resources this often. Default is 10 minutes`)
 
@@ -303,6 +307,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		BucketsResponseTime:       *bucketsResponseTime,
 		RateLimitUpdate:           *rateLimitUpdate,
 		ResyncPeriod:              *resyncPeriod,
+		WaitBeforeUpdate:          *waitBeforeUpdate,
 		DefaultService:            *defaultSvc,
 		IngressClass:              *ingressClass,
 		WatchNamespace:            *watchNamespace,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -106,7 +106,9 @@ func (hc *HAProxyController) configController() {
 		hc.logger, hc.cfg.Client, hc.controller, hc.tracker, hc.ingressQueue,
 		hc.cfg.WatchNamespace, hc.cfg.ForceNamespaceIsolation,
 		hc.cfg.DisablePodList,
-		hc.cfg.ResyncPeriod)
+		hc.cfg.ResyncPeriod,
+		hc.cfg.WaitBeforeUpdate,
+	)
 	var acmeSigner acme.Signer
 	if hc.cfg.AcmeServer {
 		electorID := fmt.Sprintf("%s-%s", hc.cfg.AcmeElectionID, hc.cfg.IngressClass)


### PR DESCRIPTION
Add an option to configure the delay between the first event of a clean notification cache and start the reconciliation process. This option avoids to start two consecutive reconciliations due to a batch update.