### PR TITLE
Fix path precedence of distinct match types

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -1644,8 +1644,8 @@ See also:
 
 Defines how the path of an incoming request should match a declared path in the ingress object.
 
-* `path-type`: Configures the path type. Case insensitive, so `Begin` and `begin` configures the same path type option. The ingress spec has priority, this option will only be used if the `pathType` attribute from the ingress spec is declared as `ImplementationSpecific` or is not declared.
-* `path-type-order`: Defines a comma-separated list of priority path types. First types has higher precedence, which means that if two distinct paths of two distinct types overlaps, the first in the list will be used to handle the request. All path types must be provided. Case insensitive, use all path types in lowercase.
+* `path-type`: Configures the path type. Case insensitive, so `Begin` and `begin` configures the same path type option. The ingress spec has priority, this option will only be used if the `pathType` attribute from the ingress spec is declared as `ImplementationSpecific`.
+* `path-type-order`: Defines a comma-separated list of the order that non overlapping paths should be matched. The default order starts with `exact` which is the fastest match, and finishes with `regex` which is the slowest one. All path types must be provided. Case insensitive, use all path types in lowercase. In the case of overlapping paths, eg `/dir/sub` and `/dir`, the one with the highest precedence, `/dir/sub` in the example, will always be checked first despite its match type.
 
 {{% alert title="Warning" color="warning" %}}
 Wildcard hostnames and alias-regex match incoming requests using the regex path type, even if the path itself has a distinct one. Changing the precedence order of paths also changes the precedence order of hostnames. See also [server-alias-regex](#server-alias) and [strict host](#strict-host).

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -321,12 +321,9 @@ func (c *config) WriteBackendMaps() error {
 
 func writeMaps(maps *hatypes.HostsMaps, template *template.Config) error {
 	for _, hmap := range maps.Items {
-		for _, match := range hmap.UsedMatchTypes() {
-			filename, err := hmap.Filename(match)
-			if err != nil {
-				return err
-			}
-			if err := template.WriteOutput(hmap.BuildSortedValues(match), filename); err != nil {
+		for _, matchFile := range hmap.MatchFiles() {
+			filename := matchFile.Filename()
+			if err := template.WriteOutput(matchFile.Values(), filename); err != nil {
 				return err
 			}
 		}

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -160,10 +160,11 @@ func (c *config) WriteFrontendMaps() error {
 		TLSNeedCrtList:        mapBuilder.AddMap(mapsDir + "/_front_tls_needcrt.list"),
 		TLSInvalidCrtPagesMap: mapBuilder.AddMap(mapsDir + "/_front_tls_invalidcrt_pages.map"),
 		TLSMissingCrtPagesMap: mapBuilder.AddMap(mapsDir + "/_front_tls_missingcrt_pages.map"),
-		//
-		CrtList: mapBuilder.AddMap(mapsDir + "/_front_bind_crt.list"),
 	}
-	fmaps.CrtList.AppendItem(c.frontend.DefaultCrtFile + " !*")
+	// TODO crtList* to be removed after implement a template to the crt list
+	c.frontend.CrtListFile = mapsDir + "/_front_bind_crt.list"
+	var crtListItems []*hatypes.HostsMapEntry
+	crtListItems = append(crtListItems, &hatypes.HostsMapEntry{Key: c.frontend.DefaultCrtFile + " !*"})
 	hasVarNamespace := c.hosts.HasVarNamespace()
 	for _, host := range c.hosts.BuildSortedItems() {
 		if host.SSLPassthrough() {
@@ -272,8 +273,11 @@ func (c *config) WriteFrontendMaps() error {
 			} else {
 				crtListEntry = fmt.Sprintf("%s [%s] %s", crtFile, strings.Join(bindConf, " "), host.Hostname)
 			}
-			fmaps.CrtList.AppendItem(crtListEntry)
+			crtListItems = append(crtListItems, &hatypes.HostsMapEntry{Key: crtListEntry})
 		}
+	}
+	if err := c.options.mapsTemplate.WriteOutput(crtListItems, c.frontend.CrtListFile); err != nil {
+		return err
 	}
 	if err := writeMaps(mapBuilder, c.options.mapsTemplate); err != nil {
 		return err
@@ -317,11 +321,6 @@ func (c *config) WriteBackendMaps() error {
 
 func writeMaps(maps *hatypes.HostsMaps, template *template.Config) error {
 	for _, hmap := range maps.Items {
-		if f, err := hmap.Filename(hatypes.MatchEmpty); err == nil {
-			if err := template.WriteOutput(hmap.BuildSortedValues(hatypes.MatchEmpty), f); err != nil {
-				return err
-			}
-		}
 		for _, match := range hmap.UsedMatchTypes() {
 			filename, err := hmap.Filename(match)
 			if err != nil {

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -307,8 +307,8 @@ d1.local/api path02`,
     # path05 = d1.local/api/v[0-9]+/
     # path02 = d1.local/app
     # path04 = d1.local/path
-    http-request set-var(txn.pathID) var(req.base),map_str(/etc/haproxy/maps/_back_d1_app_8080_idpath__exact.map)
-    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_d1_app_8080_idpath__prefix.map) if !{ var(txn.pathID) -m found }
+    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_d1_app_8080_idpath__prefix_01.map)
+    http-request set-var(txn.pathID) var(req.base),map_str(/etc/haproxy/maps/_back_d1_app_8080_idpath__exact_02.map) if !{ var(txn.pathID) -m found }
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map) if !{ var(txn.pathID) -m found }
     http-request set-var(txn.pathID) var(req.base),map_reg(/etc/haproxy/maps/_back_d1_app_8080_idpath__regex.map) if !{ var(txn.pathID) -m found }
     acl allow_rule_src0 src 172.17.0.0/16
@@ -317,10 +317,10 @@ d1.local/api path02`,
     http-request deny if { var(txn.pathID) path02 path03 path04 path05 } !allow_rule_src1`,
 			expFronts: "<<frontends-default-match-4>>",
 			expCheck: map[string]string{
-				"_back_d1_app_8080_idpath__exact.map": `
-d1.local/app path02`,
-				"_back_d1_app_8080_idpath__prefix.map": `
+				"_back_d1_app_8080_idpath__prefix_01.map": `
 d1.local/path path04`,
+				"_back_d1_app_8080_idpath__exact_02.map": `
+d1.local/app path02`,
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local/api path03
 d1.local/ path01`,
@@ -3430,8 +3430,8 @@ func (c *testConfig) checkConfigFile(expected, fileName string) {
     bind :80
     <<set-req-base>>
     <<http-headers>>
-    http-request set-var(req.backend) var(req.base),map_str(/etc/haproxy/maps/_front_http_host__exact.map)
-    http-request set-var(req.backend) var(req.base),map_dir(/etc/haproxy/maps/_front_http_host__prefix.map) if !{ var(req.backend) -m found }
+    http-request set-var(req.backend) var(req.base),map_dir(/etc/haproxy/maps/_front_http_host__prefix_01.map)
+    http-request set-var(req.backend) var(req.base),map_str(/etc/haproxy/maps/_front_http_host__exact_02.map) if !{ var(req.backend) -m found }
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map) if !{ var(req.backend) -m found }
     http-request set-var(req.backend) var(req.base),map_reg(/etc/haproxy/maps/_front_http_host__regex.map) if !{ var(req.backend) -m found }
     use_backend %[var(req.backend)] if { var(req.backend) -m found }`,
@@ -3454,8 +3454,8 @@ func (c *testConfig) checkConfigFile(expected, fileName string) {
     mode http
     bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_bind_crt.list ca-ignore-err all crt-ignore-err all
     <<set-req-base>>
-    http-request set-var(req.hostbackend) var(req.base),map_str(/etc/haproxy/maps/_front_https_host__exact.map)
-    http-request set-var(req.hostbackend) var(req.base),map_dir(/etc/haproxy/maps/_front_https_host__prefix.map) if !{ var(req.hostbackend) -m found }
+    http-request set-var(req.hostbackend) var(req.base),map_dir(/etc/haproxy/maps/_front_https_host__prefix_01.map)
+    http-request set-var(req.hostbackend) var(req.base),map_str(/etc/haproxy/maps/_front_https_host__exact_02.map) if !{ var(req.hostbackend) -m found }
     http-request set-var(req.hostbackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_host__begin.map) if !{ var(req.hostbackend) -m found }
     http-request set-var(req.hostbackend) var(req.base),map_reg(/etc/haproxy/maps/_front_https_host__regex.map) if !{ var(req.hostbackend) -m found }
     <<https-headers>>

--- a/pkg/haproxy/types/maps.go
+++ b/pkg/haproxy/types/maps.go
@@ -219,15 +219,6 @@ func (hm *HostsMap) BuildSortedValues(match MatchType) []*HostsMapEntry {
 	return hm.values[match]
 }
 
-// AppendItem ...
-func (hm *HostsMap) AppendItem(item string) {
-	values := hm.values[MatchEmpty]
-	values = append(values, &HostsMapEntry{
-		Key: item,
-	})
-	hm.values[MatchEmpty] = values
-}
-
 // HasHost ...
 func (hm *HostsMap) HasHost() bool {
 	for _, values := range hm.values {
@@ -293,11 +284,7 @@ func (hm *HostsMap) Filename(match MatchType) (string, error) {
 	}
 	filename, found := hm.filenames[match]
 	if !found {
-		if match == MatchEmpty {
-			filename = hm.basename
-		} else {
-			filename = strings.Replace(hm.basename, ".", "__"+string(match)+".", 1)
-		}
+		filename = strings.Replace(hm.basename, ".", "__"+string(match)+".", 1)
 		hm.filenames[match] = filename
 	}
 	return filename, nil
@@ -321,11 +308,6 @@ func (hm *HostsMap) FilenamePrefix() (string, error) {
 // FilenameRegex ...
 func (hm *HostsMap) FilenameRegex() (string, error) {
 	return hm.Filename(MatchRegex)
-}
-
-// FilenameEmpty ...
-func (hm *HostsMap) FilenameEmpty() (string, error) {
-	return hm.Filename(MatchEmpty)
 }
 
 func (he *HostsMapEntry) String() string {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"container/list"
 	"time"
 )
 
@@ -270,16 +271,32 @@ type TCPProxyProt struct {
 type HostsMapEntry struct {
 	hostname string
 	path     string
+	match    MatchType
+	_upper   *list.Element
+	_elem    *list.Element
 	Key      string
 	Value    string
+}
+
+type hostsMapMatchFile struct {
+	entries []*HostsMapEntry
+	match   MatchType
+}
+
+// MatchFile ...
+type MatchFile struct {
+	matchFile *hostsMapMatchFile
+	filename  string
+	first     bool
 }
 
 // HostsMap ...
 type HostsMap struct {
 	basename   string
-	filenames  map[MatchType]string
-	values     map[MatchType][]*HostsMapEntry
 	matchOrder []MatchType
+	matchFiles []*MatchFile
+	rawhosts   map[string][]*HostsMapEntry
+	rawfiles   map[MatchType]*hostsMapMatchFile
 }
 
 // HostsMaps ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -302,8 +302,6 @@ type FrontendMaps struct {
 	TLSNeedCrtList        *HostsMap
 	TLSInvalidCrtPagesMap *HostsMap
 	TLSMissingCrtPagesMap *HostsMap
-	//
-	CrtList *HostsMap
 }
 
 // Frontend ...
@@ -316,6 +314,7 @@ type Frontend struct {
 	//
 	DefaultCrtFile string
 	DefaultCrtHash string
+	CrtListFile    string
 }
 
 // DefaultHost ...
@@ -358,9 +357,6 @@ const (
 	MatchExact  = MatchType("exact")
 	MatchPrefix = MatchType("prefix")
 	MatchRegex  = MatchType("regex")
-	//
-	// IMPLEMENT a temp and partially supported match to configure crt-list
-	MatchEmpty = MatchType("")
 )
 
 // DefaultMatchOrder ...

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -981,7 +981,7 @@ frontend _front_https
         {{- if $frontend.BindID }} id {{ $frontend.BindID }}{{ end }}
         {{- if $frontend.AcceptProxy }} accept-proxy{{ end }}
         {{- "" }} ssl alpn {{ $global.SSL.ALPN }}
-        {{- "" }} crt-list {{ $fmaps.CrtList.FilenameEmpty }}
+        {{- "" }} crt-list {{ $frontend.CrtListFile }}
         {{- "" }} ca-ignore-err all crt-ignore-err all
 {{- end }}
 

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -404,7 +404,7 @@ backend {{ $backend.ID }}
 {{- range $path := $backend.Paths }}
     # {{ $path.ID }} = {{ $path.Hostname }}{{ $path.Path }}
 {{- end }}
-{{- range $match := $backend.PathsMap.MatchTypes }}
+{{- range $match := $backend.PathsMap.MatchFiles }}
     http-request set-var(txn.pathID) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
@@ -843,7 +843,7 @@ listen _front__tls
     tcp-request inspect-delay 5s
 
 {{- /*------------------------------------*/}}
-{{- range $match := $fmaps.SSLPassthroughMap.MatchTypes }}
+{{- range $match := $fmaps.SSLPassthroughMap.MatchFiles }}
     tcp-request content set-var(req.sslpassback) req.ssl_sni,lower
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if not $match.First }} if !{ var(req.sslpassback) -m found }{{ end }}
@@ -908,7 +908,7 @@ frontend _front_http
 {{- /*------------------------------------*/}}
 {{- $acmeexclusive := and $global.Acme.Enabled (not $global.Acme.Shared) }}
 {{- if $fmaps.RedirFromRootMap.HasHost }}
-{{- range $match := $fmaps.RedirFromRootMap.MatchTypes }}
+{{- range $match := $fmaps.RedirFromRootMap.MatchFiles }}
     http-request set-var(req.rootredir) var(req.host)
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if not $match.First }} if !{ var(req.rootredir) -m found }{{ end }}
@@ -920,7 +920,7 @@ frontend _front_http
 
 {{- /*------------------------------------*/}}
 {{- if $fmaps.VarNamespaceMap.HasHost }}
-{{- range $match := $fmaps.VarNamespaceMap.MatchTypes }}
+{{- range $match := $fmaps.VarNamespaceMap.MatchFiles }}
     http-request set-var(txn.namespace) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
@@ -945,7 +945,7 @@ frontend _front_http
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- range $match := $fmaps.HTTPHostMap.MatchTypes }}
+{{- range $match := $fmaps.HTTPHostMap.MatchFiles }}
     http-request set-var(req.backend) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
@@ -995,14 +995,14 @@ frontend _front_https
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $fmaps.RedirFromRootMap.HasHost $fmaps.HTTPSHostMap.HasHost $fmaps.HTTPSSNIMap.HasHost $fmaps.TLSAuthList.HasHost $fmaps.TLSNeedCrtList.MatchTypes $fmaps.VarNamespaceMap.HasHost }}
+{{- if or $fmaps.RedirFromRootMap.HasHost $fmaps.HTTPSHostMap.HasHost $fmaps.HTTPSSNIMap.HasHost $fmaps.TLSAuthList.HasHost $fmaps.TLSNeedCrtList.HasHost $fmaps.VarNamespaceMap.HasHost }}
     http-request set-var(req.path) path
     http-request set-var(req.host) hdr(host),regsub(:[0-9]+$,),lower
     http-request set-var(req.base) var(req.host),concat(,req.path)
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- range $match := $fmaps.HTTPSHostMap.MatchTypes }}
+{{- range $match := $fmaps.HTTPSHostMap.MatchFiles }}
     http-request set-var(req.hostbackend) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
         {{- ""}},map_{{ $match.Method }}({{ $match.Filename }})
@@ -1011,7 +1011,7 @@ frontend _front_https
 
 {{- /*------------------------------------*/}}
 {{- if $fmaps.RedirFromRootMap.HasHost }}
-{{- range $match := $fmaps.RedirFromRootMap.MatchTypes }}
+{{- range $match := $fmaps.RedirFromRootMap.MatchFiles }}
     http-request set-var(req.rootredir) var(req.host)
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if not $match.First }} if !{ var(req.rootredir) -m found }{{ end }}
@@ -1021,7 +1021,7 @@ frontend _front_https
 
 {{- /*------------------------------------*/}}
 {{- if $fmaps.VarNamespaceMap.HasHost }}
-{{- range $match := $fmaps.VarNamespaceMap.MatchTypes }}
+{{- range $match := $fmaps.VarNamespaceMap.MatchFiles }}
     http-request set-var(txn.namespace) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
@@ -1044,29 +1044,29 @@ frontend _front_https
     acl tls-has-crt ssl_c_used
 
 {{- if $mandatory }}
-{{- range $match := $fmaps.TLSNeedCrtList.MatchTypes }}
+{{- range $match := $fmaps.TLSNeedCrtList.MatchFiles }}
     acl tls-need-crt ssl_fc_sni -i -m {{ $match.Method }} -f {{ $match.Filename }}
 {{- end }}
 {{- end }}
 
-{{- range $match := $fmaps.TLSNeedCrtList.MatchTypes }}
+{{- range $match := $fmaps.TLSNeedCrtList.MatchFiles }}
     acl tls-host-need-crt var(req.host) -i -m {{ $match.Method }} -f {{ $match.Filename }}
 {{- end }}
     acl tls-has-invalid-crt ssl_c_ca_err gt 0
     acl tls-has-invalid-crt ssl_c_err gt 0
-{{- range $match := $fmaps.TLSAuthList.MatchTypes }}
+{{- range $match := $fmaps.TLSAuthList.MatchFiles }}
     acl tls-check-crt ssl_fc_sni -i -m {{ $match.Method }} -f {{ $match.Filename }}
 {{- end }}
 
 {{- if $fmaps.HTTPSSNIMap.HasHost }}
     http-request set-var(req.snibase) ssl_fc_sni,lower,concat(,req.path)
-{{- range $match := $fmaps.HTTPSSNIMap.MatchTypes }}
+{{- range $match := $fmaps.HTTPSSNIMap.MatchFiles }}
     http-request set-var(req.snibackend) var(req.snibase)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if not $match.First }} if !{ var(req.snibackend) -m found }{{ end }}
 {{- end }}
-{{- range $match := $fmaps.HTTPSSNIMap.MatchTypes }}
+{{- range $match := $fmaps.HTTPSSNIMap.MatchFiles }}
     http-request set-var(req.snibackend) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
@@ -1079,7 +1079,7 @@ frontend _front_https
 {{- if not $fmaps.TLSMissingCrtPagesMap.HasHost }}
     http-request set-var(req.tls_nocrt_redir) str(_internal) if !tls-has-crt tls-need-crt
 {{- end }}
-{{- range $match := $fmaps.TLSMissingCrtPagesMap.MatchTypes }}
+{{- range $match := $fmaps.TLSMissingCrtPagesMap.MatchFiles }}
     http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }},_internal) if
         {{- if $match.First }} !tls-has-crt tls-need-crt
@@ -1090,7 +1090,7 @@ frontend _front_https
 {{- if not $fmaps.TLSInvalidCrtPagesMap.HasHost }}
     http-request set-var(req.tls_invalidcrt_redir) str(_internal) if tls-has-invalid-crt tls-check-crt
 {{- end }}
-{{- range $match := $fmaps.TLSInvalidCrtPagesMap.MatchTypes }}
+{{- range $match := $fmaps.TLSInvalidCrtPagesMap.MatchFiles }}
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }},_internal) if
         {{- if $match.First }} tls-has-invalid-crt tls-check-crt


### PR DESCRIPTION
All hostnames and path matches, used eg to select a backend, uses haproxy's map to increase performance on clusters with hundreds of distinct hostnames+paths. This however doesn't work very well if paths of distinct match types are used - there is one map converter per match type and the configuration was classifying paths only under the same map file.

This commit checks path overlap of distinct match types and creates new map files if a precedence should be enforced. The config file and map files lay out remain the same if there isn't overlap or if they happen under the same match type.

Should be merged down to v0.11 when path types was first implemented.