### PR TITLE
Fix basic auth backend tracking

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -128,6 +128,11 @@ func (c *updater) buildBackendAuthHTTP(d *backData) {
 				c.logger.Warn("userlist on %v for basic authentication is empty", authSecret.Source)
 			}
 		}
+		// Add secret->backend tracking again to properly track the backend if a userlist was reused
+		// Backends need always to be tracked because only hosts and backends tracking can properly start a partial update
+		// Tracker will take care of deduplicate trackings
+		// TODO build a stronger tracking
+		c.tracker.TrackBackend(convtypes.SecretType, secretName, d.backend.BackendID())
 		realm := "localhost" // HAProxy's backend name would be used if missing
 		authRealm := config.Get(ingtypes.BackAuthRealm)
 		if authRealm == nil || authRealm.Source == nil {


### PR DESCRIPTION
Basic auth users and passwords are stored in secret resources. We're properly tracking secret->userlist in the event of a secret update, and backends are also tracked but only when a new userlist is created.

A proper partial parsing need to track either a host or a backend from the haproxy model. If an untracked backend uses a tracked userlist, changes to this userlist will remove it without recreate, which will lead to failures in the configuration parsing.

This update enforces that a backend is always tracked in the event of a secret update, ensuring that partial parsing works properly.