### PR TITLE
Fix first conciliation if external haproxy is not running

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -131,6 +131,7 @@ func (hc *HAProxyController) configController() {
 		ReloadStrategy:    *hc.reloadStrategy,
 		MaxOldConfigFiles: *hc.maxOldConfigFiles,
 		SortEndpointsBy:   hc.cfg.SortEndpointsBy,
+		StopCh:            hc.stopCh,
 		ValidateConfig:    *hc.validateConfig,
 	}
 	hc.instance = haproxy.CreateInstance(hc.logger, instanceOptions)

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/acme"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/template"
@@ -45,6 +46,7 @@ type InstanceOptions struct {
 	Metrics           types.Metrics
 	ReloadStrategy    string
 	SortEndpointsBy   string
+	StopCh            chan struct{}
 	ValidateConfig    bool
 	// TODO Fake is used to skip real haproxy calls. Use a mock instead.
 	fake bool
@@ -461,6 +463,27 @@ func (i *instance) reloadEmbedded() error {
 
 func (i *instance) reloadExternal() error {
 	socket := i.config.Global().External.MasterSocket
+	if !i.up {
+		// first run, wait until the external haproxy is running
+		// and successfully listening to the master socket.
+		var j int
+		i.logger.Info("waiting for the external haproxy...")
+		for {
+			var err error
+			if _, err = hautils.HAProxyCommand(socket, nil, "show info"); err == nil {
+				break
+			}
+			j++
+			if j%10 == 0 {
+				i.logger.Info("cannot connect to the master socket '%s': %v", socket, err)
+			}
+			select {
+			case <-i.options.StopCh:
+				return fmt.Errorf("received sigterm")
+			case <-time.After(time.Second):
+			}
+		}
+	}
 	if _, err := hautils.HAProxyCommand(socket, nil, "reload"); err != nil {
 		return fmt.Errorf("error sending reload to master socket: %w", err)
 	}


### PR DESCRIPTION
The very first config conciliation might happen before haproxy is properly running and listening to its master socket. This can happen if eg the haproxy image should be download and the controller image is present. The first conciliation will now wait until the admin socket can successfully answer `show info`, and will only exit to the loop after send a command without error or if the controller receives a sigterm.