### PR TITLE
Add worker-max-reloads config option

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -257,6 +257,7 @@ The table below describes all supported configuration keys.
 | [`waf`](#waf)                                        | "modsecurity"                           | Backend |                    |
 | [`waf-mode`](#waf)                                   | [deny\|detect]                          | Backend | `deny` (if waf is set) |
 | `whitelist-source-range`                             | CIDR                                    | Backend |                    |
+| [`worker-max-reloads`](#master-worker)               | number of reloads                       | Global  | `0`                |
 
 ---
 
@@ -1210,15 +1211,24 @@ See also:
 | Configuration key        | Scope    | Default | Since |
 |--------------------------|----------|---------|-------|
 | `master-exit-on-failure` | `Global` | `true`  | v0.12 |
+| `worker-max-reloads`     | `Global` | `0`     | v0.12 |
 
-Configures master-worker related options.
+Configures master-worker related options. These options are only used when an
+external haproxy instance is configured.
 
 * `master-exit-on-failure`: If `true`, kill all the remaining workers and exit
 from master in the case of an unexpected failure of a worker, eg a segfault.
+* `worker-max-reloads`: Defines how many reloads a haproxy worker should
+survive before receive a SIGTERM. The default value is `0` which means
+unlimited. This option limits the number of active workers and the haproxy's
+pod memory usage. Useful on workloads with long running connections, eg
+websockets, and clusters that frequently changes and forces haproxy to reload.
 
 See also:
 
+* [Example]({{% relref "/docs/examples/external-haproxy" %}}) page
 * https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#3.1-master-worker
+* https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#mworker-max-reloads
 * [master-socket]({{% relref "command-line#master-socket" %}}) command-line option
 
 ---

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -118,6 +118,7 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.External.MasterSocket = c.options.MasterSocket
 	d.global.LoadServerState = mapper.Get(ingtypes.GlobalLoadServerState).Bool()
 	d.global.Master.ExitOnFailure = mapper.Get(ingtypes.GlobalMasterExitOnFailure).Bool()
+	d.global.Master.WorkerMaxReloads = mapper.Get(ingtypes.GlobalWorkerMaxReloads).Int()
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()
 	c.buildGlobalAcme(d)

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -96,4 +96,5 @@ const (
 	GlobalUseHAProxyUser               = "use-haproxy-user"
 	GlobalUseHTX                       = "use-htx"
 	GlobalUseProxyProtocol             = "use-proxy-protocol"
+	GlobalWorkerMaxReloads             = "worker-max-reloads"
 )

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -847,6 +847,7 @@ func TestInstanceEmptyExternal(t *testing.T) {
 	defer c.teardown()
 
 	c.config.global.External.MasterSocket = "/tmp/master.sock"
+	c.config.global.Master.WorkerMaxReloads = 20
 	c.config.global.Security.Username = "external"
 	c.config.global.Security.Groupname = "external"
 
@@ -862,6 +863,7 @@ global
     stats socket /var/run/haproxy.sock level admin expose-fd listeners mode 600
     maxconn 2000
     hard-stop-after 15m
+    mworker-max-reloads 20
     lua-load /etc/haproxy/lua/services.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -192,7 +192,8 @@ type HealthzConfig struct {
 
 // MasterConfig ...
 type MasterConfig struct {
-	ExitOnFailure bool
+	ExitOnFailure    bool
+	WorkerMaxReloads int
 }
 
 // PromConfig ...

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -92,6 +92,9 @@ global
 {{- if $global.Timeout.Stop }}
     hard-stop-after {{ $global.Timeout.Stop }}
 {{- end }}
+{{- if and $global.External.IsExternal $global.Master.WorkerMaxReloads }}
+    mworker-max-reloads {{ $global.Master.WorkerMaxReloads }}
+{{- end }}
 {{- if $global.Syslog.Endpoint }}
     log {{ $global.Syslog.Endpoint }} len {{ $global.Syslog.Length }} format {{ $global.Syslog.Format }} local0
     log-tag {{ $global.Syslog.Tag }}


### PR DESCRIPTION
A haproxy deployment, which is frequently reloaded due to configuration changes, might have a big number of old workers in memory if the workload has a number of long running connections, eg websocket. `worker-max-reloads` limits this number, terminating old workers that survived that number of reloads.