### PR TITLE
Add new redirect options

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -408,7 +408,7 @@ The table below describes all supported configuration keys.
 | [`proxy-body-size`](#proxy-body-size)                | size (bytes)                            | Path    | unlimited          |
 | [`proxy-protocol`](#proxy-protocol)                  | [v1\|v2\|v2-ssl\|v2-ssl-cn]             | Backend |                    |
 | [`redirect-from`](#redirect)                         | domain name                             | Host    |                    |
-| [`redirect-from-code`](#redirect)                    | http status code                        | Host    | `302`              |
+| [`redirect-from-code`](#redirect)                    | http status code                        | Global  | `302`              |
 | [`redirect-from-regex`](#redirect)                   | regex                                   | Host    |                    |
 | [`rewrite-target`](#rewrite-target)                  | path string                             | Path    |                    |
 | [`secure-backends`](#secure-backend)                 | [true\|false]                           | Backend |                    |
@@ -1876,11 +1876,11 @@ See also:
 
 ## Redirect
 
-| Configuration key     | Scope  | Default | Since |
-|-----------------------|--------|---------|-------|
-| `redirect-from`       | `Host` |         | v0.13 |
-| `redirect-from-code`  | `Host` | `302`   | v0.13 |
-| `redirect-from-regex` | `Host` |         | v0.13 |
+| Configuration key     | Scope    | Default | Since |
+|-----------------------|----------|---------|-------|
+| `redirect-from`       | `Host`   |         | v0.13 |
+| `redirect-from-code`  | `Global` | `302`   | v0.13 |
+| `redirect-from-regex` | `Host`   |         | v0.13 |
 
 Configures hostname redirect. Requests that matches the configuration will be redirected
 to the hostname of the ingress spec. Protocol, path and query string are preserved.

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -407,6 +407,9 @@ The table below describes all supported configuration keys.
 | [`prometheus-port`](#bind-port)                      | port number                             | Global  |                    |
 | [`proxy-body-size`](#proxy-body-size)                | size (bytes)                            | Path    | unlimited          |
 | [`proxy-protocol`](#proxy-protocol)                  | [v1\|v2\|v2-ssl\|v2-ssl-cn]             | Backend |                    |
+| [`redirect-from`](#redirect)                         | domain name                             | Host    |                    |
+| [`redirect-from-code`](#redirect)                    | http status code                        | Host    | `302`              |
+| [`redirect-from-regex`](#redirect)                   | regex                                   | Host    |                    |
 | [`rewrite-target`](#rewrite-target)                  | path string                             | Path    |                    |
 | [`secure-backends`](#secure-backend)                 | [true\|false]                           | Backend |                    |
 | [`secure-crt-secret`](#secure-backend)               | secret name                             | Backend |                    |
@@ -415,9 +418,6 @@ The table below describes all supported configuration keys.
 | [`secure-verify-hostname`](#secure-backend)          | hostname                                | Backend |                    |
 | [`server-alias`](#server-alias)                      | domain name                             | Host    |                    |
 | [`server-alias-regex`](#server-alias)                | regex                                   | Host    |                    |
-| [`server-redirect`](#server-redirect)                | domain name                             | Host    |                    |
-| [`server-redirect-code`](#server-redirect)           | http status code                        | Host    | `302`              |
-| [`server-redirect-regex`](#server-redirect)          | regex                                   | Host    |                    |
 | [`service-upstream`](#service-upstream)              | [true\|false]                           | Backend | `false`            |
 | [`session-cookie-dynamic`](#affinity)                | [true\|false]                           | Backend |                    |
 | [`session-cookie-keywords`](#affinity)               | cookie options                          | Backend | `indirect nocache httponly`     |
@@ -1874,6 +1874,29 @@ See also:
 
 ---
 
+## Redirect
+
+| Configuration key     | Scope  | Default | Since |
+|-----------------------|--------|---------|-------|
+| `redirect-from`       | `Host` |         | v0.13 |
+| `redirect-from-code`  | `Host` | `302`   | v0.13 |
+| `redirect-from-regex` | `Host` |         | v0.13 |
+
+Configures hostname redirect. Requests that matches the configuration will be redirected
+to the hostname of the ingress spec. Protocol, path and query string are preserved.
+
+The same source domain can be configured just once, and a target domain can be assigned
+just once as well, which means that this configuration can only be used on ingress
+resources that defines just one hostname. The redirect configuration has the lesser
+precedence, so if a source domain is also configured as a hostname in the ingress spec,
+or as an alias using annotation, the redirect will not happen.
+
+* `redirect-from`: Defines a source domain using hostname-like syntax, so wildcard domains can also be used.
+* `redirect-from-regex`: Defines a POSIX extended regular expression used to match a source domain. The regex will be used verbatim, so add `^` and `$` if strict hostname is desired and escape `\.` dots in order to strictly match them.
+* `redirect-from-code`: Which HTTP status code should be used in the redirect. A `302` response is used by default if not configured.
+
+---
+
 ## Rewrite target
 
 | Configuration key | Scope  | Default | Since |
@@ -1995,29 +2018,6 @@ attribute in the same ACL, and any of them might be used to match SNI extensions
 
 * `server-alias`: Defines an alias with hostname-like syntax. On v0.6 and older, wildcard `*` wasn't converted to match a subdomain. Regular expression was also accepted but dots were escaped, making this alias less useful as a regex. Starting v0.7 the same hostname syntax is used, so `*.my.domain` will match `app.my.domain` but won't match `sub.app.my.domain`.
 * `server-alias-regex`: Only in v0.7 and newer. Match hostname using a POSIX extended regular expression. The regex will be used verbatim, so add `^` and `$` if strict hostname is desired and escape `\.` dots in order to strictly match them. Some HTTP clients add the port number in the Host header, so remember to add `(:[0-9]+)?$` in the end of the regex if a dollar sign `$` is being used to match the end of the string.
-
----
-
-## Server redirect
-
-| Configuration key       | Scope  | Default | Since |
-|-------------------------|--------|---------|-------|
-| `server-redirect`       | `Host` |         | v0.13 |
-| `server-redirect-code`  | `Host` | `302`   | v0.13 |
-| `server-redirect-regex` | `Host` |         | v0.13 |
-
-Configures hostname redirect. Requests that matches the configuration will be redirected
-to the hostname of the ingress spec. Protocol, path and query string are preserved.
-
-The same source domain can be configured just once, and a target domain can be assigned
-just once as well, which means that this configuration can only be used on ingress
-resources that defines just one hostname. The redirect configuration has the lesser
-precedence, so if a source domain is also configured as a hostname in the ingress spec,
-or as an alias using annotation, the redirect will not happen.
-
-* `server-redirect`: Defines a source domain using hostname-like syntax, so wildcard domains can also be used.
-* `server-redirect-regex`: Defines a POSIX extended regular expression used to match a source domain. The regex will be used verbatim, so add `^` and `$` if strict hostname is desired and escape `\.` dots in order to strictly match them.
-* `server-redirect-code`: Which HTTP status code should be used in the redirect. A `302` response is used by default if not configured.
 
 ---
 

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -73,21 +73,21 @@ func (c *updater) buildHostCertSigner(d *hostData) {
 
 func (c *updater) buildHostRedirect(d *hostData) {
 	// TODO need a host<->host tracking if a target is found
-	redir := d.mapper.Get(ingtypes.HostServerRedirect)
+	redir := d.mapper.Get(ingtypes.HostRedirectFrom)
 	if target := c.haproxy.Hosts().FindTargetRedirect(redir.Value, false); target != nil {
 		c.logger.Warn("ignoring redirect from '%s' on %v, it's already targeting to '%s'",
 			redir.Value, redir.Source, target.Hostname)
 	} else {
 		d.host.Redirect.RedirectHost = redir.Value
 	}
-	redirRegex := d.mapper.Get(ingtypes.HostServerRedirectRegex)
+	redirRegex := d.mapper.Get(ingtypes.HostRedirectFromRegex)
 	if target := c.haproxy.Hosts().FindTargetRedirect(redirRegex.Value, true); target != nil {
 		c.logger.Warn("ignoring regex redirect from '%s' on %v, it's already targeting to '%s'",
 			redirRegex.Value, redirRegex.Source, target.Hostname)
 	} else {
 		d.host.Redirect.RedirectHostRegex = redirRegex.Value
 	}
-	d.host.Redirect.RedirectCode = d.mapper.Get(ingtypes.HostServerRedirectCode).Int()
+	d.host.Redirect.RedirectCode = d.mapper.Get(ingtypes.HostRedirectFromCode).Int()
 }
 
 func (c *updater) buildHostSSLPassthrough(d *hostData) {

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -87,7 +87,6 @@ func (c *updater) buildHostRedirect(d *hostData) {
 	} else {
 		d.host.Redirect.RedirectHostRegex = redirRegex.Value
 	}
-	d.host.Redirect.RedirectCode = d.mapper.Get(ingtypes.HostRedirectFromCode).Int()
 }
 
 func (c *updater) buildHostSSLPassthrough(d *hostData) {

--- a/pkg/converters/ingress/annotations/host_test.go
+++ b/pkg/converters/ingress/annotations/host_test.go
@@ -41,10 +41,9 @@ func TestBuildHostRedirect(t *testing.T) {
 		// 1
 		{
 			ann: map[string]string{
-				ingtypes.HostRedirectFrom:     "www.d.local",
-				ingtypes.HostRedirectFromCode: "301",
+				ingtypes.HostRedirectFrom: "www.d.local",
 			},
-			expected: hatypes.HostRedirectConfig{RedirectHost: "www.d.local", RedirectCode: 301},
+			expected: hatypes.HostRedirectConfig{RedirectHost: "www.d.local"},
 		},
 		// 2
 		{
@@ -60,7 +59,6 @@ func TestBuildHostRedirect(t *testing.T) {
 		{
 			annPrev: map[string]string{
 				ingtypes.HostRedirectFromRegex: "[a-z]+\\.d\\.local",
-				ingtypes.HostRedirectFromCode:  "301",
 			},
 			ann: map[string]string{
 				ingtypes.HostRedirectFrom: "www.d.local",

--- a/pkg/converters/ingress/annotations/host_test.go
+++ b/pkg/converters/ingress/annotations/host_test.go
@@ -34,53 +34,53 @@ func TestBuildHostRedirect(t *testing.T) {
 		// 0
 		{
 			ann: map[string]string{
-				ingtypes.HostServerRedirect: "www.d.local",
+				ingtypes.HostRedirectFrom: "www.d.local",
 			},
 			expected: hatypes.HostRedirectConfig{RedirectHost: "www.d.local"},
 		},
 		// 1
 		{
 			ann: map[string]string{
-				ingtypes.HostServerRedirect:     "www.d.local",
-				ingtypes.HostServerRedirectCode: "301",
+				ingtypes.HostRedirectFrom:     "www.d.local",
+				ingtypes.HostRedirectFromCode: "301",
 			},
 			expected: hatypes.HostRedirectConfig{RedirectHost: "www.d.local", RedirectCode: 301},
 		},
 		// 2
 		{
 			annPrev: map[string]string{
-				ingtypes.HostServerRedirect: "www.d.local",
+				ingtypes.HostRedirectFrom: "www.d.local",
 			},
 			ann: map[string]string{
-				ingtypes.HostServerRedirect: "www.d.local",
+				ingtypes.HostRedirectFrom: "www.d.local",
 			},
 			logging: `WARN ignoring redirect from 'www.d.local' on ingress 'default/ing1', it's already targeting to 'dprev.local'`,
 		},
 		// 3
 		{
 			annPrev: map[string]string{
-				ingtypes.HostServerRedirectRegex: "[a-z]+\\.d\\.local",
-				ingtypes.HostServerRedirectCode:  "301",
+				ingtypes.HostRedirectFromRegex: "[a-z]+\\.d\\.local",
+				ingtypes.HostRedirectFromCode:  "301",
 			},
 			ann: map[string]string{
-				ingtypes.HostServerRedirect: "www.d.local",
+				ingtypes.HostRedirectFrom: "www.d.local",
 			},
 			expected: hatypes.HostRedirectConfig{RedirectHost: "www.d.local"},
 		},
 		// 4
 		{
 			annPrev: map[string]string{
-				ingtypes.HostServerRedirectRegex: "[a-z]+\\.d\\.local",
+				ingtypes.HostRedirectFromRegex: "[a-z]+\\.d\\.local",
 			},
 			ann: map[string]string{
-				ingtypes.HostServerRedirectRegex: "[a-z]+\\.d\\.local",
+				ingtypes.HostRedirectFromRegex: "[a-z]+\\.d\\.local",
 			},
 			logging: `WARN ignoring regex redirect from '[a-z]+\.d\.local' on ingress 'default/ing1', it's already targeting to 'dprev.local'`,
 		},
 		// 5
 		{
 			ann: map[string]string{
-				ingtypes.HostServerRedirect: "*.d.local",
+				ingtypes.HostRedirectFrom: "*.d.local",
 			},
 			// haproxy/config's responsibility to convert wildcard hostnames to regex
 			expected: hatypes.HostRedirectConfig{RedirectHost: "*.d.local"},
@@ -88,10 +88,10 @@ func TestBuildHostRedirect(t *testing.T) {
 		// 6
 		{
 			annPrev: map[string]string{
-				ingtypes.HostServerRedirect: "*.d.local",
+				ingtypes.HostRedirectFrom: "*.d.local",
 			},
 			ann: map[string]string{
-				ingtypes.HostServerRedirect: "*.d.local",
+				ingtypes.HostRedirectFrom: "*.d.local",
 			},
 			logging: `WARN ignoring redirect from '*.d.local' on ingress 'default/ing1', it's already targeting to 'dprev.local'`,
 		},

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -146,7 +146,8 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()
 	//
-	c.haproxy.Frontend().DefaultServerRedirectCode = mapper.Get(ingtypes.GlobalRedirectFromCode).Int()
+	c.haproxy.Frontend().RedirectFromCode = mapper.Get(ingtypes.GlobalRedirectFromCode).Int()
+	c.haproxy.Frontend().RedirectToCode = mapper.Get(ingtypes.GlobalRedirectToCode).Int()
 	//
 	c.buildGlobalAcme(d)
 	c.buildGlobalAuthProxy(d)

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -146,7 +146,7 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()
 	//
-	c.haproxy.Frontend().DefaultServerRedirectCode = mapper.Get(ingtypes.HostRedirectFromCode).Int()
+	c.haproxy.Frontend().DefaultServerRedirectCode = mapper.Get(ingtypes.GlobalRedirectFromCode).Int()
 	//
 	c.buildGlobalAcme(d)
 	c.buildGlobalAuthProxy(d)

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -146,7 +146,7 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()
 	//
-	c.haproxy.Frontend().DefaultServerRedirectCode = mapper.Get(ingtypes.HostServerRedirectCode).Int()
+	c.haproxy.Frontend().DefaultServerRedirectCode = mapper.Get(ingtypes.HostRedirectFromCode).Int()
 	//
 	c.buildGlobalAcme(d)
 	c.buildGlobalAuthProxy(d)

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -32,12 +32,11 @@ func createDefaults() map[string]string {
 	return map[string]string{
 		types.TCPTCPServiceLogFormat: "default",
 		//
-		types.HostAuthTLSStrict:    "false",
-		types.HostRedirectFromCode: "302",
-		types.HostSSLCiphers:       defaultSSLCiphers,
-		types.HostSSLCipherSuites:  defaultSSLCipherSuites,
-		types.HostSSLOptionsHost:   "",
-		types.HostTLSALPN:          "h2,http/1.1",
+		types.HostAuthTLSStrict:   "false",
+		types.HostSSLCiphers:      defaultSSLCiphers,
+		types.HostSSLCipherSuites: defaultSSLCipherSuites,
+		types.HostSSLOptionsHost:  "",
+		types.HostTLSALPN:         "h2,http/1.1",
 		//
 		types.BackBackendServerNaming:    "sequence",
 		types.BackBackendServerSlotsInc:  "1",
@@ -95,6 +94,7 @@ func createDefaults() map[string]string {
 		types.GlobalNbthread:                     "2",
 		types.GlobalNoTLSRedirectLocations:       "/.well-known/acme-challenge",
 		types.GlobalPathTypeOrder:                "exact,prefix,begin,regex",
+		types.GlobalRedirectFromCode:             "302",
 		types.GlobalSSLDHDefaultMaxSize:          "2048",
 		types.GlobalSSLHeadersPrefix:             "X-SSL",
 		types.GlobalSSLOptions:                   defaultSSLOptions,

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -32,12 +32,12 @@ func createDefaults() map[string]string {
 	return map[string]string{
 		types.TCPTCPServiceLogFormat: "default",
 		//
-		types.HostAuthTLSStrict:      "false",
-		types.HostServerRedirectCode: "302",
-		types.HostSSLCiphers:         defaultSSLCiphers,
-		types.HostSSLCipherSuites:    defaultSSLCipherSuites,
-		types.HostSSLOptionsHost:     "",
-		types.HostTLSALPN:            "h2,http/1.1",
+		types.HostAuthTLSStrict:    "false",
+		types.HostRedirectFromCode: "302",
+		types.HostSSLCiphers:       defaultSSLCiphers,
+		types.HostSSLCipherSuites:  defaultSSLCipherSuites,
+		types.HostSSLOptionsHost:   "",
+		types.HostTLSALPN:          "h2,http/1.1",
 		//
 		types.BackBackendServerNaming:    "sequence",
 		types.BackBackendServerSlotsInc:  "1",

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -95,6 +95,7 @@ func createDefaults() map[string]string {
 		types.GlobalNoTLSRedirectLocations:       "/.well-known/acme-challenge",
 		types.GlobalPathTypeOrder:                "exact,prefix,begin,regex",
 		types.GlobalRedirectFromCode:             "302",
+		types.GlobalRedirectToCode:               "302",
 		types.GlobalSSLDHDefaultMaxSize:          "2048",
 		types.GlobalSSLHeadersPrefix:             "X-SSL",
 		types.GlobalSSLOptions:                   defaultSSLOptions,

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -481,6 +481,11 @@ func (c *converter) syncIngressHTTP(source *annotations.Source, ing *networking.
 				c.logger.Warn("skipping redeclared path '%s' of %v", uri, source)
 				continue
 			}
+			match := c.readPathType(path, annHost[ingtypes.HostPathType])
+			if redirectTo := annBack[ingtypes.BackRedirectTo]; redirectTo != "" {
+				host.AddRedirect(uri, match, redirectTo)
+				continue
+			}
 			svcName, svcPort, err := readServiceNamePort(&path.Backend)
 			if err != nil {
 				c.logger.Warn("skipping backend config of %v: %v", source, err)
@@ -492,7 +497,6 @@ func (c *converter) syncIngressHTTP(source *annotations.Source, ing *networking.
 				c.logger.Warn("skipping backend config of %v: %v", source, err)
 				continue
 			}
-			match := c.readPathType(path, annHost[ingtypes.HostPathType])
 			host.AddPath(backend, uri, match)
 			sslpassthrough, _ := strconv.ParseBool(annHost[ingtypes.HostSSLPassthrough])
 			sslpasshttpport := annHost[ingtypes.HostSSLPassthroughHTTPPort]

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -42,11 +42,11 @@ const (
 	HostAuthTLSVerifyClient    = "auth-tls-verify-client"
 	HostCertSigner             = "cert-signer"
 	HostPathType               = "path-type"
+	HostRedirectFrom           = "redirect-from"
+	HostRedirectFromCode       = "redirect-from-code"
+	HostRedirectFromRegex      = "redirect-from-regex"
 	HostServerAlias            = "server-alias"
 	HostServerAliasRegex       = "server-alias-regex"
-	HostServerRedirect         = "server-redirect"
-	HostServerRedirectCode     = "server-redirect-code"
-	HostServerRedirectRegex    = "server-redirect-regex"
 	HostSSLCiphers             = "ssl-ciphers"
 	HostSSLCipherSuites        = "ssl-cipher-suites"
 	HostSSLOptionsHost         = "ssl-options-host"
@@ -67,10 +67,10 @@ var (
 		HostCertSigner:             {},
 		HostServerAlias:            {},
 		HostPathType:               {},
+		HostRedirectFrom:           {},
+		HostRedirectFromCode:       {},
+		HostRedirectFromRegex:      {},
 		HostServerAliasRegex:       {},
-		HostServerRedirect:         {},
-		HostServerRedirectCode:     {},
-		HostServerRedirectRegex:    {},
 		HostSSLCiphers:             {},
 		HostSSLCipherSuites:        {},
 		HostSSLOptionsHost:         {},

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -135,6 +135,7 @@ const (
 	BackOAuthURIPrefix         = "oauth-uri-prefix"
 	BackProxyBodySize          = "proxy-body-size"
 	BackProxyProtocol          = "proxy-protocol"
+	BackRedirectTo             = "redirect-to"
 	BackRewriteTarget          = "rewrite-target"
 	BackSlotsMinFree           = "slots-min-free"
 	BackSecureBackends         = "secure-backends"

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -43,7 +43,6 @@ const (
 	HostCertSigner             = "cert-signer"
 	HostPathType               = "path-type"
 	HostRedirectFrom           = "redirect-from"
-	HostRedirectFromCode       = "redirect-from-code"
 	HostRedirectFromRegex      = "redirect-from-regex"
 	HostServerAlias            = "server-alias"
 	HostServerAliasRegex       = "server-alias-regex"
@@ -68,7 +67,6 @@ var (
 		HostServerAlias:            {},
 		HostPathType:               {},
 		HostRedirectFrom:           {},
-		HostRedirectFromCode:       {},
 		HostRedirectFromRegex:      {},
 		HostServerAliasRegex:       {},
 		HostSSLCiphers:             {},

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -78,6 +78,7 @@ const (
 	GlobalUsername                     = "username"
 	GlobalPrometheusPort               = "prometheus-port"
 	GlobalRedirectFromCode             = "redirect-from-code"
+	GlobalRedirectToCode               = "redirect-to-code"
 	GlobalSSLDHDefaultMaxSize          = "ssl-dh-default-max-size"
 	GlobalSSLDHParam                   = "ssl-dh-param"
 	GlobalSSLEngine                    = "ssl-engine"

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -77,6 +77,7 @@ const (
 	GlobalPathTypeOrder                = "path-type-order"
 	GlobalUsername                     = "username"
 	GlobalPrometheusPort               = "prometheus-port"
+	GlobalRedirectFromCode             = "redirect-from-code"
 	GlobalSSLDHDefaultMaxSize          = "ssl-dh-default-max-size"
 	GlobalSSLDHParam                   = "ssl-dh-param"
 	GlobalSSLEngine                    = "ssl-engine"

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -19,7 +19,6 @@ package haproxy
 import (
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 
 	"github.com/jinzhu/copier"
@@ -179,7 +178,6 @@ func (c *config) WriteFrontendMaps() error {
 		//
 		RedirFromRootMap:  mapBuilder.AddMap(mapsDir + "/_front_redir_fromroot.map"),
 		RedirSourceMap:    mapBuilder.AddMap(mapsDir + "/_front_redir_source.map"),
-		RedirCodeMap:      mapBuilder.AddMap(mapsDir + "/_front_redir_code.map"),
 		SSLPassthroughMap: mapBuilder.AddMap(mapsDir + "/_front_sslpassthrough.map"),
 		VarNamespaceMap:   mapBuilder.AddMap(mapsDir + "/_front_namespace.map"),
 		//
@@ -235,21 +233,11 @@ func (c *config) WriteFrontendMaps() error {
 		if host.SSLPassthrough() {
 			continue
 		}
-		var redirectCode string
-		if host.Redirect.RedirectCode > 0 && host.Redirect.RedirectCode != c.frontend.DefaultServerRedirectCode {
-			redirectCode = strconv.Itoa(host.Redirect.RedirectCode)
-		}
 		if host.Redirect.RedirectHost != "" {
 			fmaps.RedirSourceMap.AddHostnameMapping(host.Redirect.RedirectHost, host.Hostname)
-			if redirectCode != "" {
-				fmaps.RedirCodeMap.AddHostnameMapping(host.Redirect.RedirectHost, redirectCode)
-			}
 		}
 		if host.Redirect.RedirectHostRegex != "" {
 			fmaps.RedirSourceMap.AddHostnameMappingRegex(host.Redirect.RedirectHostRegex, host.Hostname)
-			if redirectCode != "" {
-				fmaps.RedirCodeMap.AddHostnameMappingRegex(host.Redirect.RedirectHostRegex, redirectCode)
-			}
 		}
 		if host.HasTLSAuth() {
 			fmaps.TLSAuthList.AddHostnameMapping(host.Hostname, "")

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -177,7 +177,8 @@ func (c *config) WriteFrontendMaps() error {
 		HTTPSSNIMap:  mapBuilder.AddMap(mapsDir + "/_front_https_sni.map"),
 		//
 		RedirFromRootMap:  mapBuilder.AddMap(mapsDir + "/_front_redir_fromroot.map"),
-		RedirSourceMap:    mapBuilder.AddMap(mapsDir + "/_front_redir_source.map"),
+		RedirFromMap:      mapBuilder.AddMap(mapsDir + "/_front_redir_from.map"),
+		RedirToMap:        mapBuilder.AddMap(mapsDir + "/_front_redir_to.map"),
 		SSLPassthroughMap: mapBuilder.AddMap(mapsDir + "/_front_sslpassthrough.map"),
 		VarNamespaceMap:   mapBuilder.AddMap(mapsDir + "/_front_namespace.map"),
 		//
@@ -195,30 +196,35 @@ func (c *config) WriteFrontendMaps() error {
 		for _, path := range host.Paths {
 			backendID := path.Backend.ID
 			// IMPLEMENT check if host.Alias.AliasName was already used as a hostname
-			if host.SSLPassthrough() {
-				// no ssl offload, cannot inspect incomming path, so tracking root only
-				if path.Path == "/" {
-					fmaps.SSLPassthroughMap.AddHostnameMapping(host.Hostname, backendID)
-					// the backend of the root path is the ssl-passthrough, which speaks TLS,
-					// so we cannot use it in the HTTP map. Change to the configured HTTP port
-					// in that server (if declared) or use a redirect otherwise.
-					backendID = host.HTTPPassthroughBackend
-					if backendID == "" {
-						backendID = "_redirect_https"
+			if backendID != "" {
+				if host.SSLPassthrough() {
+					// no ssl offload, cannot inspect incomming path, so tracking root only
+					if path.Path == "/" {
+						fmaps.SSLPassthroughMap.AddHostnameMapping(host.Hostname, backendID)
+						// the backend of the root path is the ssl-passthrough, which speaks TLS,
+						// so we cannot use it in the HTTP map. Change to the configured HTTP port
+						// in that server (if declared) or use a redirect otherwise.
+						backendID = host.HTTPPassthroughBackend
+						if backendID == "" {
+							backendID = "_redirect_https"
+						}
+					}
+				} else {
+					// ssl offload in place
+					if host.HasTLSAuth() {
+						fmaps.HTTPSSNIMap.AddHostnamePathMapping(host.Hostname, path, backendID)
+						fmaps.HTTPSSNIMap.AddAliasPathMapping(host.Alias, path, backendID)
+					} else {
+						fmaps.HTTPSHostMap.AddHostnamePathMapping(host.Hostname, path, backendID)
+						fmaps.HTTPSHostMap.AddAliasPathMapping(host.Alias, path, backendID)
 					}
 				}
-			} else {
-				// ssl offload in place
-				if host.HasTLSAuth() {
-					fmaps.HTTPSSNIMap.AddHostnamePathMapping(host.Hostname, path, backendID)
-					fmaps.HTTPSSNIMap.AddAliasPathMapping(host.Alias, path, backendID)
-				} else {
-					fmaps.HTTPSHostMap.AddHostnamePathMapping(host.Hostname, path, backendID)
-					fmaps.HTTPSHostMap.AddAliasPathMapping(host.Alias, path, backendID)
-				}
+				fmaps.HTTPHostMap.AddHostnamePathMapping(host.Hostname, path, backendID)
+				fmaps.HTTPHostMap.AddAliasPathMapping(host.Alias, path, backendID)
+			} else if path.RedirTo != "" {
+				fmaps.RedirToMap.AddHostnamePathMapping(host.Hostname, path, path.RedirTo)
+				fmaps.RedirToMap.AddAliasPathMapping(host.Alias, path, path.RedirTo)
 			}
-			fmaps.HTTPHostMap.AddHostnamePathMapping(host.Hostname, path, backendID)
-			fmaps.HTTPHostMap.AddAliasPathMapping(host.Alias, path, backendID)
 			if hasVarNamespace {
 				// add "-" on missing paths to avoid overlap
 				var ns string
@@ -234,10 +240,10 @@ func (c *config) WriteFrontendMaps() error {
 			continue
 		}
 		if host.Redirect.RedirectHost != "" {
-			fmaps.RedirSourceMap.AddHostnameMapping(host.Redirect.RedirectHost, host.Hostname)
+			fmaps.RedirFromMap.AddHostnameMapping(host.Redirect.RedirectHost, host.Hostname)
 		}
 		if host.Redirect.RedirectHostRegex != "" {
-			fmaps.RedirSourceMap.AddHostnameMappingRegex(host.Redirect.RedirectHostRegex, host.Hostname)
+			fmaps.RedirFromMap.AddHostnameMappingRegex(host.Redirect.RedirectHostRegex, host.Hostname)
 		}
 		if host.HasTLSAuth() {
 			fmaps.TLSAuthList.AddHostnameMapping(host.Hostname, "")

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -3149,43 +3149,18 @@ func TestInstanceServerRedirect(t *testing.T) {
 		// 1
 		{
 			data: [3]hatypes.HostRedirectConfig{
-				{RedirectHost: "*.d1.local", RedirectCode: 301},
-			},
-			expHTTP: `
-    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_source__regex.map) if !{ var(req.backend) -m found }
-    http-request set-var(req.redircode) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_code__regex.map,302) if { var(req.redirdest) -m found }
-    http-request redirect prefix //%[var(req.redirdest)] code %[var(req.redircode)] if { var(req.redirdest) -m found }`,
-			expHTTPS: `
-    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_source__regex.map) if !{ var(req.hostbackend) -m found }
-    http-request set-var(req.redircode) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_code__regex.map,302) if { var(req.redirdest) -m found }
-    http-request redirect prefix //%[var(req.redirdest)] code %[var(req.redircode)] if { var(req.redirdest) -m found }`,
-			expMaps: map[string]string{
-				"_front_redir_source__regex.map": `
-^[^.]+\.d1\.local$ d1.local
-`,
-				"_front_redir_code__regex.map": `
-^[^.]+\.d1\.local$ 301`,
-			},
-		},
-		// 2
-		{
-			data: [3]hatypes.HostRedirectConfig{
 				{RedirectHost: "*.d1.local"},
-				{RedirectHost: "sub.d2.local", RedirectHostRegex: "^[a-z]+\\.d2\\.local$", RedirectCode: 301},
+				{RedirectHost: "sub.d2.local", RedirectHostRegex: "^[a-z]+\\.d2\\.local$"},
 				{RedirectHostRegex: "\\.d3\\.local$"},
 			},
 			expHTTP: `
     http-request set-var(req.redirdest) var(req.host),map_str(/etc/haproxy/maps/_front_redir_source__exact.map) if !{ var(req.backend) -m found }
     http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_source__regex.map) if !{ var(req.backend) -m found } !{ var(req.redirdest) -m found }
-    http-request set-var(req.redircode) var(req.host),map_str(/etc/haproxy/maps/_front_redir_code__exact.map) if { var(req.redirdest) -m found }
-    http-request set-var(req.redircode) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_code__regex.map,302) if { var(req.redirdest) -m found } !{ var(req.redircode) -m found }
-    http-request redirect prefix //%[var(req.redirdest)] code %[var(req.redircode)] if { var(req.redirdest) -m found }`,
+    http-request redirect prefix //%[var(req.redirdest)] code 302 if { var(req.redirdest) -m found }`,
 			expHTTPS: `
     http-request set-var(req.redirdest) var(req.host),map_str(/etc/haproxy/maps/_front_redir_source__exact.map) if !{ var(req.hostbackend) -m found }
     http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_source__regex.map) if !{ var(req.hostbackend) -m found } !{ var(req.redirdest) -m found }
-    http-request set-var(req.redircode) var(req.host),map_str(/etc/haproxy/maps/_front_redir_code__exact.map) if { var(req.redirdest) -m found }
-    http-request set-var(req.redircode) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_code__regex.map,302) if { var(req.redirdest) -m found } !{ var(req.redircode) -m found }
-    http-request redirect prefix //%[var(req.redirdest)] code %[var(req.redircode)] if { var(req.redirdest) -m found }`,
+    http-request redirect prefix //%[var(req.redirdest)] code 302 if { var(req.redirdest) -m found }`,
 			expMaps: map[string]string{
 				"_front_redir_source__exact.map": `
 sub.d2.local d2.local
@@ -3194,12 +3169,6 @@ sub.d2.local d2.local
 ^[a-z]+\.d2\.local$ d2.local
 ^[^.]+\.d1\.local$ d1.local
 \.d3\.local$ d3.local
-`,
-				"_front_redir_code__exact.map": `
-sub.d2.local 301
-`,
-				"_front_redir_code__regex.map": `
-^[a-z]+\.d2\.local$ 301
 `,
 			},
 		},

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -3120,7 +3120,7 @@ d3\.local#/ d3_app_8080
 	c.logger.CompareLogging(defaultLogging)
 }
 
-func TestInstanceServerRedirect(t *testing.T) {
+func TestInstanceRedirectFrom(t *testing.T) {
 	testCases := []struct {
 		data     [3]hatypes.HostRedirectConfig
 		code     int
@@ -3135,13 +3135,13 @@ func TestInstanceServerRedirect(t *testing.T) {
 			},
 			code: 301,
 			expHTTP: `
-    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_source__regex.map) if !{ var(req.backend) -m found }
+    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_from__regex.map) if !{ var(req.backend) -m found }
     http-request redirect prefix //%[var(req.redirdest)] code 301 if { var(req.redirdest) -m found }`,
 			expHTTPS: `
-    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_source__regex.map) if !{ var(req.hostbackend) -m found }
+    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_from__regex.map) if !{ var(req.hostbackend) -m found }
     http-request redirect prefix //%[var(req.redirdest)] code 301 if { var(req.redirdest) -m found }`,
 			expMaps: map[string]string{
-				"_front_redir_source__regex.map": `
+				"_front_redir_from__regex.map": `
 ^[^.]+\.d1\.local$ d1.local
 `,
 			},
@@ -3154,18 +3154,18 @@ func TestInstanceServerRedirect(t *testing.T) {
 				{RedirectHostRegex: "\\.d3\\.local$"},
 			},
 			expHTTP: `
-    http-request set-var(req.redirdest) var(req.host),map_str(/etc/haproxy/maps/_front_redir_source__exact.map) if !{ var(req.backend) -m found }
-    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_source__regex.map) if !{ var(req.backend) -m found } !{ var(req.redirdest) -m found }
+    http-request set-var(req.redirdest) var(req.host),map_str(/etc/haproxy/maps/_front_redir_from__exact.map) if !{ var(req.backend) -m found }
+    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_from__regex.map) if !{ var(req.backend) -m found } !{ var(req.redirdest) -m found }
     http-request redirect prefix //%[var(req.redirdest)] code 302 if { var(req.redirdest) -m found }`,
 			expHTTPS: `
-    http-request set-var(req.redirdest) var(req.host),map_str(/etc/haproxy/maps/_front_redir_source__exact.map) if !{ var(req.hostbackend) -m found }
-    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_source__regex.map) if !{ var(req.hostbackend) -m found } !{ var(req.redirdest) -m found }
+    http-request set-var(req.redirdest) var(req.host),map_str(/etc/haproxy/maps/_front_redir_from__exact.map) if !{ var(req.hostbackend) -m found }
+    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_from__regex.map) if !{ var(req.hostbackend) -m found } !{ var(req.redirdest) -m found }
     http-request redirect prefix //%[var(req.redirdest)] code 302 if { var(req.redirdest) -m found }`,
 			expMaps: map[string]string{
-				"_front_redir_source__exact.map": `
+				"_front_redir_from__exact.map": `
 sub.d2.local d2.local
 `,
-				"_front_redir_source__regex.map": `
+				"_front_redir_from__regex.map": `
 ^[a-z]+\.d2\.local$ d2.local
 ^[^.]+\.d1\.local$ d1.local
 \.d3\.local$ d3.local
@@ -3200,9 +3200,9 @@ sub.d2.local d2.local
 		h.Redirect = test.data[2]
 
 		if test.code != 0 {
-			c.config.frontend.DefaultServerRedirectCode = test.code
+			c.config.frontend.RedirectFromCode = test.code
 		} else {
-			c.config.frontend.DefaultServerRedirectCode = 302
+			c.config.frontend.RedirectFromCode = 302
 		}
 
 		c.Update()
@@ -3240,6 +3240,155 @@ frontend _front_https
     http-request set-var(req.host) hdr(host),field(1,:),lower
     http-request set-var(req.base) var(req.host),concat(\#,req.path)
     http-request set-var(req.hostbackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_host__begin.map)` + test.expHTTPS + `
+    http-request set-header X-Forwarded-Proto https
+    http-request del-header X-SSL-Client-CN
+    http-request del-header X-SSL-Client-DN
+    http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-Cert
+    use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
+    default_backend _error404
+<<support>>
+`)
+		for file, content := range test.expMaps {
+			c.checkMap(file, content)
+		}
+		c.logger.CompareLogging(defaultLogging)
+	}
+}
+
+func TestInstanceRedirectTo(t *testing.T) {
+	testCases := []struct {
+		to       [3]string
+		code     int
+		expected string
+		expMaps  map[string]string
+	}{
+		// 0
+		{
+			to: [3]string{
+				"https://app.local",
+			},
+			expected: `
+    http-request set-var(req.redirto) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_redir_to__begin.map)
+    http-request redirect location %[var(req.redirto)] code 302 if { var(req.redirto) -m found }`,
+			expMaps: map[string]string{
+				"_front_redir_to__begin.map": `
+d1.local#/ https://app.local
+`,
+			},
+		},
+		// 1
+		{
+			to: [3]string{
+				"https://app.local/login",
+				"https://app.local/app2",
+			},
+			expected: `
+    http-request set-var(req.redirto) var(req.base),map_dir(/etc/haproxy/maps/_front_redir_to__prefix_01.map)
+    http-request set-var(req.redirto) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_redir_to__begin.map) if !{ var(req.redirto) -m found }
+    http-request redirect location %[var(req.redirto)] code 302 if { var(req.redirto) -m found }`,
+			expMaps: map[string]string{
+				"_front_redir_to__prefix_01.map": `
+d1.local#/app2 https://app.local/app2
+`,
+				"_front_redir_to__begin.map": `
+d1.local#/ https://app.local/login
+`,
+			},
+		},
+		// 2
+		{
+			to: [3]string{
+				"",
+				"https://app.local/app2",
+				"https://app.local/app3",
+			},
+			expected: `
+    http-request set-var(req.redirto) var(req.base),map_dir(/etc/haproxy/maps/_front_redir_to__prefix.map)
+    http-request redirect location %[var(req.redirto)] code 302 if { var(req.redirto) -m found }`,
+			expMaps: map[string]string{
+				"_front_redir_to__prefix.map": `
+d1.local#/app3 https://app.local/app3
+d1.local#/app2 https://app.local/app2
+`,
+			},
+		},
+	}
+
+	for _, test := range testCases {
+		c := setup(t)
+		defer c.teardown()
+
+		var h *hatypes.Host
+		var b *hatypes.Backend
+
+		h = c.config.Hosts().AcquireHost("d1.local")
+
+		b = c.config.Backends().AcquireBackend("d1", "app", "8080")
+		b.Endpoints = []*hatypes.Endpoint{endpointS1}
+		if test.to[0] != "" {
+			h.AddRedirect("/", hatypes.MatchBegin, test.to[0])
+		} else {
+			h.AddPath(b, "/", hatypes.MatchBegin)
+		}
+
+		b = c.config.Backends().AcquireBackend("d2", "app", "8080")
+		b.Endpoints = []*hatypes.Endpoint{endpointS21}
+		if test.to[1] != "" {
+			h.AddRedirect("/app2", hatypes.MatchPrefix, test.to[1])
+		} else {
+			h.AddPath(b, "/app2", hatypes.MatchBegin)
+		}
+
+		b = c.config.Backends().AcquireBackend("d3", "app", "8080")
+		b.Endpoints = []*hatypes.Endpoint{endpointS31}
+		if test.to[2] != "" {
+			h.AddRedirect("/app3", hatypes.MatchPrefix, test.to[2])
+		} else {
+			h.AddPath(b, "/app3", hatypes.MatchBegin)
+		}
+
+		if test.code != 0 {
+			c.config.frontend.RedirectToCode = test.code
+		} else {
+			c.config.frontend.RedirectToCode = 302
+		}
+
+		c.Update()
+		c.checkConfig(`
+<<global>>
+<<defaults>>
+backend d1_app_8080
+    mode http
+    server s1 172.17.0.11:8080 weight 100
+backend d2_app_8080
+    mode http
+    server s21 172.17.0.121:8080 weight 100
+backend d3_app_8080
+    mode http
+    server s31 172.17.0.131:8080 weight 100
+<<backends-default>>
+frontend _front_http
+    mode http
+    bind :80
+    http-request set-var(req.path) path
+    http-request set-var(req.host) hdr(host),field(1,:),lower
+    http-request set-var(req.base) var(req.host),concat(\#,req.path)
+    http-request set-header X-Forwarded-Proto http
+    http-request del-header X-SSL-Client-CN
+    http-request del-header X-SSL-Client-DN
+    http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-Cert` + test.expected + `
+    http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
+    use_backend %[var(req.backend)] if { var(req.backend) -m found }
+    default_backend _error404
+frontend _front_https
+    mode http
+    bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_bind_crt.list ca-ignore-err all crt-ignore-err all
+    http-request set-var(req.path) path
+    http-request set-var(req.host) hdr(host),field(1,:),lower
+    http-request set-var(req.base) var(req.host),concat(\#,req.path)` + test.expected + `
+    http-request set-var(req.hostbackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_host__begin.map)
     http-request set-header X-Forwarded-Proto https
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -203,6 +203,15 @@ func (h *Host) FindPath(path string) *HostPath {
 
 // AddPath ...
 func (h *Host) AddPath(backend *Backend, path string, match MatchType) {
+	h.addPath(path, match, backend, "")
+}
+
+// AddRedirect ...
+func (h *Host) AddRedirect(path string, match MatchType, redirTo string) {
+	h.addPath(path, match, nil, redirTo)
+}
+
+func (h *Host) addPath(path string, match MatchType, backend *Backend, redirTo string) {
 	link := CreatePathLink(h.Hostname, path)
 	var hback HostBackend
 	if backend != nil {
@@ -213,7 +222,7 @@ func (h *Host) AddPath(backend *Backend, path string, match MatchType) {
 			Port:      backend.Port,
 		}
 		backend.AddBackendPath(link)
-	} else {
+	} else if redirTo == "" {
 		hback = HostBackend{ID: "_error404"}
 	}
 	h.Paths = append(h.Paths, &HostPath{
@@ -221,6 +230,7 @@ func (h *Host) AddPath(backend *Backend, path string, match MatchType) {
 		Link:    link,
 		Match:   match,
 		Backend: hback,
+		RedirTo: redirTo,
 	})
 	// reverse order in order to avoid overlap of sub-paths
 	sort.Slice(h.Paths, func(i, j int) bool {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -362,7 +362,8 @@ type FrontendMaps struct {
 	HTTPSSNIMap  *HostsMap
 	//
 	RedirFromRootMap  *HostsMap
-	RedirSourceMap    *HostsMap
+	RedirFromMap      *HostsMap
+	RedirToMap        *HostsMap
 	SSLPassthroughMap *HostsMap
 	VarNamespaceMap   *HostsMap
 	//
@@ -402,7 +403,8 @@ type Frontend struct {
 	DefaultCrtHash string
 	CrtListFile    string
 	//
-	DefaultServerRedirectCode int
+	RedirectFromCode int
+	RedirectToCode   int
 }
 
 // DefaultHost ...
@@ -471,6 +473,7 @@ type HostPath struct {
 	Link    PathLink
 	Match   MatchType
 	Backend HostBackend
+	RedirTo string
 }
 
 // HostBackend ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -363,7 +363,6 @@ type FrontendMaps struct {
 	//
 	RedirFromRootMap  *HostsMap
 	RedirSourceMap    *HostsMap
-	RedirCodeMap      *HostsMap
 	SSLPassthroughMap *HostsMap
 	VarNamespaceMap   *HostsMap
 	//
@@ -490,7 +489,6 @@ type HostAliasConfig struct {
 
 // HostRedirectConfig ...
 type HostRedirectConfig struct {
-	RedirectCode      int
 	RedirectHost      string
 	RedirectHostRegex string
 }

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1357,16 +1357,8 @@ frontend {{ $proxy__front_https }}
         {{- "" }} if !{ var({{ $varbe }}) -m found }
         {{- if not $match.First }} !{ var(req.redirdest) -m found }{{ end }}
 {{- end }}
-{{- $hasCode := ne (len $fmaps.RedirCodeMap.MatchFiles) 0 }}
-{{- range $match := $fmaps.RedirCodeMap.MatchFiles }}
-    http-request set-var(req.redircode) var(req.host)
-        {{- if $match.Lower }},lower{{ end }}
-        {{- "" }},map_{{ $match.Method }}({{ $match.Filename }}{{ if $match.Last }},{{ $frontend.DefaultServerRedirectCode }}{{ end }})
-        {{- "" }} if { var(req.redirdest) -m found }
-        {{- if not $match.First }} !{ var(req.redircode) -m found }{{ end }}
-{{- end }}
     http-request redirect prefix //%[var(req.redirdest)]
-        {{- "" }} code {{ if $hasCode }}%[var(req.redircode)]{{ else }}{{ $frontend.DefaultServerRedirectCode }}{{ end }}
+        {{- "" }} code {{ $frontend.DefaultServerRedirectCode }}
         {{- "" }} if { var(req.redirdest) -m found }
 {{- end }}
 {{- end }}

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1131,6 +1131,9 @@ frontend {{ $proxy__front_http }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- template "redirectTo" map $frontend $fmaps }}
+
+{{- /*------------------------------------*/}}
 {{- range $match := $fmaps.HTTPHostMap.MatchFiles }}
     http-request set-var(req.backend) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
@@ -1139,7 +1142,7 @@ frontend {{ $proxy__front_http }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- template "serverredirect" map $frontend $fmaps "req.backend" }}
+{{- template "redirectFrom" map $frontend $fmaps "req.backend" }}
 
 {{- /*------------------------------------*/}}
 {{- range $snippet := $global.CustomFrontend }}
@@ -1200,6 +1203,9 @@ frontend {{ $proxy__front_https }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- template "redirectTo" map $frontend $fmaps }}
+
+{{- /*------------------------------------*/}}
 {{- range $match := $fmaps.HTTPSHostMap.MatchFiles }}
     http-request set-var(req.hostbackend) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
@@ -1208,7 +1214,7 @@ frontend {{ $proxy__front_https }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- template "serverredirect" map $frontend $fmaps "req.hostbackend" }}
+{{- template "redirectFrom" map $frontend $fmaps "req.hostbackend" }}
 
 {{- /*------------------------------------*/}}
 {{- if $fmaps.RedirFromRootMap.HasHost }}
@@ -1345,12 +1351,12 @@ frontend {{ $proxy__front_https }}
 
 {{- /*------------------------------------*/}}
 {{- /*------------------------------------*/}}
-{{- define "serverredirect" }}
+{{- define "redirectFrom" }}
 {{- $frontend := .p1 }}
 {{- $fmaps := .p2 }}
 {{- $varbe := .p3 }}
-{{- if $fmaps.RedirSourceMap.MatchFiles }}
-{{- range $match := $fmaps.RedirSourceMap.MatchFiles }}
+{{- if $fmaps.RedirFromMap.MatchFiles }}
+{{- range $match := $fmaps.RedirFromMap.MatchFiles }}
     http-request set-var(req.redirdest) var(req.host)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
@@ -1358,8 +1364,24 @@ frontend {{ $proxy__front_https }}
         {{- if not $match.First }} !{ var(req.redirdest) -m found }{{ end }}
 {{- end }}
     http-request redirect prefix //%[var(req.redirdest)]
-        {{- "" }} code {{ $frontend.DefaultServerRedirectCode }}
+        {{- "" }} code {{ $frontend.RedirectFromCode }}
         {{- "" }} if { var(req.redirdest) -m found }
+{{- end }}
+{{- end }}
+
+{{- define "redirectTo" }}
+{{- $frontend := .p1 }}
+{{- $fmaps := .p2 }}
+{{- if $fmaps.RedirToMap.MatchFiles }}
+{{- range $match := $fmaps.RedirToMap.MatchFiles }}
+    http-request set-var(req.redirto) var(req.base)
+        {{- if $match.Lower }},lower{{ end }}
+        {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
+        {{- if not $match.First }} if !{ var(req.redirto) -m found }{{ end }}
+{{- end }}
+    http-request redirect location %[var(req.redirto)]
+        {{- "" }} code {{ $frontend.RedirectToCode }}
+        {{- "" }} if { var(req.redirto) -m found }
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
This update adds some improvements to the just added redirect options. From now they are named redirect from and redirect to, which covers a few more use cases. Redirect code configurations were converted to global options due to the lack of dynamic config from HAProxy http-request redirect.