### PR TITLE
Remove unix socket before start acme server

### DIFF
--- a/pkg/acme/server.go
+++ b/pkg/acme/server.go
@@ -69,6 +69,9 @@ func (s *server) Listen(stopCh chan struct{}) error {
 		s.logger.Info("acme: request token: domain=%s uri=%s", host, uri)
 	})
 	s.server = &http.Server{Addr: s.socket, Handler: handler}
+	if err := os.Remove(s.server.Addr); err != nil && !os.IsNotExist(err) {
+		s.logger.Warn("error removing an existent acme socket: %v", err)
+	}
 	l, err := net.Listen("unix", s.server.Addr)
 	if err != nil {
 		return err


### PR DESCRIPTION
An unix socket is used to answer acme challenges - it is create whenever --acme-server command-line is enabled. However it isn't removed if haproxy ingress is abruptly stopped, eg when a crash occurs. Since v0.12 an external volume is created if haproxy is running as a sidecar, leaving the unix socket file alive between restarts, causing a crashloop in the controller if the acme server is enabled. This update ensures that the unix socket file isn't present when the server is started