### PR TITLE
Add custom-tcp configuration

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -319,12 +319,12 @@ The table below describes all supported configuration keys.
 | [`blue-green-header`](#blue-green)                   | `HeaderName:LabelName` pair             | Backend |                    |
 | [`blue-green-mode`](#blue-green)                     | [pod\|deploy]                           | Backend |                    |
 | [`cert-signer`](#acme)                               | "acme"                                  | Host    |                    |
-| [`config-backend`](#configuration-snippet)           | multiline HAProxy backend config        | Backend |                    |
-| [`config-defaults`](#configuration-snippet)          | multiline HAProxy config for the defaults section | Global |           |
-| [`config-frontend`](#configuration-snippet)          | multiline HAProxy frontend config       | Global  |                    |
-| [`config-global`](#configuration-snippet)            | multiline HAProxy global config         | Global  |                    |
-| [`config-proxy`](#configuration-snippet)             | multiline HAProxy custom proxy config   | Global  |                    |
-| [`config-sections`](#configuration-snippet)          | multiline HAProxy section declarations  | Global  |                    |
+| [`config-backend`](#configuration-snippet)           | multiline backend config                | Backend |                    |
+| [`config-defaults`](#configuration-snippet)          | multiline config for the defaults section | Global |                   |
+| [`config-frontend`](#configuration-snippet)          | multiline HTTP and HTTPS frontend config | Global  |                   |
+| [`config-global`](#configuration-snippet)            | multiline config for the global section | Global  |                    |
+| [`config-proxy`](#configuration-snippet)             | multiline config for any proxy          | Global  |                    |
+| [`config-sections`](#configuration-snippet)          | multiline custom sections declaration   | Global  |                    |
 | [`cookie-key`](#affinity)                            | secret key                              | Global  | `Ingress`          |
 | [`cors-allow-credentials`](#cors)                    | [true\|false]                           | Path    |                    |
 | [`cors-allow-headers`](#cors)                        | headers list                            | Path    |                    |

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -325,6 +325,7 @@ The table below describes all supported configuration keys.
 | [`config-global`](#configuration-snippet)            | multiline config for the global section | Global  |                    |
 | [`config-proxy`](#configuration-snippet)             | multiline config for any proxy          | Global  |                    |
 | [`config-sections`](#configuration-snippet)          | multiline custom sections declaration   | Global  |                    |
+| [`config-tcp`](#configuration-snippet)               | multiline tcp-service config            | Global  |                    |
 | [`cookie-key`](#affinity)                            | secret key                              | Global  | `Ingress`          |
 | [`cors-allow-credentials`](#cors)                    | [true\|false]                           | Path    |                    |
 | [`cors-allow-headers`](#cors)                        | headers list                            | Path    |                    |
@@ -1019,6 +1020,7 @@ See also:
 | `config-global`   | `Global`  |          |       |
 | `config-proxy`    | `Global`  |          | v0.13 |
 | `config-sections` | `Global`  |          | v0.13 |
+| `config-tcp`      | `Global`  |          | v0.13 |
 
 Add HAProxy configuration snippet to the configuration file. Use multiline content
 to add more than one line of configuration.
@@ -1029,6 +1031,7 @@ to add more than one line of configuration.
 * `config-global`: Adds a configuration snippet to the end of the HAProxy global section.
 * `config-proxy`: Adds a configuration snippet to any HAProxy proxy - listen, frontend or backend. It accepts a multi section configuration, where the name of the section is the name of a HAProxy proxy without the listen/frontend/backend prefix. A section whose proxy is not found is ignored. The content of each section should be indented, the first line without indentation is the start of a new section which will configure another proxy.
 * `config-sections`: Allows to declare new HAProxy sections. The configuration is used verbatim, without any indentation or validation.
+* `config-tcp`: Adds a configuration snippet to the tcp-services sections.
 
 Examples - ConfigMap:
 
@@ -1040,6 +1043,11 @@ Examples - ConfigMap:
 ```yaml
     config-defaults: |
       option redispatch
+```
+
+```yaml
+    config-tcp: |
+      tcp-request content reject if !{ src 10.0.0.0/8 }
 ```
 
 ```yaml

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -345,6 +345,7 @@ func (c *updater) buildGlobalCustomConfig(d *globalData) {
 	d.global.CustomDefaults = utils.LineToSlice(d.mapper.Get(ingtypes.GlobalConfigDefaults).Value)
 	d.global.CustomFrontend = utils.LineToSlice(d.mapper.Get(ingtypes.GlobalConfigFrontend).Value)
 	d.global.CustomSections = utils.LineToSlice(d.mapper.Get(ingtypes.GlobalConfigSections).Value)
+	d.global.CustomTCP = utils.LineToSlice(d.mapper.Get(ingtypes.GlobalConfigTCP).Value)
 	proxy := map[string][]string{}
 	var curSection string
 	for _, line := range utils.LineToSlice(d.mapper.Get(ingtypes.GlobalConfigProxy).Value) {

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -36,6 +36,7 @@ const (
 	GlobalConfigGlobal                 = "config-global"
 	GlobalConfigProxy                  = "config-proxy"
 	GlobalConfigSections               = "config-sections"
+	GlobalConfigTCP                    = "config-tcp"
 	GlobalCookieKey                    = "cookie-key"
 	GlobalCPUMap                       = "cpu-map"
 	GlobalDefaultBackendRedirect       = "default-backend-redirect"

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2309,6 +2309,35 @@ backend d1_app_8080
 	c.logger.CompareLogging(defaultLogging)
 }
 
+func TestInstanceCustomTCP(t *testing.T) {
+	c := setup(t)
+	defer c.teardown()
+
+	tcp := c.config.TCPBackends().Acquire("default_postgresql", 5432)
+	tcp.AddEndpoint("172.17.0.11", 5432)
+
+	c.config.global.CustomTCP = []string{"## custom for TCP", "## multi line"}
+
+	c.Update()
+	c.checkConfig(`
+<<global>>
+<<defaults>>
+listen _tcp_default_postgresql_5432
+    bind :5432
+    mode tcp
+    ## custom for TCP
+    ## multi line
+    server srv001 172.17.0.11:5432
+<<backends-default>>
+<<frontend-http-clean>>
+    default_backend _error404
+<<frontend-https-clean>>
+    default_backend _error404
+<<support>>
+`)
+	c.logger.CompareLogging(defaultLogging)
+}
+
 func TestInstanceCustomProxy(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -80,6 +80,7 @@ type Global struct {
 	CustomFrontend          []string
 	CustomProxy             map[string][]string
 	CustomSections          []string
+	CustomTCP               []string
 }
 
 // GlobalBindConfig ...

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -269,6 +269,9 @@ listen {{ $proxy_name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- range $snippet := $global.CustomTCP }}
+    {{ $snippet }}
+{{- end }}
 {{- range $snippet := index $global.CustomProxy $proxy_name }}
     {{ $snippet }}
 {{- end }}


### PR DESCRIPTION
Allows to customize configmap based TCP services with configuration snippets. All TCP services receives the same configuration.