### PR TITLE
Fix incorrect reload if endpoint list grows

### DIFF
--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -151,6 +151,13 @@ func (d *dynUpdater) checkBackendPair(pair *backendPair) bool {
 
 	// Resolver == update via DNS discovery
 	if curBack.Resolver != "" {
+		if updated {
+			// DNS based updates finishes prematurelly. Ensure the ep
+			// list size of the new one is at least as big as the old one.
+			for i := len(curBack.Endpoints); i < len(oldBack.Endpoints); i++ {
+				curBack.AddEmptyEndpoint()
+			}
+		}
 		return updated
 	}
 

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -749,6 +749,26 @@ set server default_app_8080/srv001 state ready
 set server default_app_8080/srv001 weight 1`,
 			logging: `INFO-V(2) updated endpoint '172.17.0.3:8080' weight '1' state 'ready' on backend/server 'default_app_8080/srv001'`,
 		},
+		// 27
+		{
+			doconfig1: func(c *testConfig) {
+				b := c.config.Backends().AcquireBackend("default", "app", "8080")
+				b.Resolver = "k8s"
+				b.AcquireEndpoint("172.17.0.2", 8080, "")
+				b.AddEmptyEndpoint()
+			},
+			doconfig2: func(c *testConfig) {
+				b := c.config.Backends().AcquireBackend("default", "app", "8080")
+				b.Resolver = "k8s"
+				b.Dynamic.DynUpdate = true
+				b.AcquireEndpoint("172.17.0.3", 8080, "")
+			},
+			expected: []string{
+				"srv001:172.17.0.3:8080:1",
+				"srv002:127.0.0.1:1023:1",
+			},
+			dynamic: true,
+		},
 	}
 	for i, test := range testCases {
 		c := setup(t)


### PR DESCRIPTION
Dynamic updates need to check the size of the endpoint list size. Up to now the backend server list cannot dynamically grow, even when using DNS updates. HAProxy Ingress has a list of empty slots to dynamically update endpoints, forcing a reload only when no new empty slots can be found.

Kubernetes' ep based updates always rebalance new endpoints with empty slots so its size is at least as big as the old one, but DNS based only do this if a reload is needed. This update rebalance the new list, so future DNS based dynamic updates can work without needing to reload haproxy.