### PR TITLE
Use default certificate only if provided SNI isn't found

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -163,7 +163,7 @@ func (c *config) WriteFrontendMaps() error {
 		//
 		CrtList: mapBuilder.AddMap(mapsDir + "/_front_bind_crt.list"),
 	}
-	fmaps.CrtList.AppendItem(c.frontend.DefaultCrtFile)
+	fmaps.CrtList.AppendItem(c.frontend.DefaultCrtFile + " !*")
 	hasVarNamespace := c.hosts.HasVarNamespace()
 	for _, host := range c.hosts.BuildSortedItems() {
 		if host.SSLPassthrough() {

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1594,7 +1594,7 @@ frontend _front_https
 d2.local/app d2_app_8080
 `)
 	c.checkMap("_front_bind_crt.list", `
-/var/haproxy/ssl/certs/default.pem
+/var/haproxy/ssl/certs/default.pem !*
 `)
 	c.checkMap("_front_namespace__begin.map", `
 d2.local/app d2
@@ -1782,7 +1782,7 @@ d2.local/app -
 `)
 
 	c.checkMap("_front_bind_crt.list", `
-/var/haproxy/ssl/certs/default.pem
+/var/haproxy/ssl/certs/default.pem !*
 /var/haproxy/ssl/certs/d1.pem d1.local
 /var/haproxy/ssl/certs/d2.pem d2.local
 `)
@@ -1924,7 +1924,7 @@ d6.local/ d_app_8080
 ^[^.]+\.d1\.local/ d_app_8080
 `)
 	c.checkMap("_front_bind_crt.list", `
-/var/haproxy/ssl/certs/default.pem
+/var/haproxy/ssl/certs/default.pem !*
 /var/haproxy/ssl/certs/default.pem [ca-file /var/haproxy/ssl/ca/d1.local.pem verify optional] *.d1.local
 /var/haproxy/ssl/certs/default.pem [ca-file /var/haproxy/ssl/ca/d2.local.pem verify optional crl-file /var/haproxy/ssl/ca/d2.local.crl.pem] d2.local
 /var/haproxy/ssl/certs/default.pem [ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384] d3.local
@@ -2174,7 +2174,7 @@ d3.local d3_app-ssl_8443`)
 d2.local/ _redirect_https
 d3.local/ d3_app-http_8080`)
 	c.checkMap("_front_bind_crt.list", `
-/var/haproxy/ssl/certs/default.pem
+/var/haproxy/ssl/certs/default.pem !*
 `)
 
 	c.logger.CompareLogging(defaultLogging)


### PR DESCRIPTION
Default or fallback certificate is defined in haproxy declaring it as the first certificate. It should be used in TLS handshakes when SNI is not provided or if the provided one does not have a match.

HAProxy Ingress uses `crt-list` to better implements Ingress spec: a valid certificate is not one that its CN or SAN has the provided SNI, but instead that one the user declares in the spec.tls hostname.

There is however a scenario which trigger the wrong path: if the default certificate is valid for a provided SNI, haproxy will use it in the handshake instead of a declared certificate - this happens because the default certificate, being the first one, is validated first.

This commit adds a `!*` in the snifilter of the default certificate. This will instruct haproxy to not add any of its domains - CN and SAN - in the SNI, so it won't match any domain, except if a valid one cannot be found. This is exactly what a default certificate is all about.

#687 