### PR TITLE
Allow default crt on tcp service

### DIFF
--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -1720,6 +1720,13 @@ WARN skipping TLS secret 'tls2' of ingress 'default/echo2': TLS of tcp service p
 				ing.SetAnnotations(paramToMap(annPort))
 			case 2:
 				ing = c.createIngTLS1(name, domain, "/", ":", params[1])
+				if strings.Index(params[1], ":") < 0 {
+					// remove default host in the array, this allows to
+					// test secret name without a hosts list
+					for i := range ing.Spec.TLS {
+						ing.Spec.TLS[i].Hosts = nil
+					}
+				}
 				ing.Spec.Rules = nil
 				ing.SetAnnotations(paramToMap(annPort))
 			case 3:


### PR DESCRIPTION
Any distinct TCP service port can have it's own default certificate - a certificate that should be used when SNI doesn't match or isn't used at all. This differs from HTTP services because a default certificate is already configured via command-line and all HTTP ingress need to use the same configuration because the listening port is always the same (defaults to 443). Before this update, an empty `ingress.spec.tls[].hosts[]` list was ignoring the secret name on TCP services.