### PR TITLE
Fix reload failure if admin socket refuses connection

### DIFF
--- a/rootfs/haproxy-reload.sh
+++ b/rootfs/haproxy-reload.sh
@@ -37,8 +37,9 @@ set -e
 HAPROXY_SOCKET=/var/run/haproxy/admin.sock
 HAPROXY_STATE=/var/lib/haproxy/state-global
 if [ -S $HAPROXY_SOCKET ]; then
-    echo "show servers state" | socat $HAPROXY_SOCKET - > $HAPROXY_STATE
-else
+    echo "show servers state" | socat $HAPROXY_SOCKET - > /tmp/state && mv /tmp/state $HAPROXY_STATE
+fi
+if [ ! -s $HAPROXY_STATE ]; then
     echo "#" > $HAPROXY_STATE
 fi
 case "$1" in


### PR DESCRIPTION
The reload script uses the admin socket to read the current haproxy state, before reloading a new configuration. This state reading would fail the reload if the socket exists but is refusing connection, eg if haproxy has died.