### PR TITLE
Improve old and new backend comparison

### DIFF
--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -95,6 +95,7 @@ func backendsMatch(back1, back2 *Backend) bool {
 	}
 	b1copy := *back1
 	b1copy.PathsMap = back2.PathsMap
+	b1copy.pathConfig = back2.pathConfig
 	b1copy.Endpoints = back2.Endpoints
 	if !reflect.DeepEqual(&b1copy, back2) {
 		return false


### PR DESCRIPTION
Old and new backends are compared whenever a direct or indirect related ingress, service or endpoint changes. This comparison improves CPU usage avoiding cfg bulding if configurations match, and haproxy reload if a dynamic update can be made.

A static comparison check if all but endpoints match. This comparison need to ignore internal controller attributes related with endpoint, otherwise any change eg to the endpoints order would count as a backend change, which is not right.

`pathConfig` was added in Per Path Backend Config and since then it was incorrectly firing some backend cfg parsings. This commit remove it from the comparison.