### PR TITLE
Allow to configure a list of annotations prefix

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -19,7 +19,7 @@ The following command-line options are supported:
 | [`--acme-token-configmap-name`](#acme)                  | [namespace]/configmap-name | `acme-validation-tokens` | v0.9 |
 | [`--acme-track-tls-annotation`](#acme)                  | [true\|false]              | `false`                 | v0.9  |
 | [`--allow-cross-namespace`](#allow-cross-namespace)     | [true\|false]              | `false`                 |       |
-| [`--annotation-prefix`](#annotation-prefix)             | prefix without `/`         | `ingress.kubernetes.io` | v0.8  |
+| [`--annotations-prefix`](#annotations-prefix)           | prefix list without `/`    | `haproxy-ingress.github.io,ingress.kubernetes.io` | v0.8  |
 | [`--backend-shards`](#backend-shards)                   | int                        | `0`                     | v0.11 |
 | [`--buckets-response-time`](#buckets-response-time)     | float64 slice           | `.0005,.001,.002,.005,.01` | v0.10 |
 | [`--controller-class`](#ingress-class)                  | suffix                     | ``                      | v0.12 |
@@ -78,13 +78,21 @@ annotation, where cross namespace reading were allowed without any configuration
 
 ---
 
-## --annotation-prefix
+## --annotations-prefix
 
-Changes the annotation prefix the controller should look for when parsing services and ingress
-objects. The default value is `ingress.kubernetes.io` if not declared, which means SSL Redirect
-should be configured with the annotation name `ingress.kubernetes.io/ssl-redirect`. Annotations
-with other prefix are ignored. This allows using HAProxy Ingress with other ingress controllers
-that shares ingress and service objects without conflicting each other.
+Configures a comma-separated list of annotations prefix that the controller should look for when
+parsing services and ingress objects. The default value is `haproxy-ingress.github.io,ingress.kubernetes.io`.
+The default configuration means declare eg a SSL Redirect annotation with
+`haproxy-ingress.github.io/ssl-redirect: "true"` or `ingress.kubernetes.io/ssl-redirect: "true"`.
+
+The order of the declaration is used to priorize one of them if the same configuration key is
+declared twice - if two distinct prefix is used to configure the same key in the same ingress or
+service resource, the value of the annotation with the prefix that was configured first in this
+command-line option is used.
+
+Annotations with other prefix or without any prefix are ignored. This allows to use HAProxy Ingress
+with other ingress controllers that shares ingress and service resources without conflicting each
+other.
 
 ---
 

--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -73,7 +73,7 @@ See also:
 
 `--allow-cross-namespace` argument, if added, will allow reading secrets from one namespace to an
 ingress resource of another namespace. The default behavior is to deny such cross namespace reading.
-This adds a breaking change from `v0.4` to `v0.5` on `ingress.kubernetes.io/auth-tls-secret`
+This adds a breaking change from `v0.4` to `v0.5` on `haproxy-ingress.github.io/auth-tls-secret`
 annotation, where cross namespace reading were allowed without any configuration.
 
 ---

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -109,9 +109,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    ingress.kubernetes.io/balance-algorithm: roundrobin
-    ingress.kubernetes.io/maxconn-server: "500"
-    ingress.kubernetes.io/ssl-redirect: "false"
+    haproxy-ingress.github.io/balance-algorithm: roundrobin
+    haproxy-ingress.github.io/maxconn-server: "500"
+    haproxy-ingress.github.io/ssl-redirect: "false"
   name: app
   namespace: default
 spec:
@@ -208,7 +208,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    ingress.kubernetes.io/rewrite-target: /
+    haproxy-ingress.github.io/rewrite-target: /
   name: app-back
 spec:
   rules:
@@ -538,7 +538,7 @@ and certificate signing, and will also start a leader election to define which
 haproxy-ingress instance should perform authorizations and certificate signing.
 
 The haproxy-ingress leader tracks ingress objects that declares the annotation
-`ingress.kubernetes.io/cert-signer` with value `acme` and a configured secret name for
+`haproxy-ingress.github.io/cert-signer` with value `acme` and a configured secret name for
 TLS certificate. The annotation `kubernetes.io/tls-acme` with value `"true"` will also
 be used if the command-line option `--acme-track-tls-annotation` is declared. The
 secret does not need to exist. A new certificate will be issued if the certificate is
@@ -1160,7 +1160,7 @@ Annotations:
 
 ```yaml
     annotations:
-      ingress.kubernetes.io/config-backend: |
+      haproxy-ingress.github.io/config-backend: |
         acl bar-url path /bar
         http-request deny if bar-url
         http-request set-var(txn.path) path
@@ -1170,7 +1170,7 @@ Annotations:
 
 ```yaml
     annotations:
-      ingress.kubernetes.io/config-tcp-service: |
+      haproxy-ingress.github.io/config-tcp-service: |
         timeout client 1m
         timeout connect 15s
 ```
@@ -1487,7 +1487,7 @@ Configuration example:
 
 ```yaml
     annotations:
-      ingress.kubernetes.io/headers: |
+      haproxy-ingress.github.io/headers: |
         x-path: /
         host: %[service].%[namespace].svc.cluster.local
 ```

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -98,7 +98,9 @@ Annotations are read in the following conditions:
 * From `Services` that classified Ingress resources are linking to. `Services` only accept keys from the `Backend` scope.
 
 A configuration key needs a prefix in front of its name to use as an annotation key.
-The default prefix is `ingress.kubernetes.io`, change with the `--annotation-prefix`
+The default prefix is `haproxy-ingress.github.io`, and `ingress.kubernetes.io` is also
+supported for backward compatibility. Change the prefix with the
+[`--annotations-prefix`]({{% relref "command-line#annotations-prefix" %}})
 command-line option. The annotation value spec expects a string as the key value, so
 declare numbers and booleans as strings, HAProxy Ingress will convert them when needed.
 

--- a/docs/content/en/docs/examples/blue-green.md
+++ b/docs/content/en/docs/examples/blue-green.md
@@ -83,10 +83,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    ingress.kubernetes.io/balance-algorithm: roundrobin
-    ingress.kubernetes.io/blue-green-deploy: group=blue=1,group=green=1
-    ingress.kubernetes.io/blue-green-mode: pod
-    ingress.kubernetes.io/ssl-redirect: "false"
+    haproxy-ingress.github.io/balance-algorithm: roundrobin
+    haproxy-ingress.github.io/blue-green-deploy: group=blue=1,group=green=1
+    haproxy-ingress.github.io/blue-green-mode: pod
+    haproxy-ingress.github.io/ssl-redirect: "false"
   name: bluegreen
 spec:
   rules:
@@ -162,7 +162,7 @@ instead of single pods.
 
 ```
 $ kubectl annotate --overwrite ingress bluegreen \
-  ingress.kubernetes.io/blue-green-mode=deploy
+  haproxy-ingress.github.io/blue-green-mode=deploy
 ```
 
 * BG Mode: deploy
@@ -182,7 +182,7 @@ Changing now the balance to 1/3 blue and 2/3 green:
 
 ```
 $ kubectl annotate --overwrite ingress bluegreen \
-  ingress.kubernetes.io/blue-green-deploy=group=blue=1,group=green=2
+  haproxy-ingress.github.io/blue-green-deploy=group=blue=1,group=green=2
 ```
 
 * BG Mode: deploy
@@ -227,7 +227,7 @@ After that, add the following annotation:
 
 ```
 $ kubectl annotate --overwrite ingress bluegreen \
-  ingress.kubernetes.io/blue-green-header=x-server:group
+  haproxy-ingress.github.io/blue-green-header=x-server:group
 ```
 
 Create (or update) the `hareq` alias. Change `IP` to your HAProxy Ingress controller
@@ -269,7 +269,7 @@ Choose an invalid group, the configured blue/green balance will be used:
 
 ```
 $ kubectl annotate --overwrite ingress bluegreen \
-  ingress.kubernetes.io/blue-green-deploy=group=blue=1,group=green=3
+  haproxy-ingress.github.io/blue-green-deploy=group=blue=1,group=green=3
 $ GROUP=invalid
 $ hareq
 Running 100 requests...

--- a/docs/content/en/docs/examples/metrics/whoami-ingress.yaml
+++ b/docs/content/en/docs/examples/metrics/whoami-ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    ingress.kubernetes.io/ssl-redirect: "false"
+    haproxy-ingress.github.io/ssl-redirect: "false"
   name: whoami
   namespace: default
 spec:

--- a/docs/content/en/docs/examples/modsecurity.md
+++ b/docs/content/en/docs/examples/modsecurity.md
@@ -90,8 +90,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    ingress.kubernetes.io/ssl-redirect: "false"
-    ingress.kubernetes.io/waf: "modsecurity"
+    haproxy-ingress.github.io/ssl-redirect: "false"
+    haproxy-ingress.github.io/waf: "modsecurity"
   name: echo
 spec:
   rules:

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -74,7 +74,7 @@ type Configuration struct {
 	AllowCrossNamespace     bool
 	DisableNodeList         bool
 	DisablePodList          bool
-	AnnPrefix               string
+	AnnPrefix               []string
 
 	AcmeServer              bool
 	AcmeCheckPeriod         time.Duration

--- a/pkg/converters/ingress/annotations/mapper.go
+++ b/pkg/converters/ingress/annotations/mapper.go
@@ -27,7 +27,6 @@ import (
 // MapBuilder ...
 type MapBuilder struct {
 	logger      types.Logger
-	annPrefix   string
 	annDefaults map[string]string
 }
 
@@ -64,10 +63,9 @@ type ConfigValue struct {
 }
 
 // NewMapBuilder ...
-func NewMapBuilder(logger types.Logger, annPrefix string, annDefaults map[string]string) *MapBuilder {
+func NewMapBuilder(logger types.Logger, annDefaults map[string]string) *MapBuilder {
 	return &MapBuilder{
 		logger:      logger,
-		annPrefix:   annPrefix,
 		annDefaults: annDefaults,
 	}
 }
@@ -178,8 +176,8 @@ func (c *Mapper) Get(key string) *ConfigValue {
 		}
 		if len(sources) > 0 {
 			c.logger.Warn(
-				"annotation '%s' from %s overrides the same annotation with distinct value from %s",
-				c.annPrefix+key, value.Source, sources)
+				"configuration key '%s' from %s overrides the same key with distinct value from %s",
+				key, value.Source, sources)
 		}
 	}
 	return value

--- a/pkg/converters/ingress/annotations/mapper_test.go
+++ b/pkg/converters/ingress/annotations/mapper_test.go
@@ -60,12 +60,11 @@ func TestAddAnnotation(t *testing.T) {
 	pathPath := hatypes.CreatePathLink("domain.local", "/path")
 	pathURL := hatypes.CreatePathLink("domain.local", "/url")
 	testCases := []struct {
-		ann       []ann
-		annPrefix string
-		getKey    string
-		expMiss   bool
-		expVal    string
-		expLog    string
+		ann     []ann
+		getKey  string
+		expMiss bool
+		expVal  string
+		expLog  string
 	}{
 		// 0
 		{
@@ -73,10 +72,9 @@ func TestAddAnnotation(t *testing.T) {
 				{srcing1, pathRoot, "auth-basic", "default/basic1", false},
 				{srcing2, pathURL, "auth-basic", "default/basic2", false},
 			},
-			annPrefix: "ing/",
-			getKey:    "auth-basic",
-			expVal:    "default/basic1",
-			expLog:    "WARN annotation 'ing/auth-basic' from ingress 'default/ing1' overrides the same annotation with distinct value from [ingress 'default/ing2']",
+			getKey: "auth-basic",
+			expVal: "default/basic1",
+			expLog: "WARN configuration key 'auth-basic' from ingress 'default/ing1' overrides the same key with distinct value from [ingress 'default/ing2']",
 		},
 		// 1
 		{
@@ -86,10 +84,9 @@ func TestAddAnnotation(t *testing.T) {
 				{srcing3, pathPath, "auth-basic", "default/basic3", false},
 				{srcing4, pathApp, "auth-basic", "default/basic4", false},
 			},
-			annPrefix: "ing.k8s.io/",
-			getKey:    "auth-basic",
-			expVal:    "default/basic1",
-			expLog:    "WARN annotation 'ing.k8s.io/auth-basic' from ingress 'default/ing1' overrides the same annotation with distinct value from [ingress 'default/ing2' ingress 'default/ing3' ingress 'default/ing4']",
+			getKey: "auth-basic",
+			expVal: "default/basic1",
+			expLog: "WARN configuration key 'auth-basic' from ingress 'default/ing1' overrides the same key with distinct value from [ingress 'default/ing2' ingress 'default/ing3' ingress 'default/ing4']",
 		},
 		// 2
 		{
@@ -99,10 +96,9 @@ func TestAddAnnotation(t *testing.T) {
 				{srcing3, pathPath, "auth-basic", "default/basic1", false},
 				{srcing4, pathApp, "auth-basic", "default/basic2", false},
 			},
-			annPrefix: "ing.k8s.io/",
-			getKey:    "auth-basic",
-			expVal:    "default/basic1",
-			expLog:    "WARN annotation 'ing.k8s.io/auth-basic' from ingress 'default/ing1' overrides the same annotation with distinct value from [ingress 'default/ing4']",
+			getKey: "auth-basic",
+			expVal: "default/basic1",
+			expLog: "WARN configuration key 'auth-basic' from ingress 'default/ing1' overrides the same key with distinct value from [ingress 'default/ing4']",
 		},
 		// 3
 		{
@@ -131,7 +127,7 @@ func TestAddAnnotation(t *testing.T) {
 	}
 	for i, test := range testCases {
 		c := setup(t)
-		mapper := NewMapBuilder(c.logger, test.annPrefix, map[string]string{}).NewMapper()
+		mapper := NewMapBuilder(c.logger, map[string]string{}).NewMapper()
 		for j, ann := range test.ann {
 			if conflict := mapper.addAnnotation(ann.src, ann.path, ann.key, ann.val); conflict != ann.expConflict {
 				t.Errorf("expect conflict '%t' on '// %d (%d)', but was '%t'", ann.expConflict, i, j, conflict)
@@ -158,7 +154,6 @@ func TestGetAnnotation(t *testing.T) {
 	pathURL := hatypes.CreatePathLink("domain.local", "/url")
 	testCases := []struct {
 		ann       []ann
-		annPrefix string
 		getKey    string
 		expMiss   bool
 		expConfig []*PathConfig
@@ -202,7 +197,7 @@ func TestGetAnnotation(t *testing.T) {
 	}
 	for i, test := range testCases {
 		c := setup(t)
-		mapper := NewMapBuilder(c.logger, test.annPrefix, map[string]string{}).NewMapper()
+		mapper := NewMapBuilder(c.logger, map[string]string{}).NewMapper()
 		for j, ann := range test.ann {
 			if conflict := mapper.addAnnotation(ann.src, ann.path, ann.key, ann.val); conflict != ann.expConflict {
 				t.Errorf("expect conflict '%t' on '// %d (%d)', but was '%t'", ann.expConflict, i, j, conflict)
@@ -290,7 +285,7 @@ func TestGetDefault(t *testing.T) {
 	pathRoot := hatypes.CreatePathLink("domain.local", "/")
 	for i, test := range testCases {
 		c := setup(t)
-		mapper := NewMapBuilder(c.logger, "ing.k8s.io", test.annDefaults).NewMapper()
+		mapper := NewMapBuilder(c.logger, test.annDefaults).NewMapper()
 		mapper.AddAnnotations(&Source{}, pathRoot, test.ann)
 		for key, exp := range test.expAnn {
 			value := mapper.Get(key).Value

--- a/pkg/converters/ingress/annotations/updater_test.go
+++ b/pkg/converters/ingress/annotations/updater_test.go
@@ -146,7 +146,7 @@ func (c *testConfig) createUpdater() *updater {
 }
 
 func (c *testConfig) createBackendData(svcFullName string, source *Source, ann, annDefault map[string]string) *backData {
-	mapper := NewMapBuilder(c.logger, "ing.k8s.io/", annDefault).NewMapper()
+	mapper := NewMapBuilder(c.logger, annDefault).NewMapper()
 	mapper.AddAnnotations(source, hatypes.CreatePathLink("domain.local", "/"), ann)
 	svcName := strings.Split(svcFullName, "/")
 	namespace := svcName[0]
@@ -191,7 +191,7 @@ func (c *testConfig) createBackendMappingData(
 }
 
 func (c *testConfig) createHostData(source *Source, ann, annDefault map[string]string) *hostData {
-	mapper := NewMapBuilder(c.logger, "", annDefault).NewMapper()
+	mapper := NewMapBuilder(c.logger, annDefault).NewMapper()
 	mapper.AddAnnotations(source, hatypes.CreatePathLink("domain.local", "/"), ann)
 	return &hostData{
 		host:   &hatypes.Host{},
@@ -208,6 +208,6 @@ func (c *testConfig) compareObjects(name string, index int, actual, expected int
 func (c *testConfig) createGlobalData(config map[string]string) *globalData {
 	return &globalData{
 		global: &hatypes.Global{},
-		mapper: NewMapBuilder(c.logger, "", config).NewMapper(),
+		mapper: NewMapBuilder(c.logger, config).NewMapper(),
 	}
 }

--- a/pkg/converters/ingress/types/options.go
+++ b/pkg/converters/ingress/types/options.go
@@ -32,6 +32,6 @@ type ConverterOptions struct {
 	DefaultCrtSecret string
 	FakeCrtFile      convtypes.CrtFile
 	FakeCAFile       convtypes.CrtFile
-	AnnotationPrefix string
+	AnnotationPrefix []string
 	AcmeTrackTLSAnn  bool
 }


### PR DESCRIPTION
This update converts the annotations prefix to a slice, allowing to configure more than one supported prefix. Using a list of prefix makes it possible to conveniently change the default value without breaking backward compatibility. In the case of a conflict, the prefix that appears first in the command-line option will have precedence.