### PR TITLE
Update to networking.k8s.io/v1 api

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -207,7 +207,7 @@ remove old configuration files. If `0`, the default value, a single `haproxy.cfg
 Some infrastructure tools like `external-DNS` relay in the ingress status to created access routes to the services exposed with ingress object.
 
 ```
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 ...
 status:

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -103,7 +103,7 @@ command-line option. The annotation value spec expects a string as the key value
 declare numbers and booleans as strings, HAProxy Ingress will convert them when needed.
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -134,7 +134,7 @@ section [above](#annotation), with the benefit of allowing the reuse of the
 IngressClass+ConfigMap configuration.
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
   name: my-class
@@ -158,7 +158,7 @@ metadata:
 ```
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: app
@@ -183,7 +183,7 @@ Ingress resources can be fragmented in order to add distinct configurations
 to distinct routes. For example:
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: app-front
@@ -193,13 +193,16 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: frontend
-          servicePort: 8080
+          service:
+            name: frontend
+            port:
+              number: 8080
 ```
 
 ```yaml
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -211,9 +214,12 @@ spec:
     http:
       paths:
       - path: /api
+        pathType: Prefix
         backend:
-          serviceName: backend
-          servicePort: 8080
+          service:
+            name: backend
+            port:
+              number: 8080
 ```
 
 HAProxy Ingress will merge all the resources, so there is no difference if the

--- a/docs/content/en/docs/examples/blue-green.md
+++ b/docs/content/en/docs/examples/blue-green.md
@@ -79,7 +79,7 @@ Configure the ingress resource. No need to change the host below, `bluegreen.exa
 
 ```
 $ kubectl create -f - <<EOF
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -93,10 +93,13 @@ spec:
   - host: bluegreen.example.com
     http:
       paths:
-      - backend:
-          serviceName: bluegreen
-          servicePort: 8000
-        path: /
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: bluegreen
+            port:
+              number: 8000
 EOF
 ```
 

--- a/docs/content/en/docs/examples/metrics.md
+++ b/docs/content/en/docs/examples/metrics.md
@@ -92,7 +92,7 @@ Create the ingress which will expose Grafana. Change `HOST` below to a domain of
 ```
 HOST=grafana.192.168.1.1.nip.io
 kubectl create -f - <<EOF
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: grafana
@@ -102,10 +102,13 @@ spec:
   - host: $HOST
     http:
       paths:
-      - backend:
-          serviceName: grafana
-          servicePort: 3000
-        path: /
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: grafana
+            port:
+              number: 3000
   tls:
   - hosts:
     - $HOST

--- a/docs/content/en/docs/examples/metrics/whoami-ingress.yaml
+++ b/docs/content/en/docs/examples/metrics/whoami-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -10,10 +10,13 @@ spec:
   - host: whoami.localdomain
     http:
       paths:
-      - backend:
-          serviceName: whoami
-          servicePort: 8000
-        path: /
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: whoami
+            port:
+              number: 8000
   tls:
   - hosts:
     - whoami.localdomain

--- a/docs/content/en/docs/examples/modsecurity.md
+++ b/docs/content/en/docs/examples/modsecurity.md
@@ -86,7 +86,7 @@ No need to use a valid domain, `echo.domain` below is fine:
 
 ```console
 $ kubectl create -f - <<EOF
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -99,9 +99,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: echo
-          servicePort: 8080
+          service:
+            name: echo
+            port:
+              number: 8080
 EOF
 ```
 

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -94,7 +94,7 @@ Obs.: `nip.io` is a convenient service which converts a valid domain name to any
 ```shell
 $ HOST=echoserver.192.168.1.11.nip.io
 $ kubectl create -f - <<EOF
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -105,10 +105,13 @@ spec:
   - host: $HOST
     http:
       paths:
-      - backend:
-          serviceName: echoserver
-          servicePort: 8080
-        path: /
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: echoserver
+            port:
+              number: 8080
 EOF
 ```
 

--- a/examples/auth/oauth/app.yaml
+++ b/examples/auth/oauth/app.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -10,14 +10,20 @@ spec:
   - host: app.192.168.100.99.nip.io
     http:
       paths:
-      - backend:
-          serviceName: oauth2-proxy
-          servicePort: 4180
-        path: /oauth2
-      - backend:
-          serviceName: echoserver
-          servicePort: 8080
-        path: /
+      - path: /oauth2
+        pathType: Prefix
+        backend:
+          service:
+            name: oauth2-proxy
+            port:
+              number: 4180
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: echoserver
+            port:
+              number: 8080
   tls:
   - hosts:
     - app.192.168.100.99.nip.io

--- a/examples/blue-green/README.md
+++ b/examples/blue-green/README.md
@@ -73,7 +73,7 @@ Configure the ingress resource. No need to change the host below, `bluegreen.exa
 
 ```
 $ kubectl create -f - <<EOF
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -87,10 +87,13 @@ spec:
   - host: bluegreen.example.com
     http:
       paths:
-      - backend:
-          serviceName: bluegreen
-          servicePort: 8000
-        path: /
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: bluegreen
+            port:
+              number: 8000
 EOF
 ```
 

--- a/examples/deployment/README.md
+++ b/examples/deployment/README.md
@@ -107,7 +107,7 @@ From now the optional web app should be deployed. Deploy an ingress resource to 
 
 ```console
 $ kubectl --namespace=ingress-controller create -f - <<EOF
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: app
@@ -117,9 +117,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: http-svc
-          servicePort: 8080
+          service:
+            name: http-svc
+            port:
+              number: 8080
 EOF
 ```
 

--- a/examples/modsecurity/README.md
+++ b/examples/modsecurity/README.md
@@ -80,7 +80,7 @@ No need to use a valid domain, `echo.domain` below is fine:
 
 ```console
 $ kubectl create -f - <<EOF
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -93,9 +93,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: echo
-          servicePort: 8080
+          service:
+            name: echo
+            port:
+              number: 8080
 EOF
 ```
 

--- a/examples/multi-tls/ingress-multi-tls.yaml
+++ b/examples/multi-tls/ingress-multi-tls.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: app
@@ -15,13 +15,19 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: back-svc1
-          servicePort: 8080
+          service:
+            name: back-svc1
+            port:
+              number: 8080
   - host: bar.foo
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: back-svc2
-          servicePort: 8080
+          service:
+            name: back-svc2
+            port:
+              number: 8080

--- a/examples/tls-termination/ingress-tls-default.yaml
+++ b/examples/tls-termination/ingress-tls-default.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: app
@@ -11,6 +11,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: http-svc
-          servicePort: 8080
+          service:
+            name: http-svc
+            port:
+              number: 8080

--- a/examples/tls-termination/ingress-tls-foobar.yaml
+++ b/examples/tls-termination/ingress-tls-foobar.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: app
@@ -12,6 +12,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: http-svc
-          servicePort: 8080
+          service:
+            name: http-svc
+            port:
+              number: 8080

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -26,7 +26,7 @@ import (
 	"github.com/golang/glog"
 
 	apiv1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	clientset "k8s.io/client-go/kubernetes"
 	v1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -281,7 +281,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 	}
 
 	if *watchNamespace != "" {
-		_, err = kubeClient.NetworkingV1beta1().Ingresses(*watchNamespace).List(ctx, metav1.ListOptions{Limit: 1})
+		_, err = kubeClient.NetworkingV1().Ingresses(*watchNamespace).List(ctx, metav1.ListOptions{Limit: 1})
 		if err != nil {
 			glog.Fatalf("no watchNamespace with name %v found: %v", *watchNamespace, err)
 		}

--- a/pkg/common/ingress/controller/status.go
+++ b/pkg/common/ingress/controller/status.go
@@ -30,7 +30,7 @@ import (
 
 	pool "gopkg.in/go-playground/pool.v3"
 	apiv1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -350,7 +350,7 @@ func runUpdate(ctx context.Context, ing *networking.Ingress, status []apiv1.Load
 			return true, nil
 		}
 
-		ingClient := client.NetworkingV1beta1().Ingresses(ing.Namespace)
+		ingClient := client.NetworkingV1().Ingresses(ing.Namespace)
 
 		currIng, err := ingClient.Get(ctx, ing.Name, metav1.GetOptions{})
 		if err != nil {

--- a/pkg/common/ingress/types.go
+++ b/pkg/common/ingress/types.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/spf13/pflag"
 	apiv1 "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	"k8s.io/apiserver/pkg/server/healthz"
 )
 

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	api "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	k8s "k8s.io/client-go/kubernetes"

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -25,7 +25,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/spf13/pflag"
 	api "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/acme"

--- a/pkg/controller/listers.go
+++ b/pkg/controller/listers.go
@@ -22,15 +22,15 @@ import (
 	"time"
 
 	api "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/informers"
-	informersv1 "k8s.io/client-go/informers/core/v1"
-	informersv1beta1 "k8s.io/client-go/informers/networking/v1beta1"
+	informerscore "k8s.io/client-go/informers/core/v1"
+	informersnetworking "k8s.io/client-go/informers/networking/v1"
 	k8s "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
-	listersv1 "k8s.io/client-go/listers/core/v1"
-	listersv1beta1 "k8s.io/client-go/listers/networking/v1beta1"
+	listerscore "k8s.io/client-go/listers/core/v1"
+	listersnetworking "k8s.io/client-go/listers/networking/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
@@ -54,14 +54,14 @@ type listers struct {
 	hasPodLister  bool
 	hasNodeLister bool
 	//
-	ingressLister      listersv1beta1.IngressLister
-	ingressClassLister listersv1beta1.IngressClassLister
-	endpointLister     listersv1.EndpointsLister
-	serviceLister      listersv1.ServiceLister
-	secretLister       listersv1.SecretLister
-	configMapLister    listersv1.ConfigMapLister
-	podLister          listersv1.PodLister
-	nodeLister         listersv1.NodeLister
+	ingressLister      listersnetworking.IngressLister
+	ingressClassLister listersnetworking.IngressClassLister
+	endpointLister     listerscore.EndpointsLister
+	serviceLister      listerscore.ServiceLister
+	secretLister       listerscore.SecretLister
+	configMapLister    listerscore.ConfigMapLister
+	podLister          listerscore.PodLister
+	nodeLister         listerscore.NodeLister
 	//
 	ingressInformer      cache.SharedInformer
 	ingressClassInformer cache.SharedInformer
@@ -105,8 +105,8 @@ func createListers(
 		recorder: recorder,
 		logger:   logger,
 	}
-	l.createIngressLister(ingressInformer.Networking().V1beta1().Ingresses())
-	l.createIngressClassLister(ingressInformer.Networking().V1beta1().IngressClasses())
+	l.createIngressLister(ingressInformer.Networking().V1().Ingresses())
+	l.createIngressClassLister(ingressInformer.Networking().V1().IngressClasses())
 	l.createEndpointLister(resourceInformer.Core().V1().Endpoints())
 	l.createServiceLister(resourceInformer.Core().V1().Services())
 	l.createSecretLister(resourceInformer.Core().V1().Secrets())
@@ -168,7 +168,7 @@ func (l *listers) RunAsync(stopCh <-chan struct{}) {
 	}
 }
 
-func (l *listers) createIngressLister(informer informersv1beta1.IngressInformer) {
+func (l *listers) createIngressLister(informer informersnetworking.IngressInformer) {
 	l.ingressLister = informer.Lister()
 	l.ingressInformer = informer.Informer()
 	l.ingressInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -227,7 +227,7 @@ func (l *listers) createIngressLister(informer informersv1beta1.IngressInformer)
 	})
 }
 
-func (l *listers) createIngressClassLister(informer informersv1beta1.IngressClassInformer) {
+func (l *listers) createIngressClassLister(informer informersnetworking.IngressClassInformer) {
 	l.ingressClassLister = informer.Lister()
 	l.ingressClassInformer = informer.Informer()
 	l.ingressClassInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -262,7 +262,7 @@ func (l *listers) createIngressClassLister(informer informersv1beta1.IngressClas
 	})
 }
 
-func (l *listers) createEndpointLister(informer informersv1.EndpointsInformer) {
+func (l *listers) createEndpointLister(informer informerscore.EndpointsInformer) {
 	l.endpointLister = informer.Lister()
 	l.endpointInformer = informer.Informer()
 	l.endpointInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -282,7 +282,7 @@ func (l *listers) createEndpointLister(informer informersv1.EndpointsInformer) {
 	})
 }
 
-func (l *listers) createServiceLister(informer informersv1.ServiceInformer) {
+func (l *listers) createServiceLister(informer informerscore.ServiceInformer) {
 	l.serviceLister = informer.Lister()
 	l.serviceInformer = informer.Informer()
 	l.serviceInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -312,7 +312,7 @@ func (l *listers) createServiceLister(informer informersv1.ServiceInformer) {
 	})
 }
 
-func (l *listers) createSecretLister(informer informersv1.SecretInformer) {
+func (l *listers) createSecretLister(informer informerscore.SecretInformer) {
 	l.secretLister = informer.Lister()
 	l.secretInformer = informer.Informer()
 	l.secretInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -342,7 +342,7 @@ func (l *listers) createSecretLister(informer informersv1.SecretInformer) {
 	})
 }
 
-func (l *listers) createConfigMapLister(informer informersv1.ConfigMapInformer) {
+func (l *listers) createConfigMapLister(informer informerscore.ConfigMapInformer) {
 	l.configMapLister = informer.Lister()
 	l.configMapInformer = informer.Informer()
 	l.configMapInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -368,7 +368,7 @@ func (l *listers) createConfigMapLister(informer informersv1.ConfigMapInformer) 
 	})
 }
 
-func (l *listers) createPodLister(informer informersv1.PodInformer) {
+func (l *listers) createPodLister(informer informerscore.PodInformer) {
 	l.podLister = informer.Lister()
 	l.podInformer = informer.Informer()
 	l.podInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -385,7 +385,7 @@ func (l *listers) createPodLister(informer informersv1.PodInformer) {
 	})
 }
 
-func (l *listers) createNodeLister(informer informersv1.NodeInformer) {
+func (l *listers) createNodeLister(informer informerscore.NodeInformer) {
 	l.nodeLister = informer.Lister()
 	l.nodeInformer = informer.Informer()
 }

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	api "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 )

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	api "k8s.io/api/core/v1"
-	networking "k8s.io/api/networking/v1beta1"
+	networking "k8s.io/api/networking/v1"
 
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 )


### PR DESCRIPTION
This migration maps v1beta1 to v1 changes, without adding any new functionality:

- spec.backend to spec.defaultBackend
- backend.serviceName/Port to backend.service
- port (intOrStr) to port.name/number

Resource backend wasn't implemented.