### PR TITLE
Add ingress class support

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -22,11 +22,11 @@ The following command-line options are supported:
 | [`--annotation-prefix`](#annotation-prefix)             | prefix without `/`         | `ingress.kubernetes.io` | v0.8  |
 | [`--backend-shards`](#backend-shards)                   | int                        | `0`                     | v0.11 |
 | [`--buckets-response-time`](#buckets-response-time)     | float64 slice           | `.0005,.001,.002,.005,.01` | v0.10 |
+| [`--controller-class`](#ingress-class)                  | suffix                     | ``                      | v0.12 |
 | [`--default-backend-service`](#default-backend-service) | namespace/servicename      | haproxy's 404 page      |       |
 | [`--default-ssl-certificate`](#default-ssl-certificate) | namespace/secretname       | fake, auto generated    |       |
 | [`--disable-pod-list`](#disable-pod-list)               | [true\|false]              | `false`                 | v0.11 |
 | [`--healthz-port`](#stats)                              | port number                | `10254`                 |       |
-| [`--ignore-ingress-without-class`](#ignore-ingress-without-class)| [true\|false]     | `false`                 | v0.10 |
 | [`--ingress-class`](#ingress-class)                     | name                       | `haproxy`               |       |
 | [`--kubeconfig`](#kubeconfig)                           | /path/to/kubeconfig        | in cluster config       |       |
 | [`--master-socket`](#master-socket)                     | socket path                | use embedded haproxy    | v0.12 |
@@ -42,6 +42,7 @@ The following command-line options are supported:
 | [`--verify-hostname`](#verify-hostname)                 | [true\|false]              | `true`                  |       |
 | [`--wait-before-shutdown`](#wait-before-shutdown)       | seconds as integer         | `0`                     | v0.8  |
 | [`--wait-before-update`](#wait-before-update)           | duration                   | `200ms`                 | v0.11 |
+| [`--watch-ingress-without-class`](#ingress-class)       | [true\|false]              | `false`                 | v0.12 |
 | [`--watch-namespace`](#watch-namespace)                 | namespace                  | all namespaces          |       |
 
 ---
@@ -130,21 +131,35 @@ Disables in memory pod list and also pod watch for changes. Pod list and watch i
 
 ---
 
-## --ignore-ingress-without-class
+## Ingress Class
 
-Defines if the ingress without the ingress.class annotation will be considered or not. If `--ignore-ingress-without-class=true` then only the ingresses with the matching ingress.class annotation will be considered, ingresses with missing or different ingress.class annotation will not be considered. Default is false.
+More than one ingress controller is supported per Kubernetes cluster. These options allow to
+override the class of ingress resources that this instance of the controller should listen to.
+Classes that match will be used in the HAProxy configuration, other classes will be ignored.
+Ingress resources without class name and without class annotation is also ignored since v0.12,
+add the command-line option `--watch-ingress-without-class` to also listen to these ingress.
 
----
+These options have a new behavior since v0.12, see the corresponding documentation if using an
+older controller version.
 
-## --ingress-class
+* `--ingress-class`: defines the value of `kubernetes.io/ingress.class` annotation this controller
+should listen to. The default value is `haproxy` if not declared.
+* `--controller-class`: by default, HAProxy Ingress will watch IngressClasses whose
+`spec.controller` name is `haproxy-ingress.github.io/controller`. All ingress resources that
+link to these IngressClasses will be added to the configuration. The `--controller-class`
+command-line option customizes the controller name, allowing to run more than one HAProxy Ingress
+in the same cluster. Configuring `--controller-class=staging` would listen to IngressClasses whose
+controller name is `haproxy-ingress.github.io/controller/staging`.
+* `--watch-ingress-without-class`: defines if this controller should also listen to ingress resources
+that doesn't declare neither the `kubernetes.io/ingress.class` annotation nor the
+`<ingress>.spec.ingressClassName` field. The default since v0.12 is to ignore ingress without class
+annotation and class name.
+* `--ignore-ingress-without-class`: this option is ignored since v0.12. Use
+`--watch-ingress-without-class` instead.
 
-More than one ingress controller is supported per Kubernetes cluster. The `--ingress-class`
-argument allow to override the class name of ingress resources that this instance of the
-controller should listen to. Class names that match will be used in the HAProxy configuration.
-Other classes will be ignored.
+See also:
 
-The ingress resource must use the `kubernetes.io/ingress.class` annotation to name it's
-ingress class.
+* https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
 
 ---
 

--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -159,6 +159,7 @@ annotation and class name.
 
 See also:
 
+* [Class matter]({{% relref "keys/#class-matter" %}}) in the Configuration Keys doc
 * https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
 
 ---

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -102,9 +102,9 @@ $ wget -qO- --no-check-certificate https://echoserver.192.168.1.11.nip.io
 
 ## What's next?
 
-Learn more about ingress from the Kubernetes docs:
+Learn more about Ingress and IngressClass resources:
 
-* [Ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) from Kubernetes docs
+* [Ingress and IngressClass resources](https://kubernetes.io/docs/concepts/services-networking/ingress/) from Kubernetes docs
 
 HAProxy Ingress has lots of configuration options. See the following tips to get started faster:
 

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -8,7 +8,7 @@ description: >
 
 ## Prerequisites
 
-HAProxy Ingress needs a running Kubernetes cluster. Controller version v0.11 needs Kubernetes 1.14, while version v0.10 and older work on clusters as old as 1.6. HAProxy Ingress also works fine on local k8s deployments like [minikube](https://minikube.sigs.k8s.io) or [kind](https://kind.sigs.k8s.io).
+HAProxy Ingress needs a running Kubernetes cluster. Controller version v0.12 needs Kubernetes 1.18 or newer, see other supported versions in the [README](https://github.com/jcmoraisjr/haproxy-ingress/#use-haproxy-ingress) file. HAProxy Ingress also works fine on local k8s deployments like [minikube](https://minikube.sigs.k8s.io) or [kind](https://kind.sigs.k8s.io).
 
 An ingress controller works exposing internal services to the external world, so another pre-requisite is that at least one cluster node is accessible externally. On cloud environments, a cloud load balancer can be configured to reach the ingress controller nodes.
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -40,6 +40,7 @@ import (
 type NewCtrlIntf interface {
 	GetIngressList() ([]*networking.Ingress, error)
 	GetSecret(name string) (*apiv1.Secret, error)
+	IsValidClass(ing *networking.Ingress) bool
 }
 
 // GenericController holds the boilerplate code required to build an Ingress controlller.
@@ -125,20 +126,6 @@ func newIngressController(config *Configuration) *GenericController {
 	}
 
 	return &ic
-}
-
-// IngressClassKey ...
-const IngressClassKey = "kubernetes.io/ingress.class"
-
-// IsValidClass ...
-func (ic *GenericController) IsValidClass(ing *networking.Ingress) bool {
-	ann, found := ing.Annotations[IngressClassKey]
-
-	if ic.cfg.IgnoreIngressWithoutClass {
-		return found && ann == ic.cfg.IngressClass
-	}
-
-	return !found || ann == ic.cfg.IngressClass
 }
 
 // GetConfig expose the controller configuration

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -62,10 +62,12 @@ type Configuration struct {
 	ResyncPeriod     time.Duration
 	WaitBeforeUpdate time.Duration
 
-	DefaultService string
-	IngressClass   string
-	WatchNamespace string
-	ConfigMapName  string
+	DefaultService           string
+	IngressClass             string
+	ControllerName           string
+	WatchIngressWithoutClass bool
+	WatchNamespace           string
+	ConfigMapName            string
 
 	ForceNamespaceIsolation bool
 	WaitBeforeShutdown      int
@@ -98,9 +100,8 @@ type Configuration struct {
 	ElectionID             string
 	UpdateStatusOnShutdown bool
 
-	BackendShards             int
-	SortEndpointsBy           string
-	IgnoreIngressWithoutClass bool
+	BackendShards   int
+	SortEndpointsBy string
 }
 
 // newIngressController creates an Ingress controller

--- a/pkg/common/ingress/controller/status.go
+++ b/pkg/common/ingress/controller/status.go
@@ -308,7 +308,7 @@ func (s *statusSync) updateStatus(newIngressPoint []apiv1.LoadBalancerIngress) e
 	batch := p.Batch()
 
 	for _, ing := range ings {
-		if !s.ic.IsValidClass(ing) {
+		if !s.ic.newctrl.IsValidClass(ing) {
 			continue
 		}
 

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -201,6 +201,10 @@ func (c *k8scache) GetIngressList() ([]*networking.Ingress, error) {
 	return validIngList[:i], nil
 }
 
+func (c *k8scache) GetIngressClass(className string) (*networking.IngressClass, error) {
+	return c.listers.ingressClassLister.Get(className)
+}
+
 func (c *k8scache) GetService(serviceName string) (*api.Service, error) {
 	namespace, name, err := cache.SplitMetaNamespaceKey(serviceName)
 	if err != nil {
@@ -569,11 +573,11 @@ func (c *k8scache) IsValidIngress(ing *networking.Ingress) bool {
 	// check if ingress `hasClass` and, if so, if it's valid `fromClass` perspective
 	var hasClass, fromClass bool
 	if className := ing.Spec.IngressClassName; className != nil {
-		if ingClass, err := c.listers.ingressClassLister.Get(*className); ingClass != nil {
-			hasClass = true
+		hasClass = true
+		if ingClass, err := c.GetIngressClass(*className); ingClass != nil {
 			fromClass = c.IsValidIngressClass(ingClass)
 		} else if err != nil {
-			c.logger.Warn("error reading ingress class %s: %v", *className, err)
+			c.logger.Warn("error reading ingress class '%s': %v", *className, err)
 		} else {
 			c.logger.Warn("ingress class not found: %s", *className)
 		}

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -300,6 +300,10 @@ func (c *k8scache) GetPod(podName string) (*api.Pod, error) {
 	return c.client.CoreV1().Pods(namespace).Get(c.ctx, name, metav1.GetOptions{})
 }
 
+func (c *k8scache) GetPodNamespace() string {
+	return c.podNamespace
+}
+
 func (c *k8scache) buildSecretName(defaultNamespace, secretName string) (string, string, error) {
 	ns, name, err := cache.SplitMetaNamespaceKey(secretName)
 	if err != nil {

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -573,10 +573,10 @@ func (c *k8scache) IsValidIngress(ing *networking.Ingress) bool {
 	var hasAnn, fromAnn bool
 	var ann string
 	ann, hasAnn = ing.Annotations["kubernetes.io/ingress.class"]
-	if c.cfg.IgnoreIngressWithoutClass {
-		fromAnn = hasAnn && ann == c.cfg.IngressClass
-	} else {
+	if c.cfg.WatchIngressWithoutClass {
 		fromAnn = !hasAnn || ann == c.cfg.IngressClass
+	} else {
+		fromAnn = hasAnn && ann == c.cfg.IngressClass
 	}
 
 	// check if ingress `hasClass` and, if so, if it's valid `fromClass` perspective
@@ -586,9 +586,9 @@ func (c *k8scache) IsValidIngress(ing *networking.Ingress) bool {
 		if ingClass, err := c.GetIngressClass(*className); ingClass != nil {
 			fromClass = c.IsValidIngressClass(ingClass)
 		} else if err != nil {
-			c.logger.Warn("error reading ingress class '%s': %v", *className, err)
+			c.logger.Warn("error reading IngressClass '%s': %v", *className, err)
 		} else {
-			c.logger.Warn("ingress class not found: %s", *className)
+			c.logger.Warn("IngressClass not found: %s", *className)
 		}
 	}
 
@@ -607,12 +607,12 @@ func (c *k8scache) IsValidIngress(ing *networking.Ingress) bool {
 }
 
 func (c *k8scache) IsValidIngressClass(ingressClass *networking.IngressClass) bool {
-	return ingressClass.Spec.Controller == "haproxy-ingress.github.io/controller"
+	return ingressClass.Spec.Controller == c.cfg.ControllerName
 }
 
 // implements ListerEvents
 func (c *k8scache) IsValidConfigMap(cm *api.ConfigMap) bool {
-	// Ingress Class Parameters can use ConfigMaps in the controller namespace
+	// IngressClass' Parameters can use ConfigMaps in the controller namespace
 	if cm.Namespace == c.podNamespace {
 		return true
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -253,6 +253,12 @@ func (hc *HAProxyController) GetSecret(name string) (*api.Secret, error) {
 	return hc.cache.GetSecret(name)
 }
 
+// IsValidClass ...
+// implements oldcontroller.NewCtrlIntf
+func (hc *HAProxyController) IsValidClass(ing *networking.Ingress) bool {
+	return hc.cache.IsValidIngress(ing)
+}
+
 // Name provides the complete name of the controller
 func (hc *HAProxyController) Name() string {
 	return "HAProxy Ingress Controller"

--- a/pkg/controller/listers.go
+++ b/pkg/controller/listers.go
@@ -358,6 +358,11 @@ func (l *listers) createConfigMapLister(informer informersv1.ConfigMapInformer) 
 				}
 			}
 		},
+		DeleteFunc: func(obj interface{}) {
+			if l.events.IsValidConfigMap(obj.(*api.ConfigMap)) {
+				l.events.Notify(obj, nil)
+			}
+		},
 	})
 }
 

--- a/pkg/controller/listers.go
+++ b/pkg/controller/listers.go
@@ -133,7 +133,7 @@ func (l *listers) RunAsync(stopCh <-chan struct{}) {
 	}
 	l.logger.Info("loading object cache...")
 
-	// wait ingress class lister initialize, ingress informers initialization depends on it
+	// wait IngressClass lister initialize, ingress informers initialization depends on it
 	go l.ingressClassInformer.Run(stopCh)
 	ingClassSynced := cache.WaitForCacheSync(stopCh,
 		l.ingressClassInformer.HasSynced,

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -36,6 +36,7 @@ type CacheMock struct {
 	tracker       convtypes.Tracker
 	Changed       *convtypes.ChangedObjects
 	IngList       []*networking.Ingress
+	IngClassList  []*networking.IngressClass
 	SvcList       []*api.Service
 	EpList        map[string]*api.Endpoints
 	TermPodList   map[string][]*api.Pod
@@ -81,6 +82,16 @@ func (c *CacheMock) GetIngress(ingressName string) (*networking.Ingress, error) 
 // GetIngressList ...
 func (c *CacheMock) GetIngressList() ([]*networking.Ingress, error) {
 	return c.IngList, nil
+}
+
+// GetIngressClass ...
+func (c *CacheMock) GetIngressClass(className string) (*networking.IngressClass, error) {
+	for _, ingClass := range c.IngClassList {
+		if ingClass.Name == className {
+			return ingClass, nil
+		}
+	}
+	return nil, fmt.Errorf("ingress class not found: %s", className)
 }
 
 // GetService ...

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -39,6 +39,7 @@ type CacheMock struct {
 	IngClassList  []*networking.IngressClass
 	SvcList       []*api.Service
 	EpList        map[string]*api.Endpoints
+	ConfigMapList map[string]*api.ConfigMap
 	TermPodList   map[string][]*api.Pod
 	PodList       map[string]*api.Pod
 	SecretTLSPath map[string]string
@@ -116,6 +117,14 @@ func (c *CacheMock) GetEndpoints(service *api.Service) (*api.Endpoints, error) {
 	return nil, fmt.Errorf("could not find endpoints for service '%s'", serviceName)
 }
 
+// GetConfigMap ...
+func (c *CacheMock) GetConfigMap(configMapName string) (*api.ConfigMap, error) {
+	if configMap, found := c.ConfigMapList[configMapName]; found {
+		return configMap, nil
+	}
+	return nil, fmt.Errorf("configmap not found: %s", configMapName)
+}
+
 // GetTerminatingPods ...
 func (c *CacheMock) GetTerminatingPods(service *api.Service, track convtypes.TrackingTarget) ([]*api.Pod, error) {
 	serviceName := service.Namespace + "/" + service.Name
@@ -131,6 +140,11 @@ func (c *CacheMock) GetPod(podName string) (*api.Pod, error) {
 		return pod, nil
 	}
 	return nil, fmt.Errorf("pod not found: '%s'", podName)
+}
+
+// GetPodNamespace ...
+func (c *CacheMock) GetPodNamespace() string {
+	return "ingress-controller"
 }
 
 // GetTLSSecretPath ...

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -92,7 +92,7 @@ func (c *CacheMock) GetIngressClass(className string) (*networking.IngressClass,
 			return ingClass, nil
 		}
 	}
-	return nil, fmt.Errorf("ingress class not found: %s", className)
+	return nil, fmt.Errorf("IngressClass not found: %s", className)
 }
 
 // GetService ...

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -242,7 +242,13 @@ func (c *converter) syncPartial() {
 	addPodNames := pod2names(c.changed.Pods)
 	c.trackAddedIngress()
 	dirtyIngs, dirtyHosts, dirtyBacks, dirtyUsers, dirtyStorages :=
-		c.tracker.GetDirtyLinks(oldIngNames, addIngNames, oldSvcNames, addSvcNames, oldSecretNames, addSecretNames, addPodNames)
+		c.tracker.GetDirtyLinks(
+			oldIngNames, addIngNames,
+			[]string{}, []string{},
+			oldSvcNames, addSvcNames,
+			oldSecretNames, addSecretNames,
+			addPodNames,
+		)
 	c.tracker.DeleteHostnames(dirtyHosts)
 	c.tracker.DeleteBackends(dirtyBacks)
 	c.tracker.DeleteUserlists(dirtyUsers)

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -256,6 +256,7 @@ func (c *converter) syncPartial() {
 		c.tracker.GetDirtyLinks(
 			oldIngNames, addIngNames,
 			oldClsNames, addClsNames,
+			[]string{}, []string{},
 			oldSvcNames, addSvcNames,
 			oldSecretNames, addSecretNames,
 			addPodNames,

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -563,7 +563,7 @@ func (c *converter) readIngressClass(source *annotations.Source, hostname string
 			return ingressClass
 		}
 		c.tracker.TrackMissingOnHostname(convtypes.IngressClassType, *ingressClassName, hostname)
-		c.logger.Warn("error reading ingress class of %s: %v", source, err)
+		c.logger.Warn("error reading IngressClass of %s: %v", source, err)
 	}
 	return nil
 }
@@ -648,11 +648,11 @@ func (c *converter) addBackendWithClass(source *annotations.Source, hostname, ur
 		c.logger.Warn("skipping backend '%s:%s' annotation(s) from %v due to conflict: %v",
 			svcName, svcPort, source, conflict)
 	}
-	// Merging Ingress Class Parameters with less priority
+	// Merging IngressClass Parameters with less priority
 	if ingressClass != nil {
 		if cfg := c.readParameters(ingressClass, hostname); cfg != nil {
 			// Using a work around to add a per resource default config:
-			// we add Ingress Class Parameters after service and ingress annotations,
+			// we add IngressClass Parameters after service and ingress annotations,
 			// ignoring conflicts. This would really conflict with other Parameters
 			// only if the same host+path is declared twice, but such duplication is
 			// already filtred out in the ingress parsing.
@@ -793,22 +793,22 @@ func (c *converter) parseParameters(ingressClass *networking.IngressClass, track
 	}
 	// Currently only ConfigMap is supported
 	if parameters.APIGroup != nil && *parameters.APIGroup != "" {
-		c.logger.Warn("unsupported Parameters' APIGroup on Ingress Class '%s': %s", ingressClass.Name, *parameters.APIGroup)
+		c.logger.Warn("unsupported Parameters' APIGroup on IngressClass '%s': %s", ingressClass.Name, *parameters.APIGroup)
 		return nil
 	}
 	if strings.ToLower(parameters.Kind) != "configmap" {
-		c.logger.Warn("unsupported Parameters' Kind on Ingress Class '%s': %s", ingressClass.Name, parameters.Kind)
+		c.logger.Warn("unsupported Parameters' Kind on IngressClass '%s': %s", ingressClass.Name, parameters.Kind)
 		return nil
 	}
 	podNamespace := c.cache.GetPodNamespace()
 	if podNamespace == "" {
-		c.logger.Warn("need to configure POD_NAMESPACE to use ConfigMap on Ingress Class '%s'", ingressClass.Name)
+		c.logger.Warn("need to configure POD_NAMESPACE to use ConfigMap on IngressClass '%s'", ingressClass.Name)
 		return nil
 	}
 	configMapName := podNamespace + "/" + parameters.Name
 	configMap, err := c.cache.GetConfigMap(configMapName)
 	if err != nil {
-		c.logger.Warn("error reading ConfigMap on Ingress Class '%s': %v", ingressClass.Name, err)
+		c.logger.Warn("error reading ConfigMap on IngressClass '%s': %v", ingressClass.Name, err)
 		c.tracker.TrackMissingOnHostname(convtypes.ConfigMapType, configMapName, trackingHostname)
 		return nil
 	}

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -598,7 +598,7 @@ func TestSyncIngressClass(t *testing.T) {
 				Kind:     "any",
 				Name:     "none",
 			},
-			logging: `WARN unsupported Parameters' APIGroup on Ingress Class 'haproxy-config': some.io`,
+			logging: `WARN unsupported Parameters' APIGroup on IngressClass 'haproxy-config': some.io`,
 		},
 		// 1
 		{
@@ -606,7 +606,7 @@ func TestSyncIngressClass(t *testing.T) {
 				Kind: "any",
 				Name: "none",
 			},
-			logging: `WARN unsupported Parameters' Kind on Ingress Class 'haproxy-config': any`,
+			logging: `WARN unsupported Parameters' Kind on IngressClass 'haproxy-config': any`,
 		},
 		// 2
 		{
@@ -614,7 +614,7 @@ func TestSyncIngressClass(t *testing.T) {
 				Kind: "ConfigMap",
 				Name: "none",
 			},
-			logging: `WARN error reading ConfigMap on Ingress Class 'haproxy-config': configmap not found: ingress-controller/none`,
+			logging: `WARN error reading ConfigMap on IngressClass 'haproxy-config': configmap not found: ingress-controller/none`,
 		},
 		// 3
 		{

--- a/pkg/converters/ingress/tracker/tracker_test.go
+++ b/pkg/converters/ingress/tracker/tracker_test.go
@@ -82,13 +82,15 @@ func TestGetDirtyLinks(t *testing.T) {
 		trackedMissingHosts []hostTracking
 		trackedMissingBacks []backTracking
 		//
-		oldIngressList []string
-		addIngressList []string
-		oldServiceList []string
-		addServiceList []string
-		oldSecretList  []string
-		addSecretList  []string
-		addPodList     []string
+		oldIngressList      []string
+		addIngressList      []string
+		oldIngressClassList []string
+		addIngressClassList []string
+		oldServiceList      []string
+		addServiceList      []string
+		oldSecretList       []string
+		addSecretList       []string
+		addPodList          []string
 		//
 		expDirtyIngs     []string
 		expDirtyHosts    []string
@@ -280,6 +282,22 @@ func TestGetDirtyLinks(t *testing.T) {
 			expDirtyIngs:     []string{"default/ing2"},
 			expDirtyStorages: []string{"crt2", "crt3"},
 		},
+		// 19
+		{
+			trackedHosts: []hostTracking{
+				{convtypes.IngressClassType, "haproxy", "app1.local"},
+			},
+			oldIngressClassList: []string{"haproxy"},
+			expDirtyHosts:       []string{"app1.local"},
+		},
+		// 20
+		{
+			trackedMissingHosts: []hostTracking{
+				{convtypes.IngressClassType, "haproxy", "app1.local"},
+			},
+			addIngressClassList: []string{"haproxy"},
+			expDirtyHosts:       []string{"app1.local"},
+		},
 	}
 	for i, test := range testCases {
 		c := setup(t)
@@ -305,6 +323,8 @@ func TestGetDirtyLinks(t *testing.T) {
 			c.tracker.GetDirtyLinks(
 				test.oldIngressList,
 				test.addIngressList,
+				test.oldIngressClassList,
+				test.addIngressClassList,
 				test.oldServiceList,
 				test.addServiceList,
 				test.oldSecretList,
@@ -335,17 +355,21 @@ func TestDeleteHostnames(t *testing.T) {
 		//
 		deleteHostnames []string
 		//
-		expIngressHostname stringStringMap
-		expHostnameIngress stringStringMap
-		expServiceHostname stringStringMap
-		expHostnameService stringStringMap
-		expSecretHostname  stringStringMap
-		expHostnameSecret  stringStringMap
+		expIngressHostname      stringStringMap
+		expHostnameIngress      stringStringMap
+		expIngressClassHostname stringStringMap
+		expHostnameIngressClass stringStringMap
+		expServiceHostname      stringStringMap
+		expHostnameService      stringStringMap
+		expSecretHostname       stringStringMap
+		expHostnameSecret       stringStringMap
 		//
-		expServiceHostnameMissing stringStringMap
-		expHostnameServiceMissing stringStringMap
-		expSecretHostnameMissing  stringStringMap
-		expHostnameSecretMissing  stringStringMap
+		expIngressClassHostnameMissing stringStringMap
+		expHostnameIngressClassMissing stringStringMap
+		expServiceHostnameMissing      stringStringMap
+		expHostnameServiceMissing      stringStringMap
+		expSecretHostnameMissing       stringStringMap
+		expHostnameSecretMissing       stringStringMap
 	}{
 		// 0
 		{},
@@ -433,9 +457,28 @@ func TestDeleteHostnames(t *testing.T) {
 		// 12
 		{
 			trackedHosts: []hostTracking{
+				{convtypes.IngressClassType, "haproxy1", "domain1.local"},
+				{convtypes.IngressClassType, "haproxy2", "domain1.local"},
+			},
+			deleteHostnames: []string{"domain1.local", "domain2.local"},
+		},
+		// 13
+		{
+			trackedMissingHosts: []hostTracking{
+				{convtypes.IngressClassType, "haproxy1", "domain1.local"},
+				{convtypes.IngressClassType, "haproxy2", "domain1.local"},
+			},
+			deleteHostnames: []string{"domain1.local", "domain2.local"},
+		},
+		// 14
+		{
+			trackedHosts: []hostTracking{
 				{convtypes.IngressType, "default/ing1", "domain1.local"},
 				{convtypes.IngressType, "default/ing1", "domain2.local"},
 				{convtypes.IngressType, "default/ing1", "domain3.local"},
+				{convtypes.IngressClassType, "haproxy", "domain1.local"},
+				{convtypes.IngressClassType, "haproxy", "domain2.local"},
+				{convtypes.IngressClassType, "haproxy", "domain3.local"},
 				{convtypes.ServiceType, "default/svc1", "domain1.local"},
 				{convtypes.ServiceType, "default/svc1", "domain2.local"},
 				{convtypes.ServiceType, "default/svc1", "domain3.local"},
@@ -443,13 +486,15 @@ func TestDeleteHostnames(t *testing.T) {
 				{convtypes.SecretType, "default/secret1", "domain2.local"},
 				{convtypes.SecretType, "default/secret1", "domain3.local"},
 			},
-			deleteHostnames:    []string{"domain1.local", "domain2.local"},
-			expIngressHostname: stringStringMap{"default/ing1": {"domain3.local": empty{}}},
-			expHostnameIngress: stringStringMap{"domain3.local": {"default/ing1": empty{}}},
-			expServiceHostname: stringStringMap{"default/svc1": {"domain3.local": empty{}}},
-			expHostnameService: stringStringMap{"domain3.local": {"default/svc1": empty{}}},
-			expSecretHostname:  stringStringMap{"default/secret1": {"domain3.local": empty{}}},
-			expHostnameSecret:  stringStringMap{"domain3.local": {"default/secret1": empty{}}},
+			deleteHostnames:         []string{"domain1.local", "domain2.local"},
+			expIngressHostname:      stringStringMap{"default/ing1": {"domain3.local": empty{}}},
+			expHostnameIngress:      stringStringMap{"domain3.local": {"default/ing1": empty{}}},
+			expIngressClassHostname: stringStringMap{"haproxy": {"domain3.local": empty{}}},
+			expHostnameIngressClass: stringStringMap{"domain3.local": {"haproxy": empty{}}},
+			expServiceHostname:      stringStringMap{"default/svc1": {"domain3.local": empty{}}},
+			expHostnameService:      stringStringMap{"domain3.local": {"default/svc1": empty{}}},
+			expSecretHostname:       stringStringMap{"default/secret1": {"domain3.local": empty{}}},
+			expHostnameSecret:       stringStringMap{"domain3.local": {"default/secret1": empty{}}},
 		},
 	}
 	for i, test := range testCases {
@@ -463,10 +508,14 @@ func TestDeleteHostnames(t *testing.T) {
 		c.tracker.DeleteHostnames(test.deleteHostnames)
 		c.compareObjects("ingressHostname", i, c.tracker.ingressHostname, test.expIngressHostname)
 		c.compareObjects("hostnameIngress", i, c.tracker.hostnameIngress, test.expHostnameIngress)
+		c.compareObjects("ingressClassHostname", i, c.tracker.ingressClassHostname, test.expIngressClassHostname)
+		c.compareObjects("hostnameIngressClass", i, c.tracker.hostnameIngressClass, test.expHostnameIngressClass)
 		c.compareObjects("serviceHostname", i, c.tracker.serviceHostname, test.expServiceHostname)
 		c.compareObjects("hostnameService", i, c.tracker.hostnameService, test.expHostnameService)
 		c.compareObjects("secretHostname", i, c.tracker.secretHostname, test.expSecretHostname)
 		c.compareObjects("hostnameSecret", i, c.tracker.hostnameSecret, test.expHostnameSecret)
+		c.compareObjects("ingressClassHostnameMissing", i, c.tracker.ingressClassHostnameMissing, test.expIngressClassHostnameMissing)
+		c.compareObjects("hostnameIngressClassMissing", i, c.tracker.hostnameIngressClassMissing, test.expHostnameIngressClassMissing)
 		c.compareObjects("serviceHostnameMissing", i, c.tracker.serviceHostnameMissing, test.expServiceHostnameMissing)
 		c.compareObjects("hostnameServiceMissing", i, c.tracker.hostnameServiceMissing, test.expHostnameServiceMissing)
 		c.compareObjects("secretHostnameMissing", i, c.tracker.secretHostnameMissing, test.expSecretHostnameMissing)

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -59,6 +59,8 @@ type ChangedObjects struct {
 	//
 	SecretsDel, SecretsUpd, SecretsAdd []*api.Secret
 	//
+	ConfigMapsDel, ConfigMapsUpd, ConfigMapsAdd []*api.ConfigMap
+	//
 	Pods []*api.Pod
 	//
 	Objects []string

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -68,7 +68,7 @@ type Tracker interface {
 	TrackBackend(rtype ResourceType, name string, backendID hatypes.BackendID)
 	TrackMissingOnHostname(rtype ResourceType, name, hostname string)
 	TrackStorage(rtype ResourceType, name, storage string)
-	GetDirtyLinks(oldIngressList, addIngressList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers, dirtyStorages []string)
+	GetDirtyLinks(oldIngressList, addIngressList, oldIngressClassList, addIngressClassList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers, dirtyStorages []string)
 	DeleteHostnames(hostnames []string)
 	DeleteBackends(backends []hatypes.BackendID)
 	DeleteUserlists(userlists []string)
@@ -102,6 +102,9 @@ type ResourceType int
 const (
 	// IngressType ...
 	IngressType ResourceType = iota
+
+	// IngressClassType ...
+	IngressClassType
 
 	// ServiceType ...
 	ServiceType

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -32,8 +32,10 @@ type Cache interface {
 	GetIngressClass(className string) (*networking.IngressClass, error)
 	GetService(serviceName string) (*api.Service, error)
 	GetEndpoints(service *api.Service) (*api.Endpoints, error)
+	GetConfigMap(configMapName string) (*api.ConfigMap, error)
 	GetTerminatingPods(service *api.Service, track TrackingTarget) ([]*api.Pod, error)
 	GetPod(podName string) (*api.Pod, error)
+	GetPodNamespace() string
 	GetTLSSecretPath(defaultNamespace, secretName string, track TrackingTarget) (CrtFile, error)
 	GetCASecretPath(defaultNamespace, secretName string, track TrackingTarget) (ca, crl File, err error)
 	GetDHSecretPath(defaultNamespace, secretName string) (File, error)

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -50,6 +50,8 @@ type ChangedObjects struct {
 	//
 	IngressesDel, IngressesUpd, IngressesAdd []*networking.Ingress
 	//
+	IngressClassesDel, IngressClassesUpd, IngressClassesAdd []*networking.IngressClass
+	//
 	Endpoints []*api.Endpoints
 	//
 	ServicesDel, ServicesUpd, ServicesAdd []*api.Service

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -71,7 +71,7 @@ type Tracker interface {
 	TrackBackend(rtype ResourceType, name string, backendID hatypes.BackendID)
 	TrackMissingOnHostname(rtype ResourceType, name, hostname string)
 	TrackStorage(rtype ResourceType, name, storage string)
-	GetDirtyLinks(oldIngressList, addIngressList, oldIngressClassList, addIngressClassList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers, dirtyStorages []string)
+	GetDirtyLinks(oldIngressList, addIngressList, oldIngressClassList, addIngressClassList, oldConfigMapList, addConfigMapList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers, dirtyStorages []string)
 	DeleteHostnames(hostnames []string)
 	DeleteBackends(backends []hatypes.BackendID)
 	DeleteUserlists(userlists []string)
@@ -108,6 +108,9 @@ const (
 
 	// IngressClassType ...
 	IngressClassType
+
+	// ConfigMapType ...
+	ConfigMapType
 
 	// ServiceType ...
 	ServiceType

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -29,6 +29,7 @@ import (
 type Cache interface {
 	GetIngress(ingressName string) (*networking.Ingress, error)
 	GetIngressList() ([]*networking.Ingress, error)
+	GetIngressClass(className string) (*networking.IngressClass, error)
 	GetService(serviceName string) (*api.Service, error)
 	GetEndpoints(service *api.Service) (*api.Endpoints, error)
 	GetTerminatingPods(service *api.Service, track TrackingTarget) ([]*api.Pod, error)


### PR DESCRIPTION
Follow the 1.18 ingress [spec](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) and implement `ingressClassName` support.

This doesn't remove `kubernetes.io/ingress.class` annotation support and its behavior, which continue to have precedence in the case of a conflict.

**Breaking backward compatibility**

Starting v0.12, HAProxy Ingress will ignore unclassified ingress resources. Deployments that does not declare `--ignore-ingress-without-class` should now declare `--watch-ingress-without-class`. This configuration can be ignored if all ingress resources of the cluster are classified: has either the `kubernetes.io/ingress.class` annotation or configures the `ingressClassName` field.

**Tasks**

* [x] Strictly follow ingress spec - this breaks backward compatibility
* [x] Add ingress class lister and informer
* [x] Filter ingress resource based on `ingressClassName` attribute
* [x] Notify ingress class update
* [x] Track existing and missing ingress class
* [x] ~Add default ingress class support~
* [x] Add parameters support
* [x] Option to run more HAProxy Ingress instances in the same cluster
* [x] Unit tests
* [x] Exploratory tests
* [x] Documentation
