### PR TITLE
Accept header names in auth and oauth-headers

### DIFF
--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -53,7 +53,7 @@ func createDefaults() map[string]string {
 		types.BackHSTSMaxAge:             "15768000",
 		types.BackHSTSPreload:            "false",
 		types.BackInitialWeight:          "1",
-		types.BackOAuthHeaders:           "X-Auth-Request-Email:req.auth_response_header.x_auth_request_email",
+		types.BackOAuthHeaders:           "X-Auth-Request-Email",
 		types.BackSessionCookieDynamic:   "true",
 		types.BackSessionCookiePreserve:  "false",
 		types.BackSessionCookieValue:     "server-name",


### PR DESCRIPTION
`auth-request.lua` sanitizes header names from the authentication service in a predictable way. So instead of document this to the user, we're now running the same sanitization in code, simplifying the user interface with the configuration key. Now `auth-headers` and `oauth-headers` can configure just the header name (the same name is copied from the auth service), another header name as the source, as well as a HAProxy variable name. The later gives some flexibility and preserve backward compatibility. Vars are identified from the prefix used in the name, and if identified, their names are used verbatim instead of performing the sanitization.