### PR TITLE
Add SameSite cookie attribute

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -535,6 +535,7 @@ See also:
 | `session-cookie-keywords`       | `Backend` | `indirect nocache httponly` | v0.11 |
 | `session-cookie-name`           | `Backend` | `INGRESSCOOKIE`             |       |
 | `session-cookie-preserve`       | `Backend` | `false`                     | v0.12 |
+| `session-cookie-same-site`      | `Backend` | `false`                     | v0.12 |
 | `session-cookie-shared`         | `Backend` | `false`                     | v0.8  |
 | `session-cookie-strategy`       | `Backend` | `insert`                    |       |
 | `session-cookie-value-strategy` | `Backend` | `server-name`               | v0.12 |
@@ -547,6 +548,7 @@ Configure if HAProxy should maintain client requests to the same backend server.
 * `session-cookie-keywords`: additional options to the `cookie` option like `nocache`, `httponly`. For the sake of backwards compatibility the default is `indirect nocache httponly` if not declared and `strategy` is `insert`.
 * `session-cookie-name`: the name of the cookie. `INGRESSCOOKIE` is the default value if not declared.
 * `session-cookie-preserve`: indicates whether the session cookie will be set to `preserve` mode. If this mode is enabled, haproxy will allow backend servers to use a `Set-Cookie` HTTP header to emit their own persistence cookie value, meaning the backend servers have knowledge of which cookie value should route to which server. Since the cookie value is tightly coupled with a particular backend server in this scenario, this mode will cause dynamic updating to understand that it must keep the same cookie value associated with the same backend server. If this is disabled, dynamic updating is free to assign servers in a way that can make their cookie value no longer matching.
+* `session-cookie-same-site`: if `true`, adds the `SameSite=None; Secure` attributes, which configures the browser to send the persistence cookie with both cross-site and same-site requests. The default value is `false`, which means only same-site requests will send the persistence cookie.
 * `session-cookie-shared`: defines if the persistence cookie should be shared between all domains that uses this backend. Defaults to `false`. If `true` the `Set-Cookie` response will declare all the domains that shares this backend, indicating to the HTTP agent that all of them should use the same backend server.
 * `session-cookie-strategy`: the cookie strategy to use (insert, rewrite, prefix). `insert` is the default value if not declared.
 * `session-cookie-value-strategy`: the strategy to use to calculate the cookie value of a server (`server-name`, `pod-uid`). `server-name` is the default if not declared, and indicates that the cookie will be set based on the name defined in `backend-server-naming`. `pod-uid` indicates that the cookie will be set to the `UID` of the pod running the target server.
@@ -559,6 +561,7 @@ limitation was removed on v0.6.
 
 See also:
 
+* https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
 * https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#4-cookie
 * https://cbonte.github.io/haproxy-dconv/2.0/configuration.html#5.2-cookie
 * https://www.haproxy.com/blog/load-balancing-affinity-persistence-sticky-sessions-what-you-need-to-know/

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -67,6 +67,7 @@ func (c *updater) buildBackendAffinity(d *backData) {
 	d.backend.Cookie.Keywords = keywordsValue
 	d.backend.Cookie.Dynamic = d.mapper.Get(ingtypes.BackSessionCookieDynamic).Bool()
 	d.backend.Cookie.Preserve = d.mapper.Get(ingtypes.BackSessionCookiePreserve).Bool()
+	d.backend.Cookie.SameSite = d.mapper.Get(ingtypes.BackSessionCookieSameSite).Bool()
 	d.backend.Cookie.Shared = d.mapper.Get(ingtypes.BackSessionCookieShared).Bool()
 
 	cookieStrategy := d.mapper.Get(ingtypes.BackSessionCookieValue)

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -120,6 +120,7 @@ const (
 	BackSessionCookieKeywords  = "session-cookie-keywords"
 	BackSessionCookieName      = "session-cookie-name"
 	BackSessionCookiePreserve  = "session-cookie-preserve"
+	BackSessionCookieSameSite  = "session-cookie-same-site"
 	BackSessionCookieShared    = "session-cookie-shared"
 	BackSessionCookieStrategy  = "session-cookie-strategy"
 	BackSessionCookieValue     = "session-cookie-value-strategy"

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -87,6 +87,16 @@ func TestBackends(t *testing.T) {
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
+				b.Cookie.Name = "Ingress"
+				b.Cookie.Strategy = "insert"
+				b.Cookie.Keywords = "indirect nocache httponly"
+				b.Cookie.SameSite = true
+			},
+			expected: `
+    cookie Ingress insert attr SameSite=None secure indirect nocache httponly`,
+		},
+		{
+			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
 				config := hatypes.Cors{
 					Enabled:      true,
 					AllowOrigin:  "*",

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -641,6 +641,7 @@ type Cookie struct {
 	Name     string
 	Dynamic  bool
 	Preserve bool
+	SameSite bool
 	Shared   bool
 	Strategy string
 	Keywords string

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -565,6 +565,7 @@ backend {{ $backend.ID }}
 {{- $cookie := $backend.Cookie }}
     cookie {{ $cookie.Name }} {{ $cookie.Strategy }}
         {{- if $cookie.Preserve }} preserve{{ end }}
+        {{- if $cookie.SameSite }} attr SameSite=None secure{{ end }}
         {{- if $cookie.Keywords }} {{ $cookie.Keywords }}{{ end }}
         {{- if $cookie.Shared }}
             {{- range $hostname := $backend.Hostnames }} domain {{ $hostname }}{{ end }}


### PR DESCRIPTION
Add a configuration key to enable `SameSite=<Lax|None>` on persistence cookie attribute. This is a syntax sugar to add `attr SameSite=None secure` in the `session-cookie-keywords` configuration key.