### PR TITLE
Add server redirect options

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -404,6 +404,9 @@ The table below describes all supported configuration keys.
 | [`secure-verify-hostname`](#secure-backend)          | hostname                                | Backend |                    |
 | [`server-alias`](#server-alias)                      | domain name                             | Host    |                    |
 | [`server-alias-regex`](#server-alias)                | regex                                   | Host    |                    |
+| [`server-redirect`](#server-redirect)                | domain name                             | Host    |                    |
+| [`server-redirect-code`](#server-redirect)           | http status code                        | Host    | `302`              |
+| [`server-redirect-regex`](#server-redirect)          | regex                                   | Host    |                    |
 | [`service-upstream`](#service-upstream)              | [true\|false]                           | Backend | `false`            |
 | [`session-cookie-dynamic`](#affinity)                | [true\|false]                           | Backend |                    |
 | [`session-cookie-keywords`](#affinity)               | cookie options                          | Backend | `indirect nocache httponly`     |
@@ -1964,6 +1967,29 @@ attribute in the same ACL, and any of them might be used to match SNI extensions
 
 * `server-alias`: Defines an alias with hostname-like syntax. On v0.6 and older, wildcard `*` wasn't converted to match a subdomain. Regular expression was also accepted but dots were escaped, making this alias less useful as a regex. Starting v0.7 the same hostname syntax is used, so `*.my.domain` will match `app.my.domain` but won't match `sub.app.my.domain`.
 * `server-alias-regex`: Only in v0.7 and newer. Match hostname using a POSIX extended regular expression. The regex will be used verbatim, so add `^` and `$` if strict hostname is desired and escape `\.` dots in order to strictly match them. Some HTTP clients add the port number in the Host header, so remember to add `(:[0-9]+)?$` in the end of the regex if a dollar sign `$` is being used to match the end of the string.
+
+---
+
+## Server redirect
+
+| Configuration key       | Scope  | Default | Since |
+|-------------------------|--------|---------|-------|
+| `server-redirect`       | `Host` |         | v0.13 |
+| `server-redirect-code`  | `Host` | `302`   | v0.13 |
+| `server-redirect-regex` | `Host` |         | v0.13 |
+
+Configures hostname redirect. Requests that matches the configuration will be redirected
+to the hostname of the ingress spec. Protocol, path and query string are preserved.
+
+The same source domain can be configured just once, and a target domain can be assigned
+just once as well, which means that this configuration can only be used on ingress
+resources that defines just one hostname. The redirect configuration has the lesser
+precedence, so if a source domain is also configured as a hostname in the ingress spec,
+or as an alias using annotation, the redirect will not happen.
+
+* `server-redirect`: Defines a source domain using hostname-like syntax, so wildcard domains can also be used.
+* `server-redirect-regex`: Defines a POSIX extended regular expression used to match a source domain. The regex will be used verbatim, so add `^` and `$` if strict hostname is desired and escape `\.` dots in order to strictly match them.
+* `server-redirect-code`: Which HTTP status code should be used in the redirect. A `302` response is used by default if not configured.
 
 ---
 

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -71,6 +71,25 @@ func (c *updater) buildHostCertSigner(d *hostData) {
 	// just the warnings, ingress.syncIngress() has already added the domains
 }
 
+func (c *updater) buildHostRedirect(d *hostData) {
+	// TODO need a host<->host tracking if a target is found
+	redir := d.mapper.Get(ingtypes.HostServerRedirect)
+	if target := c.haproxy.Hosts().FindTargetRedirect(redir.Value, false); target != nil {
+		c.logger.Warn("ignoring redirect from '%s' on %v, it's already targeting to '%s'",
+			redir.Value, redir.Source, target.Hostname)
+	} else {
+		d.host.Redirect.RedirectHost = redir.Value
+	}
+	redirRegex := d.mapper.Get(ingtypes.HostServerRedirectRegex)
+	if target := c.haproxy.Hosts().FindTargetRedirect(redirRegex.Value, true); target != nil {
+		c.logger.Warn("ignoring regex redirect from '%s' on %v, it's already targeting to '%s'",
+			redirRegex.Value, redirRegex.Source, target.Hostname)
+	} else {
+		d.host.Redirect.RedirectHostRegex = redirRegex.Value
+	}
+	d.host.Redirect.RedirectCode = d.mapper.Get(ingtypes.HostServerRedirectCode).Int()
+}
+
 func (c *updater) buildHostSSLPassthrough(d *hostData) {
 	sslpassthrough := d.mapper.Get(ingtypes.HostSSLPassthrough)
 	if !sslpassthrough.Bool() {

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -143,6 +143,9 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.Master.WorkerMaxReloads = mapper.Get(ingtypes.GlobalWorkerMaxReloads).Int()
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()
+	//
+	c.haproxy.Frontend().DefaultServerRedirectCode = mapper.Get(ingtypes.HostServerRedirectCode).Int()
+	//
 	c.buildGlobalAcme(d)
 	c.buildGlobalAuthProxy(d)
 	c.buildGlobalBind(d)
@@ -171,6 +174,7 @@ func (c *updater) UpdateHostConfig(host *hatypes.Host, mapper *Mapper) {
 	host.VarNamespace = mapper.Get(ingtypes.HostVarNamespace).Bool()
 	c.buildHostAuthTLS(data)
 	c.buildHostCertSigner(data)
+	c.buildHostRedirect(data)
 	c.buildHostSSLPassthrough(data)
 	c.buildHostTLSConfig(data)
 }

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -30,11 +30,12 @@ const (
 
 func createDefaults() map[string]string {
 	return map[string]string{
-		types.HostAuthTLSStrict:   "false",
-		types.HostSSLCiphers:      defaultSSLCiphers,
-		types.HostSSLCipherSuites: defaultSSLCipherSuites,
-		types.HostSSLOptionsHost:  "",
-		types.HostTLSALPN:         "h2,http/1.1",
+		types.HostAuthTLSStrict:      "false",
+		types.HostServerRedirectCode: "302",
+		types.HostSSLCiphers:         defaultSSLCiphers,
+		types.HostSSLCipherSuites:    defaultSSLCipherSuites,
+		types.HostSSLOptionsHost:     "",
+		types.HostTLSALPN:            "h2,http/1.1",
 		//
 		types.BackBackendServerNaming:    "sequence",
 		types.BackBackendServerSlotsInc:  "1",

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -27,6 +27,9 @@ const (
 	HostPathType               = "path-type"
 	HostServerAlias            = "server-alias"
 	HostServerAliasRegex       = "server-alias-regex"
+	HostServerRedirect         = "server-redirect"
+	HostServerRedirectCode     = "server-redirect-code"
+	HostServerRedirectRegex    = "server-redirect-regex"
 	HostSSLCiphers             = "ssl-ciphers"
 	HostSSLCipherSuites        = "ssl-cipher-suites"
 	HostSSLOptionsHost         = "ssl-options-host"
@@ -48,6 +51,9 @@ var (
 		HostServerAlias:            {},
 		HostPathType:               {},
 		HostServerAliasRegex:       {},
+		HostServerRedirect:         {},
+		HostServerRedirectCode:     {},
+		HostServerRedirectRegex:    {},
 		HostSSLCiphers:             {},
 		HostSSLCipherSuites:        {},
 		HostSSLOptionsHost:         {},

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -66,6 +66,29 @@ func (h *Hosts) RemoveAll(hostnames []string) {
 	}
 }
 
+// FindTargetRedirect ...
+func (h *Hosts) FindTargetRedirect(redirfrom string, isRegex bool) *Host {
+	if redirfrom == "" {
+		return nil
+	}
+	// TODO this'd be somewhat expensive on full parsing,
+	// tens of thousands of ingress and most of them using redirect
+	if isRegex {
+		for _, host := range h.items {
+			if host.Redirect.RedirectHostRegex == redirfrom {
+				return host
+			}
+		}
+		return nil
+	}
+	for _, host := range h.items {
+		if host.Redirect.RedirectHost == redirfrom {
+			return host
+		}
+	}
+	return nil
+}
+
 // Shrink removes matching added and deleted hosts from the changing hashmap
 // tracker that has the same content. A matching added+deleted pair means
 // that a hostname was reparsed but its content wasn't changed.

--- a/pkg/haproxy/types/maps.go
+++ b/pkg/haproxy/types/maps.go
@@ -45,12 +45,22 @@ func (hm *HostsMaps) AddMap(basename string) *HostsMap {
 
 // AddHostnameMapping ...
 func (hm *HostsMap) AddHostnameMapping(hostname, target string) {
-	hostname, hasWildcard := convertWildcardToRegex(hostname)
-	if hasWildcard {
-		hm.addTarget(hostname, "", target, MatchRegex)
-	} else {
-		hm.addTarget(hostname, "", target, MatchExact)
+	hm.addHostnameMappingMatch(hostname, target, MatchExact)
+}
+
+// AddHostnameMappingRegex ...
+func (hm *HostsMap) AddHostnameMappingRegex(hostname, target string) {
+	hm.addHostnameMappingMatch(hostname, target, MatchRegex)
+}
+
+func (hm *HostsMap) addHostnameMappingMatch(hostname, target string, match MatchType) {
+	if match != MatchRegex {
+		var hasWildcard bool
+		if hostname, hasWildcard = convertWildcardToRegex(hostname); hasWildcard {
+			match = MatchRegex
+		}
 	}
+	hm.addTarget(hostname, "", target, match)
 }
 
 // AddHostnamePathMapping ...
@@ -227,7 +237,11 @@ func (hm *HostsMap) rebuildMatchFiles() (matchFiles []*MatchFile) {
 			matchFile: matchFile,
 			filename:  strings.Replace(hm.basename, ".", suffix+".", 1),
 			first:     i == 1,
+			last:      false,
 		})
+	}
+	if len(matchFiles) > 0 {
+		matchFiles[len(matchFiles)-1].last = true
 	}
 	return matchFiles
 }
@@ -333,6 +347,11 @@ func (m MatchFile) Filename() string {
 // First ...
 func (m MatchFile) First() bool {
 	return m.first
+}
+
+// Last ...
+func (m MatchFile) Last() bool {
+	return m.last
 }
 
 // Lower ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -295,6 +295,7 @@ type MatchFile struct {
 	matchFile *hostsMapMatchFile
 	filename  string
 	first     bool
+	last      bool
 }
 
 // HostsMap ...
@@ -319,6 +320,8 @@ type FrontendMaps struct {
 	HTTPSSNIMap  *HostsMap
 	//
 	RedirFromRootMap  *HostsMap
+	RedirSourceMap    *HostsMap
+	RedirCodeMap      *HostsMap
 	SSLPassthroughMap *HostsMap
 	VarNamespaceMap   *HostsMap
 	//
@@ -357,6 +360,8 @@ type Frontend struct {
 	DefaultCrtFile string
 	DefaultCrtHash string
 	CrtListFile    string
+	//
+	DefaultServerRedirectCode int
 }
 
 // DefaultHost ...
@@ -381,6 +386,7 @@ type Host struct {
 	Paths    []*HostPath
 	//
 	Alias                  HostAliasConfig
+	Redirect               HostRedirectConfig
 	HTTPPassthroughBackend string
 	RootRedirect           string
 	TLS                    HostTLSConfig
@@ -438,6 +444,13 @@ type HostBackend struct {
 type HostAliasConfig struct {
 	AliasName  string
 	AliasRegex string
+}
+
+// HostRedirectConfig ...
+type HostRedirectConfig struct {
+	RedirectCode      int
+	RedirectHost      string
+	RedirectHostRegex string
 }
 
 // HostTLSConfig ...

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1057,6 +1057,9 @@ frontend {{ $proxy__front_http }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- template "serverredirect" map $frontend $fmaps "req.backend" }}
+
+{{- /*------------------------------------*/}}
 {{- range $snippet := $global.CustomFrontend }}
     {{ $snippet }}
 {{- end }}
@@ -1116,6 +1119,9 @@ frontend {{ $proxy__front_https }}
         {{- ""}},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if not $match.First }} if !{ var(req.hostbackend) -m found }{{ end }}
 {{- end }}
+
+{{- /*------------------------------------*/}}
+{{- template "serverredirect" map $frontend $fmaps "req.hostbackend" }}
 
 {{- /*------------------------------------*/}}
 {{- if $fmaps.RedirFromRootMap.HasHost }}
@@ -1248,6 +1254,34 @@ frontend {{ $proxy__front_https }}
 {{- template "defaultbackend" map $hosts $defaultbackend }}
 
 {{- end }}{{/* define "frontends" */}}
+
+{{- /*------------------------------------*/}}
+{{- /*------------------------------------*/}}
+{{- define "serverredirect" }}
+{{- $frontend := .p1 }}
+{{- $fmaps := .p2 }}
+{{- $varbe := .p3 }}
+{{- if $fmaps.RedirSourceMap.MatchFiles }}
+{{- range $match := $fmaps.RedirSourceMap.MatchFiles }}
+    http-request set-var(req.redirdest) var(req.host)
+        {{- if $match.Lower }},lower{{ end }}
+        {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
+        {{- "" }} if !{ var({{ $varbe }}) -m found }
+        {{- if not $match.First }} !{ var(req.redirdest) -m found }{{ end }}
+{{- end }}
+{{- $hasCode := ne (len $fmaps.RedirCodeMap.MatchFiles) 0 }}
+{{- range $match := $fmaps.RedirCodeMap.MatchFiles }}
+    http-request set-var(req.redircode) var(req.host)
+        {{- if $match.Lower }},lower{{ end }}
+        {{- "" }},map_{{ $match.Method }}({{ $match.Filename }}{{ if $match.Last }},{{ $frontend.DefaultServerRedirectCode }}{{ end }})
+        {{- "" }} if { var(req.redirdest) -m found }
+        {{- if not $match.First }} !{ var(req.redircode) -m found }{{ end }}
+{{- end }}
+    http-request redirect prefix //%[var(req.redirdest)]
+        {{- "" }} code {{ if $hasCode }}%[var(req.redircode)]{{ else }}{{ $frontend.DefaultServerRedirectCode }}{{ end }}
+        {{- "" }} if { var(req.redirdest) -m found }
+{{- end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- /*------------------------------------*/}}


### PR DESCRIPTION
A server redirect allows to configure source domains that, if provided in a request, should redirect to the domain configured in the ingress' spec. Valid hostnames will always have precedence, which means that in the case of a match, the redirect will not happen.

As a host scoped config, two new maps were created (redirect source and status code) which will only be used if the functionality is also used.