### PR TITLE
Fix initial weight configuration

### DIFF
--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -648,7 +648,6 @@ func (c *converter) addBackendWithClass(source *annotations.Source, hostname, ur
 			Type:      "service",
 		}, pathlink, ann)
 		c.backendAnnotations[backend] = mapper
-		backend.Server.InitialWeight = mapper.Get(ingtypes.BackInitialWeight).Int()
 	}
 	// Merging Ingress annotations
 	conflict := mapper.AddAnnotations(source, pathlink, ann)
@@ -669,6 +668,7 @@ func (c *converter) addBackendWithClass(source *annotations.Source, hostname, ur
 	}
 	// Configure endpoints
 	if !found {
+		backend.Server.InitialWeight = mapper.Get(ingtypes.BackInitialWeight).Int()
 		switch mapper.Get(ingtypes.BackBackendServerNaming).Value {
 		case "ip":
 			backend.EpNaming = hatypes.EpIPPort


### PR DESCRIPTION
Weights can be used to distribute distinct load to distinct servers in the same backend. An initial value greater the default 1 (one) can be configured so agents that changes server weight can properly work and adjust the weight in lower granularity.

The initial weight configuration isn't properly working when declared in the ingress resource because its usage occurs before the value is actually read from the ingress annotation. It works however when declared in the service - service has priority and is read in the same block the backend is created and configured with initial weight and other defaults. Moving down the reading just before starting the endpoint configuration fixes this.