### PR TITLE
Create state file only if load-server-state is enabled

### DIFF
--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -450,8 +450,12 @@ func (i *instance) reload() error {
 }
 
 func (i *instance) reloadEmbedded() error {
+	state := "0"
+	if i.config.Global().LoadServerState {
+		state = "1"
+	}
 	// TODO Move all magic strings to a single place
-	out, err := exec.Command("/haproxy-reload.sh", i.options.ReloadStrategy, i.options.HAProxyCfgDir).CombinedOutput()
+	out, err := exec.Command("/haproxy-reload.sh", i.options.ReloadStrategy, i.options.HAProxyCfgDir, state).CombinedOutput()
 	outstr := string(out)
 	if len(outstr) > 0 {
 		i.logger.Warn("output from haproxy:\n%v", outstr)

--- a/rootfs/haproxy-reload.sh
+++ b/rootfs/haproxy-reload.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #
-# Copyright 2017 The Kubernetes Authors. All rights reserved.
+# Copyright 2021 The HAProxy Ingress Controller Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,15 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# A script to help with haproxy reloads. Needs sudo for :80.
 #
-# Receives the reload strategy as the first parameter:
-#  native <.cfg>
+# A script to help with haproxy reloads. Needs sudo if haproxy uses :80 / :443.
+#
+# ./haproxy-reload.sh <strategy> <cfg>
+#
+# <strategy>: `native`
 #    Uses native HAProxy soft restart. Running it for the first time starts
 #    HAProxy, each subsequent invocation will perform a soft-reload.
-#  reusesocket <.cfg>
+# <strategy>: `reusesocket` or any other string != `native`
 #    Pass the listening sockets to the new HAProxy process instead of
 #    rebinding them, allowing hitless reloads.
+#
+# <cfg>: configuration file or directory
 #
 # HAProxy options:
 #  -f config file
@@ -31,36 +35,29 @@
 #  -sf soft reload, wait for pids to finish handling requests
 #      send pids a resume signal if reload of new config fails
 #  -x get the listening sockets from the old HAProxy process
+#
 
 set -e
 
+PARAM_STRATEGY="$1"
+PARAM_CFG="$2"
+
 HAPROXY_SOCKET=/var/run/haproxy/admin.sock
 HAPROXY_STATE=/var/lib/haproxy/state-global
-if [ -S $HAPROXY_SOCKET ]; then
-    echo "show servers state" | socat $HAPROXY_SOCKET - > /tmp/state && mv /tmp/state $HAPROXY_STATE
+HAPROXY_PID=/var/run/haproxy/haproxy.pid
+OLD_PID=$(cat "$HAPROXY_PID" 2>/dev/null || :)
+
+if [ -S "$HAPROXY_SOCKET" ]; then
+    echo "show servers state" | socat "$HAPROXY_SOCKET" - > /tmp/state && mv /tmp/state "$HAPROXY_STATE"
 fi
-if [ ! -s $HAPROXY_STATE ]; then
-    echo "#" > $HAPROXY_STATE
+if [ ! -s "$HAPROXY_STATE" ]; then
+    echo "#" > "$HAPROXY_STATE"
 fi
-case "$1" in
-    native)
-        CONFIG="$2"
-        HAPROXY_PID=/var/run/haproxy/haproxy.pid
-        haproxy -f "$CONFIG" -p "$HAPROXY_PID" -D -sf $(cat "$HAPROXY_PID" 2>/dev/null || :)
-        ;;
-    reusesocket|multibinder)
-        # multibinder is now deprecated and, if used, is an alias to reusesocket
-        CONFIG="$2"
-        HAPROXY_PID=/var/run/haproxy/haproxy.pid
-        OLD_PID=$(cat "$HAPROXY_PID" 2>/dev/null || :)
-        if [ -S "$HAPROXY_SOCKET" ]; then
-            haproxy -f "$CONFIG" -p "$HAPROXY_PID" -D -sf $OLD_PID -x "$HAPROXY_SOCKET"
-        else
-            haproxy -f "$CONFIG" -p "$HAPROXY_PID" -D -sf $OLD_PID
-        fi
-        ;;
-    *)
-        echo "Unsupported reload strategy: $1"
-        exit 1
-        ;;
-esac
+
+# Any strategy != `native` means `reusesocket` or `multibinder`
+# If there isn't a unix socket (eg first start) fallback to native
+if [ "$PARAM_STRATEGY" != "native" ] && [ -S "$HAPROXY_SOCKET" ]; then
+    haproxy -f "$PARAM_CFG" -p "$HAPROXY_PID" -D -sf $OLD_PID -x "$HAPROXY_SOCKET"
+else
+    haproxy -f "$PARAM_CFG" -p "$HAPROXY_PID" -D -sf $OLD_PID
+fi


### PR DESCRIPTION
Save the current state might be a bit expensive if the configuration is very large. This update makes the reload script read the current state only if the state would be used later.