### PR TITLE
Add path-type-order global config

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -185,6 +185,7 @@ The table below describes all supported configuration keys.
 | [`oauth-headers`](#oauth)                            | `<header>:<var>,...`                    | Backend |                    |
 | [`oauth-uri-prefix`](#oauth)                         | URI prefix                              | Backend |                    |
 | [`path-type`](#path-type)                            | path matching type                      | Host    | `begin`            |
+| [`path-type-order`](#path-type)                      | comma-separated path type list          | Global  | `exact,prefix,begin,regex` |
 | [`prometheus-port`](#bind-port)                      | port number                             | Global  |                    |
 | [`proxy-body-size`](#proxy-body-size)                | size (bytes)                            | Backend | unlimited          |
 | [`proxy-protocol`](#proxy-protocol)                  | [v1\|v2\|v2-ssl\|v2-ssl-cn]             | Backend |                    |
@@ -1300,13 +1301,19 @@ See also:
 
 ## Path type
 
-| Configuration key | Scope  | Default | Since |
-|-------------------|--------|---------|-------|
-| `path-type`       | `Host` | `begin` | v0.11 |
+| Configuration key | Scope    | Default                    | Since |
+|-------------------|----------|----------------------------|-------|
+| `path-type`       | `Host`   | `begin`                    | v0.11 |
+| `path-type-order` | `Global` | `exact,prefix,begin,regex` | v0.12 |
 
 Defines how the path of an incoming request should match a declared path in the ingress object.
 
 * `path-type`: Configures the path type. Case insensitive, so `Begin` and `begin` configures the same path type option. The ingress spec has priority, this option will only be used if the `pathType` attribute from the ingress spec is declared as `ImplementationSpecific` or is not declared.
+* `path-type-order`: Defines a comma-separated list of priority path types. First types has higher precedence, which means that if two distinct paths of two distinct types overlaps, the first in the list will be used to handle the request. All path types must be provided. Case insensitive, use all path types in lowercase.
+
+{{% alert title="Warning" color="warning" %}}
+Wildcard hostnames and alias-regex match incoming requests using the regex path type, even if the path itself has a distinct one. Changing the precedence order of paths also changes the precedence order of hostnames. See also [server-alias-regex](#server-alias) and [strict host](#strict-host).
+{{% /alert %}}
 
 Supported `path-type` values:
 

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -123,6 +123,7 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	c.buildGlobalForwardFor(d)
 	c.buildGlobalHTTPStoHTTP(d)
 	c.buildGlobalModSecurity(d)
+	c.buildGlobalPathTypeOrder(d)
 	c.buildGlobalProc(d)
 	c.buildGlobalSSL(d)
 	c.buildGlobalStats(d)

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -86,6 +86,7 @@ func createDefaults() map[string]string {
 		types.GlobalNbprocBalance:                "1",
 		types.GlobalNbthread:                     "2",
 		types.GlobalNoTLSRedirectLocations:       "/.well-known/acme-challenge",
+		types.GlobalPathTypeOrder:                "exact,prefix,begin,regex",
 		types.GlobalSSLDHDefaultMaxSize:          "2048",
 		types.GlobalSSLHeadersPrefix:             "X-SSL",
 		types.GlobalSSLOptions:                   defaultSSLOptions,

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -64,6 +64,7 @@ const (
 	GlobalNbprocSSL                    = "nbproc-ssl"
 	GlobalNbthread                     = "nbthread"
 	GlobalNoTLSRedirectLocations       = "no-tls-redirect-locations"
+	GlobalPathTypeOrder                = "path-type-order"
 	GlobalPrometheusPort               = "prometheus-port"
 	GlobalSSLDHDefaultMaxSize          = "ssl-dh-default-max-size"
 	GlobalSSLDHParam                   = "ssl-dh-param"

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -61,17 +61,10 @@ type config struct {
 type options struct {
 	mapsTemplate *template.Config
 	mapsDir      string
-	matchOrder   []hatypes.MatchType
 	shardCount   int
 }
 
 func createConfig(options options) *config {
-	options.matchOrder = []hatypes.MatchType{
-		hatypes.MatchExact,
-		hatypes.MatchPrefix,
-		hatypes.MatchBegin,
-		hatypes.MatchRegex,
-	}
 	if options.mapsTemplate == nil {
 		options.mapsTemplate = template.CreateConfig()
 	}
@@ -152,7 +145,7 @@ func (c *config) WriteFrontendMaps() error {
 		// hosts are clean, maps are updated
 		return nil
 	}
-	mapBuilder := hatypes.CreateMaps(c.options.matchOrder)
+	mapBuilder := hatypes.CreateMaps(c.global.MatchOrder)
 	mapsDir := c.options.mapsDir
 	fmaps := &hatypes.FrontendMaps{
 		HTTPHostMap:  mapBuilder.AddMap(mapsDir + "/_front_http_host.map"),
@@ -313,7 +306,7 @@ func (c *config) WriteBackendMaps() error {
 		// backends are clean, maps are updated
 		return nil
 	}
-	mapBuilder := hatypes.CreateMaps(c.options.matchOrder)
+	mapBuilder := hatypes.CreateMaps(c.global.MatchOrder)
 	for _, backend := range c.backends.ItemsAdd() {
 		if backend.NeedACL() {
 			mapsPrefix := c.options.mapsDir + "/_back_" + backend.ID

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -3095,6 +3095,7 @@ func (c *testConfig) configGlobal(global *hatypes.Global) {
 	global.Bind.HTTPSBind = ":443"
 	global.Cookie.Key = "Ingress"
 	global.Healthz.Port = 10253
+	global.MatchOrder = hatypes.DefaultMatchOrder
 	global.MaxConn = 2000
 	global.SSL.ALPN = "h2,http/1.1"
 	global.SSL.BackendCiphers = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256"

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -64,6 +64,7 @@ type Global struct {
 	LoadServerState bool
 	AdminSocket     string
 	Healthz         HealthzConfig
+	MatchOrder      []MatchType
 	Prometheus      PromConfig
 	Stats           StatsConfig
 	StrictHost      bool
@@ -341,6 +342,9 @@ const (
 	// IMPLEMENT a temp and partially supported match to configure crt-list
 	MatchEmpty = MatchType("")
 )
+
+// DefaultMatchOrder ...
+var DefaultMatchOrder = []MatchType{MatchExact, MatchPrefix, MatchBegin, MatchRegex}
 
 // PathLink is a unique identifier of a request
 // configuration. Several request based configurations


### PR DESCRIPTION
`path-type-order` creates a list of priority path types. First types has higher precedence to choose the correct path in the case distinct paths of distinct types overlaps.