### PR TITLE
Fix per path filter of default host rules

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1958,24 +1958,33 @@ func TestInstanceDefaultHost(t *testing.T) {
 
 	var h *hatypes.Host
 	var b *hatypes.Backend
+	hdef := c.config.Hosts().AcquireHost(hatypes.DefaultHost)
 
 	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
-	h = c.config.Hosts().AcquireHost(hatypes.DefaultHost)
-	h.AddPath(b, "/", hatypes.MatchBegin)
+	b.Endpoints = []*hatypes.Endpoint{endpointS1}
+	h = c.config.Hosts().AcquireHost("d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
-	b.FindBackendPath(h.FindPath("/").Link).SSLRedirect = true
-	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 	h.VarNamespace = true
+	hdef.AddPath(b, "/", hatypes.MatchBegin)
+	hdef.AddPath(b, "/app1", hatypes.MatchExact)
+	hdef.AddPath(b, "/app2", hatypes.MatchPrefix)
+	b.FindBackendPath(hdef.FindPath("/").Link).SSLRedirect = true
+	b.FindBackendPath(hdef.FindPath("/app1").Link).RewriteURL = "/"
+	b.FindBackendPath(hdef.FindPath("/app2").Link).MaxBodySize = 32768
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
+	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 	h = c.config.Hosts().AcquireHost("d2.local")
-	h.AddPath(b, "/app", hatypes.MatchBegin)
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
-	b.FindBackendPath(h.FindPath("/app").Link).SSLRedirect = true
-	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 	h.VarNamespace = true
+	h.AddPath(b, "/app11", hatypes.MatchBegin)
+	hdef.AddPath(b, "/app12", hatypes.MatchExact)
+	hdef.AddPath(b, "/app13", hatypes.MatchPrefix)
+	b.FindBackendPath(h.FindPath("/app11").Link).SSLRedirect = true
+	b.FindBackendPath(hdef.FindPath("/app12").Link).RewriteURL = "/"
+	b.FindBackendPath(hdef.FindPath("/app13").Link).MaxBodySize = 65536
 
 	c.Update()
 	c.checkConfig(`
@@ -1984,12 +1993,28 @@ func TestInstanceDefaultHost(t *testing.T) {
 backend d1_app_8080
     mode http
     acl https-request ssl_fc
-    http-request redirect scheme https if !https-request
+    # path01 = <default>/
+    # path02 = <default>/app1
+    # path03 = <default>/app2
+    http-request set-var(txn.pathID) var(req.path),map_dir(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__prefix_01.map)
+    http-request set-var(txn.pathID) var(req.path),map_str(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__exact_02.map) if !{ var(txn.pathID) -m found }
+    http-request set-var(txn.pathID) var(req.path),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__begin.map) if !{ var(txn.pathID) -m found }
+    http-request redirect scheme https if !https-request { var(txn.pathID) path01 }
+    http-request use-service lua.send-413 if { var(txn.pathID) path03 } { req.body_size,sub(32768) gt 0 }
+    http-request replace-path ^/app1/?(.*)$     /\1     if { var(txn.pathID) path02 }
     server s1 172.17.0.11:8080 weight 100
 backend d2_app_8080
     mode http
     acl https-request ssl_fc
-    http-request redirect scheme https if !https-request
+    # path02 = <default>/app12
+    # path03 = <default>/app13
+    # path01 = d2.local/app11
+    http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d2_app_8080_idpath__begin.map)
+    http-request set-var(txn.pathID) var(req.path),map_str(/etc/haproxy/maps/_back_d2_app_8080_idpathdef__exact.map) if !{ var(txn.pathID) -m found }
+    http-request set-var(txn.pathID) var(req.path),map_dir(/etc/haproxy/maps/_back_d2_app_8080_idpathdef__prefix.map) if !{ var(txn.pathID) -m found }
+    http-request redirect scheme https if !https-request { var(txn.pathID) path01 }
+    http-request use-service lua.send-413 if { var(txn.pathID) path03 } { req.body_size,sub(65536) gt 0 }
+    http-request replace-path ^/app12/?(.*)$     /\1     if { var(txn.pathID) path02 }
     server s1 172.17.0.11:8080 weight 100
 backend default_default-backend_8080
     mode http
@@ -2002,35 +2027,61 @@ frontend _front_http
     http-request set-var(txn.namespace) str(-) if !{ var(txn.namespace) -m found }
     <<http-headers>>
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
+    http-request set-var(req.defaultbackend) var(req.path),map_dir(/etc/haproxy/maps/_front_defaulthost__prefix_01.map) if !{ var(req.backend) -m found }
+    http-request set-var(req.defaultbackend) var(req.path),map_str(/etc/haproxy/maps/_front_defaulthost__exact_02.map) if !{ var(req.backend) -m found } !{ var(req.defaultbackend) -m found }
+    http-request set-var(req.defaultbackend) var(req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.backend) -m found } !{ var(req.defaultbackend) -m found }
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
-    use_backend d1_app_8080
+    use_backend %[var(req.defaultbackend)]
     default_backend default_default-backend_8080
 frontend _front_https
     mode http
     bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_bind_crt.list ca-ignore-err all crt-ignore-err all
     <<set-req-base>>
     http-request set-var(req.hostbackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_host__begin.map)
+    http-request set-var(req.defaultbackend) var(req.path),map_dir(/etc/haproxy/maps/_front_defaulthost__prefix_01.map) if !{ var(req.hostbackend) -m found }
+    http-request set-var(req.defaultbackend) var(req.path),map_str(/etc/haproxy/maps/_front_defaulthost__exact_02.map) if !{ var(req.hostbackend) -m found } !{ var(req.defaultbackend) -m found }
+    http-request set-var(req.defaultbackend) var(req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.hostbackend) -m found } !{ var(req.defaultbackend) -m found }
     http-request set-var(txn.namespace) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_namespace__begin.map)
     http-request set-var(txn.namespace) str(-) if !{ var(txn.namespace) -m found }
     <<https-headers>>
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
-    use_backend d1_app_8080
+    use_backend %[var(req.defaultbackend)]
     default_backend default_default-backend_8080
 <<support>>
 `)
 
 	c.checkMap("_front_http_host__begin.map", `
-d2.local#/app d2_app_8080
+d2.local#/app11 d2_app_8080
 `)
 	c.checkMap("_front_bind_crt.list", `
 /var/haproxy/ssl/certs/default.pem !*
 `)
 	c.checkMap("_front_namespace__begin.map", `
-d2.local#/app d2
+d2.local#/app11 d2
 `)
 	c.checkMap("_front_https_host__begin.map", `
-d2.local#/app d2_app_8080
+d2.local#/app11 d2_app_8080
 `)
+	c.checkMap("_front_defaulthost__prefix_01.map", `
+/app2 d1_app_8080
+/app13 d2_app_8080`)
+	c.checkMap("_front_defaulthost__exact_02.map", `
+/app12 d2_app_8080
+/app1 d1_app_8080`)
+	c.checkMap("_front_defaulthost__begin.map", `
+/ d1_app_8080`)
+	c.checkMap("_back_d1_app_8080_idpathdef__exact_02.map", `
+/app1 path02`)
+	c.checkMap("_back_d1_app_8080_idpathdef__prefix_01.map", `
+/app2 path03`)
+	c.checkMap("_back_d1_app_8080_idpathdef__begin.map", `
+/ path01`)
+	c.checkMap("_back_d2_app_8080_idpathdef__exact.map", `
+/app12 path02`)
+	c.checkMap("_back_d2_app_8080_idpathdef__prefix.map", `
+/app13 path03`)
+	c.checkMap("_back_d2_app_8080_idpath__begin.map", `
+d2.local#/app11 path01`)
 
 	c.logger.CompareLogging(defaultLogging)
 }
@@ -2100,11 +2151,29 @@ backend d2_app_8080
     mode http
     server s21 172.17.0.121:8080 weight 100
 <<backends-default>>
-<<frontend-http>>
-    use_backend d2_app_8080
+frontend _front_http
+    mode http
+    bind :80
+    http-request set-var(req.path) path
+    http-request set-var(req.host) hdr(host),field(1,:),lower
+    http-request set-var(req.base) var(req.host),concat(\#,req.path)
+    <<http-headers>>
+    http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
+    http-request set-var(req.defaultbackend) var(req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.backend) -m found }
+    use_backend %[var(req.backend)] if { var(req.backend) -m found }
+    use_backend %[var(req.defaultbackend)]
     default_backend _error404
-<<frontend-https>>
-    use_backend d2_app_8080
+frontend _front_https
+    mode http
+    bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_bind_crt.list ca-ignore-err all crt-ignore-err all
+    http-request set-var(req.path) path
+    http-request set-var(req.host) hdr(host),field(1,:),lower
+    http-request set-var(req.base) var(req.host),concat(\#,req.path)
+    http-request set-var(req.hostbackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_host__begin.map)
+    http-request set-var(req.defaultbackend) var(req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.hostbackend) -m found }
+    <<https-headers>>
+    use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
+    use_backend %[var(req.defaultbackend)]
     default_backend _error404
 <<support>>
 `)
@@ -2116,6 +2185,8 @@ d1.local#/ d2_app_8080
 d1.local#/path d1_app_8080
 d1.local#/ d2_app_8080
 `)
+	c.checkMap("_front_defaulthost__begin.map", `
+/ d2_app_8080`)
 	c.logger.CompareLogging(defaultLogging)
 }
 

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -365,6 +365,11 @@ func (p *BackendPath) Hostname() string {
 	return p.Link.hostname
 }
 
+// IsDefaultHost ...
+func (p *BackendPath) IsDefaultHost() bool {
+	return p.Link.IsDefaultHost()
+}
+
 // Path ...
 func (p *BackendPath) Path() string {
 	return p.Link.path

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -266,6 +266,11 @@ func (l *PathLink) IsEmpty() bool {
 	return l.hostname == "" && l.path == ""
 }
 
+// IsDefaultHost ...
+func (l *PathLink) IsDefaultHost() bool {
+	return l.hostname == DefaultHost
+}
+
 // Less ...
 func (l *PathLink) Less(other PathLink, reversePath bool) bool {
 	if l.hostname == other.hostname {

--- a/pkg/haproxy/types/maps.go
+++ b/pkg/haproxy/types/maps.go
@@ -157,7 +157,7 @@ func buildMapKey(match MatchType, hostname, path string) string {
 			hostname = hostname + "[^/]*"
 		}
 	}
-	if path != "" {
+	if hostname != "" && path != "" {
 		// Fixes dir match type (Prefix from the ingress pathType) if a path or
 		// subpath matches a configured domain. Eg, this map:
 		//

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -371,6 +371,8 @@ type FrontendMaps struct {
 	TLSNeedCrtList        *HostsMap
 	TLSInvalidCrtPagesMap *HostsMap
 	TLSMissingCrtPagesMap *HostsMap
+	//
+	DefaultHostMap *HostsMap
 }
 
 // AuthProxy ...
@@ -556,9 +558,10 @@ type Backend struct {
 	//
 	// Paths
 	//
-	Paths      []*BackendPath
-	PathsMap   *HostsMap
-	pathConfig map[string]*BackendPathConfig
+	Paths               []*BackendPath
+	PathsMap            *HostsMap
+	PathsDefaultHostMap *HostsMap
+	pathConfig          map[string]*BackendPathConfig
 	//
 	// per backend config
 	//

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -435,6 +435,13 @@ backend {{ $backend.ID }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if not $match.First }} if !{ var(txn.pathID) -m found }{{ end }}
 {{- end }}
+{{- $pathsHasHost := $backend.PathsMap.HasHost }}
+{{- range $match := $backend.PathsDefaultHostMap.MatchFiles }}
+    http-request set-var(txn.pathID) var(req.path)
+        {{- if $match.Lower }},lower{{ end }}
+        {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
+        {{- if or $pathsHasHost (not $match.First) }} if !{ var(txn.pathID) -m found }{{ end }}
+{{- end }}
 {{- end }}
 
 {{- /* * Snippet of per-path configuration
@@ -1140,6 +1147,12 @@ frontend {{ $proxy__front_http }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if not $match.First }} if !{ var(req.backend) -m found }{{ end }}
 {{- end }}
+{{- range $match := $fmaps.DefaultHostMap.MatchFiles }}
+    http-request set-var(req.defaultbackend) var(req.path)
+        {{- if $match.Lower }},lower{{ end }}
+        {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
+        {{- "" }} if !{ var(req.backend) -m found }{{- if not $match.First }} !{ var(req.defaultbackend) -m found }{{ end }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- template "redirectFrom" map $frontend $fmaps "req.backend" }}
@@ -1211,6 +1224,12 @@ frontend {{ $proxy__front_https }}
         {{- if $match.Lower }},lower{{ end }}
         {{- ""}},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if not $match.First }} if !{ var(req.hostbackend) -m found }{{ end }}
+{{- end }}
+{{- range $match := $fmaps.DefaultHostMap.MatchFiles }}
+    http-request set-var(req.defaultbackend) var(req.path)
+        {{- if $match.Lower }},lower{{ end }}
+        {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
+        {{- "" }} if !{ var(req.hostbackend) -m found }{{- if not $match.First }} !{ var(req.defaultbackend) -m found }{{ end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -1393,10 +1412,7 @@ frontend {{ $proxy__front_https }}
 {{- $defaultHost := $hosts.DefaultHost }}
 {{- if $defaultHost }}
 {{- if not $defaultHost.SSLPassthrough }}
-{{- range $path := $defaultHost.Paths }}
-    use_backend {{ $path.Backend.ID }}
-        {{- if ne $path.Path "/" }} if { path_beg {{ $path.Path }} }{{ end }}
-{{- end }}
+    use_backend %[var(req.defaultbackend)]
 {{- end }}
 {{- end }}
 {{- if $defaultbackend }}


### PR DESCRIPTION
This update fixes two issues in rules with default host (empty hostname)

The first one is in the backend, the per path matching was trying to match the hostname with an internal representation. In this case only the path should be matched after the non empty hosts has been failed.

The other one is in the haproxy's frontend, the path was being matched with path_beg despite of the path type configuration. Now default host match uses a map just like non empty hosts.