### PR TITLE
docs/metrics: Fix prometheus config

### DIFF
--- a/docs/content/en/docs/examples/metrics.md
+++ b/docs/content/en/docs/examples/metrics.md
@@ -31,7 +31,7 @@ The following patch adds ports `9105` and `10254` to the HAProxy Ingress contain
 Note: this patch will restart the controller!
 
 ```
-kubectl --namespace ingress-controller patch daemonset haproxy-ingress -p '{"spec":{"template":{"spec":{"containers":[{"name":"haproxy-ingress","ports":[{"name":"exporter","containerPort":9105},{"name":"ingress-stats","containerPort":10254}]}]}}}}'
+kubectl --namespace ingress-controller patch deployment haproxy-ingress -p '{"spec":{"template":{"spec":{"containers":[{"name":"haproxy-ingress","ports":[{"name":"exporter","containerPort":9105},{"name":"ingress-stats","containerPort":10254}]}]}}}}'
 ```
 
 ## Deploy Prometheus
@@ -44,6 +44,19 @@ kubectl create -f https://haproxy-ingress.github.io/docs/examples/metrics/promet
 
 {{% alert title="Note" %}}
 This deployment has no persistent volume, so all the collected metrics will be lost if the pod is recreated.
+{{% /alert %}}
+
+{{% alert title="Warning" color="warning" %}}
+If HAProxy Ingress wasn't deployed with Helm, change the following line in the `configmap/prometheus-cfg` resource, jobs `haproxy-ingress` and `haproxy-exporter`:
+
+```diff
+       relabel_configs:
+-      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
++      - source_labels: [__meta_kubernetes_pod_label_run]
+         regex: haproxy-ingress
+```
+
+This will ensure that Prometheus finds the controller pods.
 {{% /alert %}}
 
 Check if Prometheus is up and running:

--- a/docs/content/en/docs/examples/metrics/prometheus.yaml
+++ b/docs/content/en/docs/examples/metrics/prometheus.yaml
@@ -49,7 +49,7 @@ data:
           names:
           - ingress-controller
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_label_run]
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
         regex: haproxy-ingress
         action: keep
       - source_labels: [__meta_kubernetes_pod_container_port_number]
@@ -66,7 +66,7 @@ data:
       params:
         scope: [global,frontend,backend]
       relabel_configs:
-      - source_labels: [__meta_kubernetes_pod_label_run]
+      - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_instance]
         regex: haproxy-ingress
         action: keep
       - source_labels: [__meta_kubernetes_pod_container_port_number]


### PR DESCRIPTION
Metrics doc depends on the controller pod selector to allow Prometheus find the controller. Controller labels was changed when upgrading to Helm deployment. This update changes also the label used in the Prometheus config.