### PR TITLE
Add dynamic update of frontend's tls certificate

### DIFF
--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -123,6 +123,10 @@ func (m *metrics) HAProxySetServerResponseTime(duration time.Duration) {
 	m.responseTime.WithLabelValues("set_server").Observe(duration.Seconds())
 }
 
+func (m *metrics) HAProxySetSSLCertResponseTime(duration time.Duration) {
+	m.responseTime.WithLabelValues("set_ssl_cert").Observe(duration.Seconds())
+}
+
 func (m *metrics) ControllerProcTime(task string, duration time.Duration) {
 	m.ctlProcTimeSum.WithLabelValues(task).Add(duration.Seconds())
 	m.ctlProcCount.WithLabelValues(task).Inc()

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -47,7 +47,7 @@ func TestDynUpdate(t *testing.T) {
 				c.config.Global().MaxConn = 1
 			},
 			dynamic: false,
-			logging: `INFO-V(2) diff outside backends: [global]`,
+			logging: `INFO-V(2) need to reload due to config changes: [global]`,
 		},
 		// 2
 		{
@@ -147,7 +147,9 @@ set server default_app_8080/srv001 weight 1`,
 				"srv008:127.0.0.1:1023:1",
 			},
 			dynamic: false,
-			logging: `INFO-V(2) added endpoints on backend 'default_app_8080'`,
+			logging: `
+INFO-V(2) added endpoints on backend 'default_app_8080'
+INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 6
 		{
@@ -364,7 +366,9 @@ INFO-V(2) disabled endpoint '172.17.0.4:8080' on backend/server 'default_app_808
 				"srv007:127.0.0.1:1023:1",
 			},
 			dynamic: false,
-			logging: `INFO-V(2) added endpoints on backend 'default_app_8080'`,
+			logging: `
+INFO-V(2) added endpoints on backend 'default_app_8080'
+INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 13
 		{
@@ -418,7 +422,9 @@ set server default_app_8080/srv002 weight 1
 			},
 			dynamic: false,
 			cmd:     ``,
-			logging: `INFO-V(2) added endpoints on backend 'default_app_8080'`,
+			logging: `
+INFO-V(2) added endpoints on backend 'default_app_8080'
+INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 15
 		{
@@ -430,7 +436,9 @@ set server default_app_8080/srv002 weight 1
 			},
 			dynamic: false,
 			cmd:     ``,
-			logging: `INFO-V(2) added backend 'default_app_8080'`,
+			logging: `
+INFO-V(2) added backend 'default_app_8080'
+INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 16
 		{
@@ -447,7 +455,9 @@ set server default_app_8080/srv002 weight 1
 			},
 			dynamic: false,
 			cmd:     ``,
-			logging: `INFO-V(2) added backend 'default_app_8080'`,
+			logging: `
+INFO-V(2) added backend 'default_app_8080'
+INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 17
 		{
@@ -495,7 +505,9 @@ set server default_app_8080/srv002 weight 1`,
 set server default_app_8080/srv002 addr 172.17.0.4 port 8080
 set server default_app_8080/srv002 state ready
 set server default_app_8080/srv002 weight 1`,
-			logging: `INFO-V(2) added endpoint '172.17.0.4:8080' weight '1' state 'ready' on backend/server 'default_app_8080/srv002'`,
+			logging: `
+INFO-V(2) added endpoint '172.17.0.4:8080' weight '1' state 'ready' on backend/server 'default_app_8080/srv002'
+INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 19
 		{
@@ -518,7 +530,9 @@ set server default_app_8080/srv002 weight 1`,
 set server default_app_8080/srv002 state maint
 set server default_app_8080/srv002 addr 127.0.0.1 port 1023
 set server default_app_8080/srv002 weight 0`,
-			logging: `INFO-V(2) disabled endpoint '172.17.0.3:8080' on backend/server 'default_app_8080/srv002'`,
+			logging: `
+INFO-V(2) disabled endpoint '172.17.0.3:8080' on backend/server 'default_app_8080/srv002'
+INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 20
 		{
@@ -542,7 +556,9 @@ set server default_app_8080/srv002 weight 0`,
 set server default_app_8080/srv002 addr 172.17.0.4 port 8080
 set server default_app_8080/srv002 state ready
 set server default_app_8080/srv002 weight 1`,
-			logging: `INFO-V(2) updated endpoint '172.17.0.4:8080' weight '1' state 'ready' on backend/server 'default_app_8080/srv002'`,
+			logging: `
+INFO-V(2) updated endpoint '172.17.0.4:8080' weight '1' state 'ready' on backend/server 'default_app_8080/srv002'
+INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 21
 		{
@@ -561,7 +577,9 @@ set server default_app_8080/srv002 weight 1`,
 				"srv001:172.17.0.3:8080:1",
 			},
 			dynamic: false,
-			logging: `INFO-V(2) backend 'default_app_8080' changed and its dynamic-scaling is 'false'`,
+			logging: `
+INFO-V(2) backend 'default_app_8080' changed and its dynamic-scaling is 'false'
+INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 22
 		{
@@ -675,7 +693,7 @@ set server default_app_8080/srv002 weight 1
 			},
 			dynamic: false,
 			cmd:     ``,
-			logging: ``,
+			logging: `INFO-V(2) need to reload due to config changes: [backends]`,
 		},
 		// 25 - test that we're able to update when a cookie value of acquired
 		// existing endpoint doesn't match and "preserve" cookie mode is not enabled

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -279,6 +279,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 			return
 		}
 	}
+	i.updateCertExpiring()
 	if updated {
 		if updater.cmdCnt > 0 {
 			if i.options.ValidateConfig {
@@ -297,7 +298,6 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 		}
 		return
 	}
-	i.updateCertExpiring()
 	i.metrics.IncUpdateFull()
 	if err := i.reload(); err != nil {
 		i.logger.Error("error reloading server:\n%v", err)
@@ -401,7 +401,6 @@ func (i *instance) writeConfig() (err error) {
 }
 
 func (i *instance) updateCertExpiring() {
-	// TODO move to dynupdate when dynamic crt update is implemented
 	hostsAdd := i.config.Hosts().ItemsAdd()
 	hostsDel := i.config.Hosts().ItemsDel()
 	if !i.config.Hosts().HasCommit() {

--- a/pkg/types/helper_test/metricsmock.go
+++ b/pkg/types/helper_test/metricsmock.go
@@ -40,6 +40,10 @@ func (m *MetricsMock) HAProxyShowInfoResponseTime(duration time.Duration) {
 func (m *MetricsMock) HAProxySetServerResponseTime(duration time.Duration) {
 }
 
+// HAProxySetSSLCertResponseTime ...
+func (m *MetricsMock) HAProxySetSSLCertResponseTime(duration time.Duration) {
+}
+
 // ControllerProcTime ...
 func (m *MetricsMock) ControllerProcTime(task string, duration time.Duration) {
 

--- a/pkg/types/metrics.go
+++ b/pkg/types/metrics.go
@@ -24,6 +24,7 @@ import (
 type Metrics interface {
 	HAProxyShowInfoResponseTime(duration time.Duration)
 	HAProxySetServerResponseTime(duration time.Duration)
+	HAProxySetSSLCertResponseTime(duration time.Duration)
 	ControllerProcTime(task string, duration time.Duration)
 	AddIdleFactor(idle int)
 	IncUpdateNoop()


### PR DESCRIPTION
Evolve dynupdate to recognize changes to the frontend's TLS certificate and apply it using the runtime api. The update also happens even if was detected that a reload should also be performed, so the configuration will be as updated as possible if for any reason the reload fails.

This code updates the minimal HAProxy version to 2.2. HAProxy 2.1 also implements TLS cert update, but this version cannot update crt-lists with filters - which we use in the default certificate.