### PR TITLE
Fix rewrite target match

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -203,7 +203,7 @@ d1.local/ path01`,
 			},
 			path: []string{"/app"},
 			expected: `
-    http-request replace-uri ^/app/?(.*)$     /\1`,
+    http-request replace-path ^/app/?(.*)$     /\1`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -216,7 +216,7 @@ d1.local/ path01`,
 			},
 			path: []string{"/app"},
 			expected: `
-    http-request replace-uri ^/app(.*)$       /other\1`,
+    http-request replace-path ^/app(.*)$       /other\1`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -229,8 +229,8 @@ d1.local/ path01`,
 			},
 			path: []string{"/app", "/app/sub"},
 			expected: `
-    http-request replace-uri ^/app(.*)$       /other/\1
-    http-request replace-uri ^/app/sub(.*)$       /other/\1`,
+    http-request replace-path ^/app(.*)$       /other/\1
+    http-request replace-path ^/app/sub(.*)$       /other/\1`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -251,9 +251,9 @@ d1.local/ path01`,
     # path02 = d1.local/path2
     # path03 = d1.local/path3
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request replace-uri ^/path1(.*)$       /sub1\1     if { var(txn.pathID) path01 }
-    http-request replace-uri ^/path2(.*)$       /sub2\1     if { var(txn.pathID) path02 }
-    http-request replace-uri ^/path3(.*)$       /sub2\1     if { var(txn.pathID) path03 }`,
+    http-request replace-path ^/path1(.*)$       /sub1\1     if { var(txn.pathID) path01 }
+    http-request replace-path ^/path2(.*)$       /sub2\1     if { var(txn.pathID) path02 }
+    http-request replace-path ^/path3(.*)$       /sub2\1     if { var(txn.pathID) path03 }`,
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local/path3 path03

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -525,10 +525,10 @@ backend {{ $backend.ID }}
 {{- if $rewrite }}
 {{- range $path := $rewriteCfg.Paths.Items }}
 {{- if eq $rewrite "/" }}
-    http-request replace-uri ^{{ $path.Path }}/?(.*)$     {{ $rewrite }}\1
+    http-request replace-path ^{{ $path.Path }}/?(.*)$     {{ $rewrite }}\1
         {{- if $needACL }}     if { var(txn.pathID) {{ $path.ID }} }{{ end }}
 {{- else }}
-    http-request replace-uri ^{{ $path.Path }}(.*)$       {{ $rewrite }}{{ if hasSuffix $path.Path "/" }}/{{ end }}\1
+    http-request replace-path ^{{ $path.Path }}(.*)$       {{ $rewrite }}{{ if hasSuffix $path.Path "/" }}/{{ end }}\1
         {{- if $needACL }}     if { var(txn.pathID) {{ $path.ID }} }{{ end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
`rewrite-target` rewrites the path of the request to another path provided in the annotation. The haproxy keyword used was `replace-uri`, and an URI by definition can have an optional scheme and domain. Change to `request-path` will leave the configuration compatible with the data being matched.