### PR TITLE
Read the whole input when the response fills the buffer

### DIFF
--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -480,7 +480,7 @@ func (i *instance) reloadExternal() error {
 		i.logger.Info("waiting for the external haproxy...")
 		for {
 			var err error
-			if _, err = hautils.HAProxyCommand(socket, nil, "show info"); err == nil {
+			if _, err = hautils.HAProxyCommand(socket, nil, "show proc"); err == nil {
 				break
 			}
 			j++

--- a/pkg/haproxy/utils/utils.go
+++ b/pkg/haproxy/utils/utils.go
@@ -113,8 +113,8 @@ func HAProxyProcs(masterSocket string) (*ProcTable, error) {
 
 // buildProcTable parses `show proc` output and creates a corresponding ProcTable
 //
-//                   1               3               4               6               8               8
-//   0.......|.......6.......|.......2.......|.......8.......|.......4.......|.......0.......|.......8
+//                   1               3               4               6               8               9
+//   0.......|.......6.......|.......2.......|.......8.......|.......4.......|.......0.......|.......6
 //   #<PID>          <type>          <relative PID>  <reloads>       <uptime>        <version>
 //   1               master          0               2               0d00h01m28s     2.2.3-0e58a34
 //   # workers
@@ -129,6 +129,13 @@ func buildProcTable(procOutput string) *ProcTable {
 		return i
 	}
 	cut := func(s string, i, j int) string {
+		l := len(s)
+		if i >= l {
+			return ""
+		}
+		if j >= l {
+			j = l - 1
+		}
 		v := strings.TrimSpace(s[i:j])
 		if strings.HasPrefix(v, "[") {
 			return v[6 : len(v)-1] // `[was: 1]`

--- a/pkg/haproxy/utils/utils_test.go
+++ b/pkg/haproxy/utils/utils_test.go
@@ -135,6 +135,21 @@ func TestHAProxyProcs(t *testing.T) {
 				},
 			},
 		},
+		// 7
+		{
+			cmdOutput: []string{`#<PID>          <type>          <relative PID>  <reloads>       <uptime>        <version>
+1001            master          0               1128            0d00h02m28s     2.2.3-0e58a34
+# workers
+3115            worker          1001            11              0d00h00m00s     2.2.3-0e58a34
+3116            worker          1002  `},
+			expOutput: &ProcTable{
+				Master: Proc{Type: "master", PID: 1001, RPID: 0, Reloads: 1128},
+				Workers: []Proc{
+					{Type: "worker", PID: 3115, RPID: 1001, Reloads: 11},
+					{Type: "worker", PID: 3116, RPID: 1002, Reloads: 0},
+				},
+			},
+		},
 	}
 	for i, test := range testCases {
 		c := setup(t)

--- a/pkg/haproxy/utils/utils_test.go
+++ b/pkg/haproxy/utils/utils_test.go
@@ -24,6 +24,20 @@ import (
 	"time"
 )
 
+func TestHAProxyCommand(t *testing.T) {
+	// needs a running HAProxy and admin socket at /tmp/h.sock
+	// also, it will output the response in the error pipe, so will always fail
+	// TODO create a test and temp server where HAProxyCommand can connect to
+	/*
+		out, err := HAProxyCommand("/tmp/h.sock", nil, "show info")
+		if err != nil {
+			t.Errorf("%v", err)
+		} else {
+			t.Errorf("%d %v", len(out[0]), out[0])
+		}
+	*/
+}
+
 func TestHAProxyProcs(t *testing.T) {
 	testCases := []struct {
 		cmdOutput []string


### PR DESCRIPTION
HAProxy responses has just a few bytes, usually saying that a backend server was successfully updated. A 1k buffer is just enough to handle such responses. Since the external process implementation, one of the responses has a list of all running procs, which will easily fill that buffer depending on the number of old workers alive. These updates:

* continue reading the buffer up to the last byte.
* validate the length of incoming response, leading to zeroes or empties if truncated - instead of crash
