### PR TITLE
Fix path-type conflict warning

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -402,7 +402,7 @@ The table below describes all supported configuration keys.
 | [`oauth`](#oauth)                                    | "oauth2_proxy"                          | Path    |                    |
 | [`oauth-headers`](#oauth)                            | `<header>:<var>,...`                    | Path    |                    |
 | [`oauth-uri-prefix`](#oauth)                         | URI prefix                              | Path    |                    |
-| [`path-type`](#path-type)                            | path matching type                      | Host    | `begin`            |
+| [`path-type`](#path-type)                            | path matching type                      | Path    | `begin`            |
 | [`path-type-order`](#path-type)                      | comma-separated path type list          | Global  | `exact,prefix,begin,regex` |
 | [`prometheus-port`](#bind-port)                      | port number                             | Global  |                    |
 | [`proxy-body-size`](#proxy-body-size)                | size (bytes)                            | Path    | unlimited          |
@@ -1802,7 +1802,7 @@ See also:
 
 | Configuration key | Scope    | Default                    | Since |
 |-------------------|----------|----------------------------|-------|
-| `path-type`       | `Host`   | `begin`                    | v0.11 |
+| `path-type`       | `Path`   | `begin`                    | v0.11 |
 | `path-type-order` | `Global` | `exact,prefix,begin,regex` | v0.12 |
 
 Defines how the path of an incoming request should match a declared path in the ingress object.

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -481,7 +481,7 @@ func (c *converter) syncIngressHTTP(source *annotations.Source, ing *networking.
 				c.logger.Warn("skipping redeclared path '%s' of %v", uri, source)
 				continue
 			}
-			match := c.readPathType(path, annHost[ingtypes.HostPathType])
+			match := c.readPathType(path, annBack[ingtypes.BackPathType])
 			if redirectTo := annBack[ingtypes.BackRedirectTo]; redirectTo != "" {
 				host.AddRedirect(uri, match, redirectTo)
 				continue

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -41,7 +41,6 @@ const (
 	HostAuthTLSStrict          = "auth-tls-strict"
 	HostAuthTLSVerifyClient    = "auth-tls-verify-client"
 	HostCertSigner             = "cert-signer"
-	HostPathType               = "path-type"
 	HostRedirectFrom           = "redirect-from"
 	HostRedirectFromRegex      = "redirect-from-regex"
 	HostServerAlias            = "server-alias"
@@ -65,7 +64,6 @@ var (
 		HostAuthTLSVerifyClient:    {},
 		HostCertSigner:             {},
 		HostServerAlias:            {},
-		HostPathType:               {},
 		HostRedirectFrom:           {},
 		HostRedirectFromRegex:      {},
 		HostServerAliasRegex:       {},
@@ -133,6 +131,7 @@ const (
 	BackOAuth                  = "oauth"
 	BackOAuthHeaders           = "oauth-headers"
 	BackOAuthURIPrefix         = "oauth-uri-prefix"
+	BackPathType               = "path-type"
 	BackProxyBodySize          = "proxy-body-size"
 	BackProxyProtocol          = "proxy-protocol"
 	BackRedirectTo             = "redirect-to"


### PR DESCRIPTION
Scopes are used to identify and log configuration conflict, and also to group configurations related to the same annotation mapping. Path type was wrongly configured as host scope and, although it was working as expected, a conflict warning was being logged if using two distinct path types in the same hostname. Change to path scope removes the warning without changing the behavior.