### PR TITLE
Only notifies ConfigMap updates if data changes

### DIFF
--- a/pkg/controller/listers.go
+++ b/pkg/controller/listers.go
@@ -352,8 +352,10 @@ func (l *listers) createConfigMapLister(informer informersv1.ConfigMapInformer) 
 			}
 		},
 		UpdateFunc: func(old, cur interface{}) {
-			if !reflect.DeepEqual(old, cur) {
-				if l.events.IsValidConfigMap(cur.(*api.ConfigMap)) {
+			curCM := cur.(*api.ConfigMap)
+			if l.events.IsValidConfigMap(curCM) {
+				oldCM := old.(*api.ConfigMap)
+				if !reflect.DeepEqual(oldCM.Data, curCM.Data) {
 					l.events.Notify(old, cur)
 				}
 			}


### PR DESCRIPTION
ConfigMap now can be used as the IngressClass' Parameters target. Because of that ConfigMaps in the controller namespace are also being watched. However other ConfigMaps that changes periodically was starting the ingress parsing - eg the cm used for leader election which is update every few seconds.

This update checks if a ConfigMap's data attribute was changed, otherwise a reconciliation isn't started.