### PR TITLE
Fix duplication of userlist

### DIFF
--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -280,6 +280,31 @@ usr2::clearpwd2`)}},
 				},
 			},
 		},
+		// 11
+		{
+			paths: []string{"/", "/admin"},
+			ann: map[string]map[string]string{
+				"/": {
+					ingtypes.BackAuthType:   "basic",
+					ingtypes.BackAuthSecret: "basicpwd",
+				},
+				"/admin": {
+					ingtypes.BackAuthType:   "basic",
+					ingtypes.BackAuthSecret: "basicpwd",
+				},
+			},
+			secrets: conv_helper.SecretContent{"default/basicpwd": {"auth": []byte(`usr1:encpwd1`)}},
+			expUserlists: []*hatypes.Userlist{{Name: "default_basicpwd", Users: []hatypes.User{
+				{Name: "usr1", Passwd: "encpwd1", Encrypted: true},
+			}}},
+			expConfig: []*hatypes.BackendConfigAuth{
+				{
+					Paths:        createBackendPaths("/", "/admin"),
+					UserlistName: "default_basicpwd",
+					Realm:        "localhost",
+				},
+			},
+		},
 	}
 
 	for i, test := range testCase {

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -224,6 +224,11 @@ func (c *config) AddUserlist(name string, users []hatypes.User) *hatypes.Userlis
 }
 
 func (c *config) FindUserlist(name string) *hatypes.Userlist {
+	for _, userlist := range c.userlists {
+		if userlist.Name == name {
+			return userlist
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
A basic auth's userlist can be reused if the same password secret is reused in more than one Ingress, or even on the same Ingress with two or more paths. The userlist was being duplicated due to a missing find func. This doesn't break the configuration because all the userlists have the same content and haproxy complains but doesn't refuse to start.