### PR TITLE
Log socket response only if message is not empty

### DIFF
--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -294,7 +294,9 @@ func (d *dynUpdater) execDisableEndpoint(backname string, ep *hatypes.Endpoint) 
 	}
 	d.logger.InfoV(2, "disabled endpoint '%s' on backend/server '%s/%s'", ep.Target, backname, ep.Name)
 	for _, m := range msg {
-		d.logger.InfoV(2, "response from server: %s", m)
+		if m != "" {
+			d.logger.InfoV(2, "response from server: %s", m)
+		}
 	}
 	return true
 }
@@ -316,7 +318,9 @@ func (d *dynUpdater) execEnableEndpoint(backname string, oldEP, curEP *hatypes.E
 	d.logger.InfoV(2, "%s endpoint '%s' weight '%d' state '%s' on backend/server '%s/%s'",
 		event, curEP.Target, curEP.Weight, state, backname, curEP.Name)
 	for _, m := range msg {
-		d.logger.InfoV(2, "response from server: %s", m)
+		if m != "" {
+			d.logger.InfoV(2, "response from server: %s", m)
+		}
 	}
 	return true
 }


### PR DESCRIPTION
Since the Add External HAProxy implementation, `HAProxyCommand` send a response message for every command sent. Dyn update always send three commands (change ip/port, change state, change weight) and some of them doesn't have a response. This behavior wasn't adjusted in the dyn update implementation and some logged haproxy responses was empty.