### PR TITLE
Fix default host if configured as ssl-passthrough

### DIFF
--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -1775,6 +1775,12 @@ func TestSyncAnnPassthrough(t *testing.T) {
 				"ingress.kubernetes.io/ssl-passthrough":           "true",
 				"ingress.kubernetes.io/ssl-passthrough-http-port": "9000",
 			}),
+		c.createIng2Ann("default/echo4", "echo:8443",
+			map[string]string{
+				"ingress.kubernetes.io/app-root":                  "/login",
+				"ingress.kubernetes.io/ssl-passthrough":           "true",
+				"ingress.kubernetes.io/ssl-passthrough-http-port": "9090",
+			}),
 	)
 
 	c.compareConfigFront(`
@@ -1786,6 +1792,14 @@ func TestSyncAnnPassthrough(t *testing.T) {
   paths:
   - path: /
     backend: default_echo_8443
+`)
+
+	c.compareConfigDefaultFront(`
+hostname: <default>
+paths:
+- path: /
+  backend: default_echo_8443
+rootredirect: /login
 `)
 
 	c.compareConfigBack(`
@@ -2012,6 +2026,12 @@ spec:
     service:
       name: ` + sservice[0]).(*networking.Ingress)
 	ing.Spec.DefaultBackend.Service.Port = createServicePort(sservice[1])
+	return ing
+}
+
+func (c *testConfig) createIng2Ann(name, service string, ann map[string]string) *networking.Ingress {
+	ing := c.createIng2(name, service)
+	ing.SetAnnotations(ann)
 	return ing
 }
 

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2617,6 +2617,17 @@ func TestInstanceSSLPassthrough(t *testing.T) {
 	b.Endpoints = []*hatypes.Endpoint{endpointS41h}
 	h.HTTPPassthroughBackend = b.ID
 
+	b = c.config.Backends().AcquireBackend("d4", "app4-ssl", "8443")
+	h = c.config.Hosts().AcquireHost(hatypes.DefaultHost)
+	h.AddPath(b, "/", hatypes.MatchBegin)
+	b.Endpoints = []*hatypes.Endpoint{endpointS41s}
+	b.ModeTCP = true
+	h.SetSSLPassthrough(true)
+
+	b = c.config.Backends().AcquireBackend("d4", "app4-http", "8080")
+	b.Endpoints = []*hatypes.Endpoint{endpointS41h}
+	h.HTTPPassthroughBackend = b.ID
+
 	c.Update()
 	c.checkConfig(`
 <<global>>
@@ -2630,6 +2641,12 @@ backend d3_app-http_8080
 backend d3_app-ssl_8443
     mode tcp
     server s41s 172.17.0.141:8443 weight 100
+backend d4_app4-http_8080
+    mode http
+    server s41h 172.17.0.141:8080 weight 100
+backend d4_app4-ssl_8443
+    mode tcp
+    server s41s 172.17.0.141:8443 weight 100
 backend _redirect_https
     mode http
     http-request redirect scheme https
@@ -2641,8 +2658,10 @@ listen _front__tls
     tcp-request content set-var(req.sslpassback) req.ssl_sni,lower,map_str(/etc/haproxy/maps/_front_sslpassthrough__exact.map)
     tcp-request content accept if { req.ssl_hello_type 1 }
     use_backend %[var(req.sslpassback)] if { var(req.sslpassback) -m found }
+    use_backend d4_app4-ssl_8443
     server _default_server_https_socket unix@/var/run/haproxy/_https_socket.sock send-proxy-v2
 <<frontend-http>>
+    use_backend d4_app4-http_8080
     default_backend _error404
 frontend _front_https
     mode http

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -957,6 +957,16 @@ listen {{ $proxy__front__tls }}
 
 {{- /*------------------------------------*/}}
     use_backend %[var(req.sslpassback)] if { var(req.sslpassback) -m found }
+{{- $defaultHost := $hosts.DefaultHost }}
+{{- if $defaultHost }}
+{{- if $defaultHost.SSLPassthrough }}
+{{- range $path := $defaultHost.Paths }}
+{{- if eq $path.Path "/" }}
+    use_backend {{ $path.Backend.ID }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
     server _default_server{{ $frontend.BindName }} {{ $frontend.BindSocket }} send-proxy-v2
 {{- end }}
 
@@ -1076,6 +1086,11 @@ frontend {{ $proxy__front_http }}
     use_backend _acme_challenge if acme-challenge
 {{- end }}
 
+{{- if $hosts.DefaultHost }}
+{{- if $hosts.DefaultHost.HTTPPassthroughBackend }}
+    use_backend {{ $hosts.DefaultHost.HTTPPassthroughBackend }}
+{{- end }}
+{{- end }}
 {{- template "defaultbackend" map $hosts $defaultbackend }}
 
   # # # # # # # # # # # # # # # # # # #
@@ -1288,10 +1303,13 @@ frontend {{ $proxy__front_https }}
 {{- define "defaultbackend" }}
 {{- $hosts := .p1 }}
 {{- $defaultbackend := .p2 }}
-{{- if $hosts.DefaultHost }}
-{{- range $path := $hosts.DefaultHost.Paths }}
+{{- $defaultHost := $hosts.DefaultHost }}
+{{- if $defaultHost }}
+{{- if not $defaultHost.SSLPassthrough }}
+{{- range $path := $defaultHost.Paths }}
     use_backend {{ $path.Backend.ID }}
         {{- if ne $path.Path "/" }} if { path_beg {{ $path.Path }} }{{ end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if $defaultbackend }}


### PR DESCRIPTION
SSL passthrough domains are added in the same hostname maps used to route http requests. They share most of their configurations with a few exceptions. One of these exceptions weren't properly implemented - default host was always being configured in the http proxy. This update checks if the default host is an ssl passthrough, properly configuring it in the tcp proxy instead.