### PR TITLE
Clear the crt expire gauge when full sync

### DIFF
--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -164,6 +164,10 @@ func (m *metrics) SetCertExpireDate(domain, cn string, notAfter *time.Time) {
 	m.certExpireGauge.WithLabelValues(domain, cn).Set(float64(notAfter.Unix()))
 }
 
+func (m *metrics) ClearCertExpire() {
+	m.certExpireGauge.Reset()
+}
+
 func (m *metrics) IncCertSigningMissing(domains string, success bool) {
 	m.certSigningCounter.WithLabelValues(domains, "missing", strconv.FormatBool(success)).Inc()
 }

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -402,6 +402,12 @@ func (i *instance) updateCertExpiring() {
 	// TODO move to dynupdate when dynamic crt update is implemented
 	hostsAdd := i.config.Hosts().ItemsAdd()
 	hostsDel := i.config.Hosts().ItemsDel()
+	if !i.config.Hosts().HasCommit() {
+		// TODO the time between this reset and finishing to repopulate the gauge would lead
+		// to incomplete data scraped by Prometheus. This however happens only when a full parsing
+		// happens - edit globals, edit default crt, invalid data comming from lister events
+		i.metrics.ClearCertExpire()
+	}
 	for hostname, oldHost := range hostsDel {
 		if oldHost.TLS.HasTLS() {
 			curHost, found := hostsAdd[hostname]

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -85,6 +85,12 @@ func (h *Hosts) Shrink() {
 func (h *Hosts) Commit() {
 	h.itemsAdd = map[string]*Host{}
 	h.itemsDel = map[string]*Host{}
+	h.hasCommit = true
+}
+
+// HasCommit ...
+func (h *Hosts) HasCommit() bool {
+	return h.hasCommit
 }
 
 // Changed ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -326,6 +326,7 @@ type Hosts struct {
 	items, itemsAdd, itemsDel map[string]*Host
 	//
 	sslPassthroughCount int
+	hasCommit           bool
 }
 
 // Host ...

--- a/pkg/types/helper_test/metricsmock.go
+++ b/pkg/types/helper_test/metricsmock.go
@@ -69,6 +69,10 @@ func (m *MetricsMock) UpdateSuccessful(success bool) {
 func (m *MetricsMock) SetCertExpireDate(domain, cn string, notAfter *time.Time) {
 }
 
+// ClearCertExpire ...
+func (m *MetricsMock) ClearCertExpire() {
+}
+
 // IncCertSigningMissing ...
 func (m *MetricsMock) IncCertSigningMissing(domains string, success bool) {
 }

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -31,6 +31,7 @@ type Metrics interface {
 	IncUpdateFull()
 	UpdateSuccessful(success bool)
 	SetCertExpireDate(domain, cn string, notAfter *time.Time)
+	ClearCertExpire()
 	IncCertSigningMissing(domains string, success bool)
 	IncCertSigningExpiring(domains string, success bool)
 	IncCertSigningOutdated(domains string, success bool)


### PR DESCRIPTION
A full syncing happens whenever a global configuration changes, the default crt is updated or, if for any reason the lister event sends invalid data or it cannot be successfully processed. Whenever this happens, domains that was removed in the mean time continue to populate the crt expire gauge.

This commit rebuilds the gauge if the haproxy config need to be rebuilt. Note that, although such clean ups shouldn't be very often, when they happen the gauge will have incomplete data during a very small amount of time.