### PR TITLE
Add custom-proxy configuration

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -323,6 +323,7 @@ The table below describes all supported configuration keys.
 | [`config-defaults`](#configuration-snippet)          | multiline HAProxy config for the defaults section | Global |           |
 | [`config-frontend`](#configuration-snippet)          | multiline HAProxy frontend config       | Global  |                    |
 | [`config-global`](#configuration-snippet)            | multiline HAProxy global config         | Global  |                    |
+| [`config-proxy`](#configuration-snippet)             | multiline HAProxy custom proxy config   | Global  |                    |
 | [`config-sections`](#configuration-snippet)          | multiline HAProxy section declarations  | Global  |                    |
 | [`cookie-key`](#affinity)                            | secret key                              | Global  | `Ingress`          |
 | [`cors-allow-credentials`](#cors)                    | [true\|false]                           | Path    |                    |
@@ -1016,10 +1017,18 @@ See also:
 | `config-defaults` | `Global`  |          | v0.8  |
 | `config-frontend` | `Global`  |          |       |
 | `config-global`   | `Global`  |          |       |
+| `config-proxy`    | `Global`  |          | v0.13 |
 | `config-sections` | `Global`  |          | v0.13 |
 
 Add HAProxy configuration snippet to the configuration file. Use multiline content
 to add more than one line of configuration.
+
+* `config-backend`: Adds a configuration snippet to a HAProxy backend section.
+* `config-defaults`: Adds a configuration snippet to the end of the HAProxy defaults section.
+* `config-frontend`: Adds a configuration snippet to the HTTP and HTTPS frontend sections.
+* `config-global`: Adds a configuration snippet to the end of the HAProxy global section.
+* `config-proxy`: Adds a configuration snippet to any HAProxy proxy - listen, frontend or backend. It accepts a multi section configuration, where the name of the section is the name of a HAProxy proxy without the listen/frontend/backend prefix. A section whose proxy is not found is ignored. The content of each section should be indented, the first line without indentation is the start of a new section which will configure another proxy.
+* `config-sections`: Allows to declare new HAProxy sections. The configuration is used verbatim, without any indentation or validation.
 
 Examples - ConfigMap:
 
@@ -1031,6 +1040,14 @@ Examples - ConfigMap:
 ```yaml
     config-defaults: |
       option redispatch
+```
+
+```yaml
+    config-proxy: |
+      _tcp_default_postgresql_5432
+          tcp-request content reject if !{ src 10.0.0.0/8 }
+      _front__tls
+          tcp-request content reject if !{ src 10.0.0.0/8 } { req.ssl_sni -m reg ^intra\..* }
 ```
 
 ```yaml
@@ -1063,14 +1080,6 @@ Annotation:
         http-request cache-use icons if { var(txn.path) -m end .ico }
         http-response cache-store icons if { var(txn.path) -m end .ico }
 ```
-
-The following keys add a configuration snippet to the ...:
-
-* `config-backend`: ... HAProxy backend section.
-* `config-global`: ... end of the HAProxy global section.
-* `config-defaults`: ... end of the HAProxy defaults section.
-* `config-frontend`: ... HAProxy frontend sections.
-* `config-sections`: ... HAProxy new section declarations.
 
 ---
 

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -345,4 +345,21 @@ func (c *updater) buildGlobalCustomConfig(d *globalData) {
 	d.global.CustomDefaults = utils.LineToSlice(d.mapper.Get(ingtypes.GlobalConfigDefaults).Value)
 	d.global.CustomFrontend = utils.LineToSlice(d.mapper.Get(ingtypes.GlobalConfigFrontend).Value)
 	d.global.CustomSections = utils.LineToSlice(d.mapper.Get(ingtypes.GlobalConfigSections).Value)
+	proxy := map[string][]string{}
+	var curSection string
+	for _, line := range utils.LineToSlice(d.mapper.Get(ingtypes.GlobalConfigProxy).Value) {
+		if line == "" {
+			continue
+		}
+		if line[0] != ' ' && line[0] != '\t' {
+			curSection = line
+			continue
+		}
+		proxy[curSection] = append(proxy[curSection], strings.TrimSpace(line))
+	}
+	if lines, hasEmpty := proxy[""]; hasEmpty {
+		c.logger.Warn("non scoped %d line(s) in the config-proxy configuration were ignored", len(lines))
+		delete(proxy, "")
+	}
+	d.global.CustomProxy = proxy
 }

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -34,6 +34,7 @@ const (
 	GlobalConfigDefaults               = "config-defaults"
 	GlobalConfigFrontend               = "config-frontend"
 	GlobalConfigGlobal                 = "config-global"
+	GlobalConfigProxy                  = "config-proxy"
 	GlobalConfigSections               = "config-sections"
 	GlobalCookieKey                    = "cookie-key"
 	GlobalCPUMap                       = "cpu-map"

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -78,6 +78,7 @@ type Global struct {
 	CustomConfig            []string
 	CustomDefaults          []string
 	CustomFrontend          []string
+	CustomProxy             map[string][]string
 	CustomSections          []string
 }
 

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -245,7 +245,8 @@ userlist {{ $userlist.Name }}
 #
 
 {{- range $backend := $tcpbackends }}
-listen _tcp_{{ $backend.Name }}_{{ $backend.Port }}
+{{- $proxy_name := printf "_tcp_%s_%d" $backend.Name $backend.Port }}
+listen {{ $proxy_name }}
 {{- $ssl := $backend.SSL }}
     bind {{ $global.Bind.TCPBindIP }}:{{ $backend.Port }}
         {{- if $ssl.Filename }} ssl crt {{ $ssl.Filename }}
@@ -265,6 +266,11 @@ listen _tcp_{{ $backend.Name }}_{{ $backend.Port }}
 {{- else }}
     no log
 {{- end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
+{{- range $snippet := index $global.CustomProxy $proxy_name }}
+    {{ $snippet }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -644,6 +650,9 @@ backend {{ $backend.ID }}
 {{- range $snippet := $backend.CustomConfig }}
     {{ $snippet }}
 {{- end }}
+{{- range $snippet := index $global.CustomProxy $backend.ID }}
+    {{ $snippet }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- $rewriteCfg := $backend.PathConfig "RewriteURL" }}
@@ -793,6 +802,9 @@ backend {{ $backend.ID }}
 #
 backend _redirect_https
     mode http
+{{- range $snippet := index $global.CustomProxy "_redirect_https" }}
+    {{ $snippet }}
+{{- end }}
     http-request redirect scheme https
         {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
 {{- end }}
@@ -805,6 +817,9 @@ backend _redirect_https
 #
 backend _acme_challenge
     mode http
+{{- range $snippet := index $global.CustomProxy "_acme_challenge" }}
+    {{ $snippet }}
+{{- end }}
     server _acme_server unix@{{ $global.Acme.Socket }}
 {{- end }}
 
@@ -816,6 +831,9 @@ backend _acme_challenge
 #
 backend _error404
     mode http
+{{- range $snippet := index $global.CustomProxy "_error404" }}
+    {{ $snippet }}
+{{- end }}
 {{- if $global.DefaultBackendRedir }}
     redirect location {{ $global.DefaultBackendRedir }} code {{ $global.DefaultBackendRedirCode }}
 {{- else }}
@@ -846,7 +864,8 @@ backend _error404
 # #
 #     TCP/TLS frontend
 #
-listen _front__tls
+{{- $proxy__front__tls := "_front__tls" }}
+listen {{ $proxy__front__tls }}
     mode tcp
     bind {{ $global.Bind.HTTPSBind }}{{ if $global.Bind.AcceptProxy }} accept-proxy{{ end }}
 
@@ -872,6 +891,11 @@ listen _front__tls
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- range $snippet := index $global.CustomProxy $proxy__front__tls }}
+    {{ $snippet }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
     tcp-request content accept if { req.ssl_hello_type 1 }
 
 {{- /*------------------------------------*/}}
@@ -887,7 +911,8 @@ listen _front__tls
 # #
 #     HTTP{{ if $hasFrontingProxy }} & Fronting Proxy{{ end }} frontend
 #
-frontend _front_http
+{{- $proxy__front_http := "_front_http" }}
+frontend {{ $proxy__front_http }}
     mode http
 {{- $hasPlainHTTPSocket := not $global.Bind.ShareHTTPPort }}
 {{- if and $global.Bind.HTTPBind $hasPlainHTTPSocket }}
@@ -978,6 +1003,9 @@ frontend _front_http
 {{- range $snippet := $global.CustomFrontend }}
     {{ $snippet }}
 {{- end }}
+{{- range $snippet := index $global.CustomProxy $proxy__front_http }}
+    {{ $snippet }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- if $acmeexclusive }}
@@ -994,7 +1022,8 @@ frontend _front_http
 # #
 #     HTTPS frontend
 #
-frontend _front_https
+{{- $proxy__front_https := "_front_https" }}
+frontend {{ $proxy__front_https }}
     mode http
 
 {{- /*------------------------------------*/}}
@@ -1132,6 +1161,9 @@ frontend _front_https
 {{- range $snippet := $global.CustomFrontend }}
     {{ $snippet }}
 {{- end }}
+{{- range $snippet := index $global.CustomProxy $proxy__front_https }}
+    {{ $snippet }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- if $fmaps.TLSAuthList.HasHost }}
@@ -1208,6 +1240,9 @@ listen stats
     no log
     option httpclose
     stats show-legends
+{{- range $snippet := index $global.CustomProxy "stats" }}
+    {{ $snippet }}
+{{- end }}
 
 {{- if $global.Prometheus.Port }}
 
@@ -1222,6 +1257,9 @@ frontend prometheus
     http-request use-service lua.send-prometheus-root if { path / }
     http-request use-service lua.send-404
     no log
+{{- range $snippet := index $global.CustomProxy "prometheus" }}
+    {{ $snippet }}
+{{- end }}
 {{- end }}
 
   # # # # # # # # # # # # # # # # # # #
@@ -1234,6 +1272,9 @@ frontend healthz
     monitor-uri /healthz
     http-request use-service lua.send-404
     no log
+{{- range $snippet := index $global.CustomProxy "healthz" }}
+    {{ $snippet }}
+{{- end }}
 
 {{- if $global.ModSecurity.Endpoints }}
 
@@ -1245,6 +1286,9 @@ backend spoe-modsecurity
     mode tcp
     timeout connect {{ $global.ModSecurity.Timeout.Connect }}
     timeout server  {{ $global.ModSecurity.Timeout.Server }}
+{{- range $snippet := index $global.CustomProxy "spoe-modsecurity" }}
+    {{ $snippet }}
+{{- end }}
 {{- range $i, $endpoint := $global.ModSecurity.Endpoints }}
     server modsec-spoa{{ $i }} {{ $endpoint }}
 {{- end }}


### PR DESCRIPTION
Allows to configure any internal proxy - listen, frontend or backend - using a single configuration key as a multi section value. Each section of the configuration adds custom snippet to distinct proxies.