### PR TITLE
Readd haproxy user in the docker image

### DIFF
--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -17,7 +17,8 @@ RUN apk --no-cache add socat openssl lua5.3 lua-socket dumb-init
 
 COPY . /
 
-RUN addgroup -g 1001 haproxy\
+RUN deluser haproxy\
+ && addgroup -g 1001 haproxy\
  && adduser -u 1001 -G haproxy -D -s /bin/false haproxy\
  && mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
  && chown -R haproxy:haproxy /etc/haproxy /var/lib/haproxy /var/run/haproxy\


### PR DESCRIPTION
The upstream `haproxy` images now have haproxy user with a distinct UID. We're now removing and adding the user again in order to preserve our old `1001` UID. Since this is a breaking change, we'll postpone to use the same `99` UID to the next release.