### PR TITLE
Add non root path support on ssl-passthrough

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -2163,10 +2163,17 @@ Defines if HAProxy should work in TCP proxy mode and leave the SSL offload to th
 SSL passthrough is a per domain configuration, which means that other domains can be
 configured to SSL offload on HAProxy.
 
-If using SSL passthrough, only root `/` path is supported.
+{{% alert title="Note" %}}
+Up to v0.12, `ssl-passthrough` supports only root `/` path. Since v0.13, non root paths are also supported and configured in the HAProxy's HTTP port.
+{{% /alert %}}
 
 * `ssl-passthrough`: Enable SSL passthrough if defined as `true`. The backend is then expected to SSL offload the incoming traffic. The default value is `false`, which means HAProxy should do the SSL handshake.
-* `ssl-passthrough-http-port`: Since v0.7. Optional HTTP port number of the backend. If defined, connections to the HAProxy HTTP port, default `80`, is sent to that port which expects to speak plain HTTP. If not defined, connections to the HTTP port will redirect connections to the HTTPS one.
+* `ssl-passthrough-http-port`: Optional HTTP port number of the backend. If defined, connections to the HAProxy's HTTP port, defaults to `80`, is sent to the configured port number of the backend, which expects to speak plain HTTP. If not defined, connections to the HTTP port will redirect the client to HTTPS.
+
+Hostnames configured as `ssl-passthrough` configures HAProxy in the following way:
+
+* Requests to the HTTPS port, defaults to `443`, will be sent to the backend and port number configured in the root `/` path of the domain. Such port must speak TLS and will make the TLS handshake with the client. There is no path inspection, so only one backend is supported.
+* Requests to the HTTP port, defaults to `80`, will follow the same rules of non `ssl-passthrough` domains: if the request matches a non root path, the configured backend will be used and it should speak plain HTTP, except if [`secure-backends`](#secure-backend) is also configured. If there isn't non root paths or if they doesn't match, the request will fall back to: redirect to HTTPS (default), or the request will be sent to `ssl-passthrough-http-port` port number of the ssl backend.
 
 ---
 

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -100,11 +100,6 @@ func (c *updater) buildHostSSLPassthrough(d *hostData) {
 		c.logger.Warn("skipping SSL of %s: root path was not configured", sslpassthrough.Source)
 		return
 	}
-	for _, path := range d.host.Paths {
-		if path.Path != "/" {
-			c.logger.Warn("ignoring path '%s' from %s: ssl-passthrough only support root path", path.Path, sslpassthrough.Source)
-		}
-	}
 	sslpassHTTPPort := d.mapper.Get(ingtypes.HostSSLPassthroughHTTPPort)
 	if sslpassHTTPPort.Source != nil {
 		httpBackend := c.haproxy.Backends().FindBackend(rootPath.Backend.Namespace, rootPath.Backend.Name, sslpassHTTPPort.Value)


### PR DESCRIPTION
A ssl-passthrough host cannot inspect uri and http headers because the request isn't offloaded in haproxy - a TCP tunnel is created instead. This however isn't true for the plain http side of the configuration, which up to now can only be configured with a 302 redirect (default behavior) or a plain http port in the same backend.

This update adds the ability to configure non root paths. Such paths does not change how the https side behaves, but do so for the http one. `ssl-passthrough-http-port` config key continue to be supported in the same way, but now act as a fallback - how the request will be handled in the http side if a path isn't found.

## Compatibility notes

Hostnames configured as `ssl-passthrough` will now add non root `/` paths of these hostnames to the HAProxy's HTTP port. v0.12 and older controller versions log a warning and ignore such configuration. The behavior continues the same in the HTTPS port. The behavior also continues the same in the HTTP port if non root paths isn't configured at all for ssl-passthrough hostnames, or whenever a request doesn't match any of the configured non root paths.