### PR TITLE
Fix reading of needFullSync status

### DIFF
--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -870,6 +870,7 @@ func (c *k8scache) SwapChangedObjects() *convtypes.ChangedObjects {
 		ConfigMapsUpd:     c.configMapsUpd,
 		ConfigMapsAdd:     c.configMapsAdd,
 		Pods:              c.podsNew,
+		NeedFullSync:      c.needFullSync,
 		Objects:           obj,
 	}
 	//
@@ -917,11 +918,4 @@ func (c *k8scache) SwapChangedObjects() *convtypes.ChangedObjects {
 	c.clear = true
 	c.needFullSync = false
 	return changed
-}
-
-// implements converters.types.Cache
-func (c *k8scache) NeedFullSync() bool {
-	c.stateMutex.RLock()
-	defer c.stateMutex.RUnlock()
-	return c.needFullSync
 }

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -50,7 +50,7 @@ func NewIngressConverter(options *ingtypes.ConverterOptions, haproxy haproxy.Con
 	// IMPLEMENT
 	// config option to allow partial parsing
 	// cache also need to know if partial parsing is enabled
-	needFullSync := options.Cache.NeedFullSync() || globalConfigNeedFullSync(changed)
+	needFullSync := changed.NeedFullSync || globalConfigNeedFullSync(changed)
 	globalConfig := changed.GlobalCur
 	if changed.GlobalNew != nil {
 		globalConfig = changed.GlobalNew

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -41,7 +41,6 @@ type Cache interface {
 	GetDHSecretPath(defaultNamespace, secretName string) (File, error)
 	GetSecretContent(defaultNamespace, secretName, keyName string, track TrackingTarget) ([]byte, error)
 	SwapChangedObjects() *ChangedObjects
-	NeedFullSync() bool
 }
 
 // ChangedObjects ...
@@ -64,6 +63,8 @@ type ChangedObjects struct {
 	ConfigMapsDel, ConfigMapsUpd, ConfigMapsAdd []*api.ConfigMap
 	//
 	Pods []*api.Pod
+	//
+	NeedFullSync bool
 	//
 	Objects []string
 }


### PR DESCRIPTION
`needFullSync` is a k8s cache status flagged when a changed resource cannot be properly identified. This status instructs HAProxy Ingress to parses all the ingress resources and build a new haproxy model from scratch, instead of try to perform a partial parsing.

The status was being read just after a cleanup, so a full sync wouldn't run if required. This update moves the current status to the changed objects struct just before being cleaned up.