### PR TITLE
Adding new entries for networking.k8s.io/ingress

### DIFF
--- a/examples/rbac/ingress-controller-rbac.yml
+++ b/examples/rbac/ingress-controller-rbac.yml
@@ -40,14 +40,22 @@ rules:
       - get
       - list
       - watch
+
   - apiGroups:
-      - "extensions"
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:
       - get
       - list
-      - watch
+      - watch  
+  - apiGroups:
+      - "networking.k8s.io"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+
   - apiGroups:
       - ""
     resources:
@@ -55,6 +63,15 @@ rules:
     verbs:
       - create
       - patch
+
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch  
   - apiGroups:
       - "extensions"
     resources:


### PR DESCRIPTION
1.19 has ingress under networking.k8s.io, so with this RBAC, it fails.