### PR TITLE
Fix dynamic update of the default backend

### DIFF
--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -97,12 +97,13 @@ func (d *dynUpdater) checkConfigChange() bool {
 	// return false on new backend which cannot be dynamically created
 	backends := make(map[string]*backendPair, len(d.config.backends.ItemsDel()))
 	for _, backend := range d.config.backends.ItemsDel() {
-		backends[backend.ID] = &backendPair{old: backend}
+		backends[backend.BackendID().String()] = &backendPair{old: backend}
 	}
 	for _, backend := range d.config.backends.ItemsAdd() {
-		back, found := backends[backend.ID]
+		id := backend.BackendID().String()
+		back, found := backends[id]
 		if !found {
-			d.logger.InfoV(2, "added backend '%s'", backend.ID)
+			d.logger.InfoV(2, "added backend '%s'", id)
 			updated = false
 		} else {
 			back.cur = backend
@@ -133,6 +134,7 @@ func (d *dynUpdater) checkBackendPair(pair *backendPair) bool {
 
 	// check equality of everything but endpoints
 	oldBackCopy := *oldBack
+	oldBackCopy.ID = curBack.ID
 	oldBackCopy.Dynamic = curBack.Dynamic
 	oldBackCopy.Endpoints = curBack.Endpoints
 	if !reflect.DeepEqual(&oldBackCopy, curBack) {

--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -231,6 +231,9 @@ func (b *Backends) RemoveAll(backendID []BackendID) {
 			}
 			b.changedShards[item.shard] = true
 			b.itemsDel[id] = item
+			if item == b.defaultBackend {
+				b.SetDefaultBackend(nil)
+			}
 			delete(b.items, id)
 		}
 	}
@@ -255,7 +258,7 @@ func (b *Backends) SetDefaultBackend(defaultBackend *Backend) {
 
 func (b BackendID) String() string {
 	if b.id == "" {
-		b.id = b.Namespace + "_" + b.Name + "_" + b.Port
+		b.id = buildID(b.Namespace, b.Name, b.Port)
 	}
 	return b.id
 }


### PR DESCRIPTION
Since v0.11, all cluster updates try to be partially applied in the in-memory model. This is addressed building an object tracking, followed by purging the old state and recreating these same objects in the new state. In short ingress objects track hostnames, services and secrets, and services track endpoints.

Default backends wasn't being updated because it exposes a service without using an ingress object, so endpoints are deployed on a full synchronization, including de first one, and wasn't tracker anymore. This update creates a dummy tracking point to bind the default backend endpoints and the haproxy model.

This update also needed to manage an issue with the backend ID: the default backend is renamed to `_default_backend` when assigned as such, and changed back when unassiged. This unassignment happens when the backend is purged in order to have its internal state updated, and such asynchrony should be fixed in the dynupdate. Now dynupdate compares backends based on an internal and immutable state.

Fixes #673 