### PR TITLE
Configure default backend to not change backend ID

### DIFF
--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -152,7 +152,7 @@ func (c *converter) syncDefaultCrt() {
 func (c *converter) syncDefaultBackend() {
 	if c.options.DefaultBackend != "" {
 		if backend, err := c.addBackend(&c.defaultBackSource, hatypes.DefaultHost, "/", c.options.DefaultBackend, "", map[string]string{}); err == nil {
-			c.haproxy.Backends().SetDefaultBackend(backend)
+			c.haproxy.Backends().DefaultBackend = backend
 			c.tracker.TrackHostname(convtypes.IngressType, c.defaultBackSource.FullName(), hatypes.DefaultHost)
 		} else {
 			c.logger.Error("error reading default service: %v", err)

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -98,7 +98,7 @@ func TestSyncSvcPortNotFound(t *testing.T) {
 `)
 
 	c.compareConfigBack(`
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080
@@ -143,7 +143,7 @@ func TestSyncSvcNamedPort(t *testing.T) {
   endpoints:
   - ip: 172.17.1.101
     port: 8080
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080
@@ -308,7 +308,7 @@ func TestSyncDrainSupport(t *testing.T) {
   - ip: 172.17.1.103
     port: 8080
     drain: true
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080
@@ -764,7 +764,7 @@ func TestSyncBackendReuseDefaultSvc(t *testing.T) {
 - hostname: default.example.com
   paths:
   - path: /app
-    backend: _default_backend`)
+    backend: system_default_8080`)
 
 	c.compareConfigDefaultFront(`[]`)
 	c.compareConfigBack(defaultBackendConfig)
@@ -1141,7 +1141,7 @@ WARN using default certificate due to an error reading secret 'default/tls1' on 
   - ip: 172.17.0.11
     port: 8080
   balancealgorithm: leastcon
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080`,
@@ -1173,7 +1173,7 @@ WARN using default certificate due to an error reading secret 'default/tls1' on 
   - ip: 172.17.0.12
     port: 8080
   balancealgorithm: leastcon
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080`,
@@ -1203,7 +1203,7 @@ WARN using default certificate due to an error reading secret 'default/tls1' on 
   - ip: 172.17.0.11
     port: 8080
   balancealgorithm: leastcon
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080`,
@@ -1221,7 +1221,7 @@ WARN using default certificate due to an error reading secret 'default/tls1' on 
   endpoints:
   - ip: 172.17.0.11
     port: 8080
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080`,
@@ -1246,7 +1246,7 @@ WARN using default certificate due to an error reading secret 'default/tls1' on 
   endpoints:
   - ip: 172.17.0.12
     port: 8080
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080`,
@@ -1363,7 +1363,7 @@ func TestSyncPartialDefaultBackend(t *testing.T) {
 
 	c.compareConfigFront(`[]`)
 	c.compareConfigBack(`
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.90
     port: 8080
@@ -1627,7 +1627,7 @@ func TestSyncAnnBackDefault(t *testing.T) {
   - ip: 172.17.0.17
     port: 8080
   balancealgorithm: roundrobin
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080
@@ -1688,7 +1688,7 @@ func TestSyncAnnPassthrough(t *testing.T) {
   endpoints:
   - ip: 172.17.1.101
     port: 8443
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080
@@ -1741,7 +1741,7 @@ paths:
   backend: default_echo1_8080`
 
 var defaultBackendConfig = `
-- id: _default_backend
+- id: system_default_8080
   endpoints:
   - ip: 172.17.0.99
     port: 8080`

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -128,7 +128,7 @@ func (c *config) SyncConfig() {
 				// TODO c.defaultBackend can be nil; create a valid
 				// _error404 backend, remove `if nil` from host.AddPath()
 				// and from `for range host.Paths` on map building.
-				back = c.backends.DefaultBackend()
+				back = c.backends.DefaultBackend
 			}
 			host.AddPath(back, "/", hatypes.MatchBegin)
 		}

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -398,7 +398,7 @@ set server default_app_8080/srv002 weight 1
 		{
 			doconfig1: func(c *testConfig) {
 				b1 := c.config.Backends().AcquireBackend("default", "default_backend", "8080")
-				c.config.Backends().SetDefaultBackend(b1)
+				c.config.Backends().DefaultBackend = b1
 				b2 := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b2.AcquireEndpoint("172.17.0.2", 8080, "")
 			},
@@ -406,7 +406,7 @@ set server default_app_8080/srv002 weight 1
 				b1 := c.config.Backends().AcquireBackend("default", "default_backend", "8080")
 				b1.Dynamic.DynUpdate = true
 				b1.Dynamic.MinFreeSlots = 1
-				c.config.Backends().SetDefaultBackend(b1)
+				c.config.Backends().DefaultBackend = b1
 				b2 := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b2.Dynamic.DynUpdate = true
 				b2.AcquireEndpoint("172.17.0.2", 8080, "")
@@ -588,7 +588,7 @@ set server default_app_8080/srv002 weight 1`,
 		{
 			doconfig1: func(c *testConfig) {
 				b1 := c.config.Backends().AcquireBackend("default", "default_backend", "8080")
-				c.config.Backends().SetDefaultBackend(b1)
+				c.config.Backends().DefaultBackend = b1
 				b2 := c.config.Backends().AcquireBackend("default", "app", "8080")
 				// some of these are unnecessary but the attempt is to have as
 				// realistic config as possible for a more reliable test
@@ -604,7 +604,7 @@ set server default_app_8080/srv002 weight 1`,
 			doconfig2: func(c *testConfig) {
 				b1 := c.config.Backends().AcquireBackend("default", "default_backend", "8080")
 				b1.Dynamic.DynUpdate = true
-				c.config.Backends().SetDefaultBackend(b1)
+				c.config.Backends().DefaultBackend = b1
 				b2 := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b2.Dynamic.DynUpdate = true
 				// some of these are unnecessary but the attempt is to have as
@@ -637,7 +637,7 @@ set server default_app_8080/srv002 weight 1
 		{
 			doconfig1: func(c *testConfig) {
 				b1 := c.config.Backends().AcquireBackend("default", "default_backend", "8080")
-				c.config.Backends().SetDefaultBackend(b1)
+				c.config.Backends().DefaultBackend = b1
 				b2 := c.config.Backends().AcquireBackend("default", "app", "8080")
 				// some of these are unnecessary but the attempt is to have as
 				// realistic config as possible for a more reliable test
@@ -653,7 +653,7 @@ set server default_app_8080/srv002 weight 1
 			doconfig2: func(c *testConfig) {
 				b1 := c.config.Backends().AcquireBackend("default", "default_backend", "8080")
 				b1.Dynamic.DynUpdate = true
-				c.config.Backends().SetDefaultBackend(b1)
+				c.config.Backends().DefaultBackend = b1
 				b2 := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b2.Dynamic.DynUpdate = true
 				// some of these are unnecessary but the attempt is to have as
@@ -683,7 +683,7 @@ set server default_app_8080/srv002 weight 1
 		{
 			doconfig1: func(c *testConfig) {
 				b1 := c.config.Backends().AcquireBackend("default", "default_backend", "8080")
-				c.config.Backends().SetDefaultBackend(b1)
+				c.config.Backends().DefaultBackend = b1
 				b2 := c.config.Backends().AcquireBackend("default", "app", "8080")
 				// some of these are unnecessary but the attempt is to have as
 				// realistic config as possible for a more reliable test
@@ -699,7 +699,7 @@ set server default_app_8080/srv002 weight 1
 			doconfig2: func(c *testConfig) {
 				b1 := c.config.Backends().AcquireBackend("default", "default_backend", "8080")
 				b1.Dynamic.DynUpdate = true
-				c.config.Backends().SetDefaultBackend(b1)
+				c.config.Backends().DefaultBackend = b1
 				b2 := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b2.Dynamic.DynUpdate = true
 				// some of these are unnecessary but the attempt is to have as
@@ -730,12 +730,12 @@ set server default_app_8080/srv002 weight 1`,
 		{
 			doconfig1: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
-				c.config.backends.SetDefaultBackend(b)
+				c.config.backends.DefaultBackend = b
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
-				c.config.backends.SetDefaultBackend(b)
+				c.config.backends.DefaultBackend = b
 				b.Dynamic.DynUpdate = true
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
 			},
@@ -744,10 +744,10 @@ set server default_app_8080/srv002 weight 1`,
 			},
 			dynamic: true,
 			cmd: `
-set server _default_backend/srv001 addr 172.17.0.3 port 8080
-set server _default_backend/srv001 state ready
-set server _default_backend/srv001 weight 1`,
-			logging: `INFO-V(2) updated endpoint '172.17.0.3:8080' weight '1' state 'ready' on backend/server '_default_backend/srv001'`,
+set server default_app_8080/srv001 addr 172.17.0.3 port 8080
+set server default_app_8080/srv001 state ready
+set server default_app_8080/srv001 weight 1`,
+			logging: `INFO-V(2) updated endpoint '172.17.0.3:8080' weight '1' state 'ready' on backend/server 'default_app_8080/srv001'`,
 		},
 	}
 	for i, test := range testCases {

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1434,7 +1434,7 @@ func TestInstanceDefaultHost(t *testing.T) {
 
 	def := c.config.Backends().AcquireBackend("default", "default-backend", "8080")
 	def.Endpoints = []*hatypes.Endpoint{endpointS0}
-	c.config.Backends().SetDefaultBackend(def)
+	c.config.Backends().DefaultBackend = def
 
 	var h *hatypes.Host
 	var b *hatypes.Backend
@@ -1471,7 +1471,7 @@ backend d2_app_8080
     acl https-request ssl_fc
     http-request redirect scheme https if !https-request
     server s1 172.17.0.11:8080 weight 100
-backend _default_backend
+backend default_default-backend_8080
     mode http
     server s0 172.17.0.99:8080 weight 100
 frontend _front_http
@@ -1484,7 +1484,7 @@ frontend _front_http
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
     use_backend d1_app_8080
-    default_backend _default_backend
+    default_backend default_default-backend_8080
 frontend _front_https
     mode http
     bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_bind_crt.list ca-ignore-err all crt-ignore-err all
@@ -1495,7 +1495,7 @@ frontend _front_https
     <<https-headers>>
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend d1_app_8080
-    default_backend _default_backend
+    default_backend default_default-backend_8080
 <<support>>
 `)
 
@@ -1605,7 +1605,7 @@ func TestInstanceFrontend(t *testing.T) {
 
 	def := c.config.Backends().AcquireBackend("default", "default-backend", "8080")
 	def.Endpoints = []*hatypes.Endpoint{endpointS0}
-	c.config.Backends().SetDefaultBackend(def)
+	c.config.Backends().DefaultBackend = def
 
 	var h *hatypes.Host
 	var b *hatypes.Backend
@@ -1641,7 +1641,7 @@ backend d2_app_8080
     acl https-request ssl_fc
     http-request redirect scheme https if !https-request
     server s1 172.17.0.11:8080 weight 100
-backend _default_backend
+backend default_default-backend_8080
     mode http
     server s0 172.17.0.99:8080 weight 100
 frontend _front_http
@@ -1655,7 +1655,7 @@ frontend _front_http
     http-request set-var(req.backend) var(req.base),map_dir(/etc/haproxy/maps/_front_http_host__prefix.map)
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map) if !{ var(req.backend) -m found }
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
-    default_backend _default_backend
+    default_backend default_default-backend_8080
 frontend _front_https
     mode http
     bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_bind_crt.list ca-ignore-err all crt-ignore-err all
@@ -1667,7 +1667,7 @@ frontend _front_https
     http-request set-var(txn.namespace) str(-) if !{ var(txn.namespace) -m found }
     <<https-headers>>
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
-    default_backend _default_backend
+    default_backend default_default-backend_8080
 <<support>>
 `)
 
@@ -1705,7 +1705,7 @@ func TestInstanceFrontendCA(t *testing.T) {
 
 	def := c.config.Backends().AcquireBackend("default", "default-backend", "8080")
 	def.Endpoints = []*hatypes.Endpoint{endpointS0}
-	c.config.Backends().SetDefaultBackend(def)
+	c.config.Backends().DefaultBackend = def
 
 	var h *hatypes.Host
 	var b *hatypes.Backend
@@ -1774,7 +1774,7 @@ backend d_app_8080
     http-request set-header X-SSL-Client-SHA1 %{+Q}[ssl_c_sha1,hex,lower]
     http-request set-header X-SSL-Client-Cert %{+Q}[ssl_c_der,base64]
     server s1 172.17.0.11:8080 weight 100
-backend _default_backend
+backend default_default-backend_8080
     mode http
     server s0 172.17.0.99:8080 weight 100
 frontend _front_http
@@ -1785,7 +1785,7 @@ frontend _front_http
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
     http-request set-var(req.backend) var(req.base),map_reg(/etc/haproxy/maps/_front_http_host__regex.map) if !{ var(req.backend) -m found }
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
-    default_backend _default_backend
+    default_backend default_default-backend_8080
 frontend _front_https
     mode http
     bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_bind_crt.list ca-ignore-err all crt-ignore-err all
@@ -1818,7 +1818,7 @@ frontend _front_https
     http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) _internal }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.snibackend)] if { var(req.snibackend) -m found }
-    default_backend _default_backend
+    default_backend default_default-backend_8080
 <<support>>
 `)
 
@@ -1881,7 +1881,7 @@ func TestInstanceSomePaths(t *testing.T) {
 
 	def := c.config.Backends().AcquireBackend("default", "default-backend", "8080")
 	def.Endpoints = []*hatypes.Endpoint{endpointS0}
-	c.config.Backends().SetDefaultBackend(def)
+	c.config.Backends().DefaultBackend = def
 
 	var h *hatypes.Host
 	var b *hatypes.Backend
@@ -1930,13 +1930,13 @@ backend d_app3_8080
     server s31 172.17.0.131:8080 weight 100
     server s32 172.17.0.132:8080 weight 100
     server s33 172.17.0.133:8080 weight 100
-backend _default_backend
+backend default_default-backend_8080
     mode http
     server s0 172.17.0.99:8080 weight 100
 <<frontend-http>>
-    default_backend _default_backend
+    default_backend default_default-backend_8080
 <<frontend-https>>
-    default_backend _default_backend
+    default_backend default_default-backend_8080
 <<support>>
 `)
 

--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -184,12 +184,6 @@ func (b *Backends) buildSortedItems(backendItems map[string]*Backend) []*Backend
 		i++
 	}
 	sort.Slice(items, func(i, j int) bool {
-		if items[i] == b.defaultBackend {
-			return false
-		}
-		if items[j] == b.defaultBackend {
-			return true
-		}
 		return items[i].ID < items[j].ID
 	})
 	return items
@@ -231,28 +225,11 @@ func (b *Backends) RemoveAll(backendID []BackendID) {
 			}
 			b.changedShards[item.shard] = true
 			b.itemsDel[id] = item
-			if item == b.defaultBackend {
-				b.SetDefaultBackend(nil)
+			if item == b.DefaultBackend {
+				b.DefaultBackend = nil
 			}
 			delete(b.items, id)
 		}
-	}
-}
-
-// DefaultBackend ...
-func (b *Backends) DefaultBackend() *Backend {
-	return b.defaultBackend
-}
-
-// SetDefaultBackend ...
-func (b *Backends) SetDefaultBackend(defaultBackend *Backend) {
-	if b.defaultBackend != nil {
-		def := b.defaultBackend
-		def.ID = buildID(def.Namespace, def.Name, def.Port)
-	}
-	b.defaultBackend = defaultBackend
-	if b.defaultBackend != nil {
-		b.defaultBackend.ID = "_default_backend"
 	}
 }
 

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -441,9 +441,9 @@ const (
 type Backends struct {
 	items, itemsAdd, itemsDel map[string]*Backend
 	//
-	defaultBackend *Backend
 	shards         []map[string]*Backend
 	changedShards  map[int]bool
+	DefaultBackend *Backend
 }
 
 // BackendID ...


### PR DESCRIPTION
The default backend configured via a command-line option has a special name since ages. This comes from a time when it was in fact a special entity created apart of the regular services referenced by ingress objects. Actually the default backend is also a regular backend that needs to be tracked and updated, and such special name is incompatible with future refactors planned in the backend entity. Iow the special name does not worth the effort anymore.