### PR TITLE
Allow more than 64k outgoing conn with source addr

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -877,6 +877,49 @@ func (c *updater) buildBackendServerNaming(d *backData) {
 	}
 }
 
+var listAddrs func(ifname string) []net.Addr = func(ifname string) []net.Addr {
+	intf, _ := net.InterfaceByName(ifname)
+	if intf == nil {
+		return nil
+	}
+	addrs, _ := intf.Addrs()
+	return addrs
+}
+
+func (c *updater) buildBackendSourceAddressIntf(d *backData) {
+	sources := d.mapper.Get(ingtypes.BackSourceAddressIntf).Value
+	if sources == "" {
+		return
+	}
+	sourceIPs, found := c.srcIPs[sources]
+	if !found {
+		for _, ifname := range strings.Split(sources, ",") {
+			var newIPs []net.IP
+			for _, addr := range listAddrs(ifname) {
+				ip := net.ParseIP(addr.String())
+				if ip == nil {
+					ip, _, _ = net.ParseCIDR(addr.String())
+				}
+				if ip != nil && len(ip.To4()) == net.IPv4len {
+					// currently only IPv4
+					newIPs = append(newIPs, ip)
+				}
+			}
+			if newIPs == nil {
+				c.logger.Warn("network interface '%s' not found or does not have any IPv4 address", ifname)
+			}
+			sourceIPs = append(sourceIPs, newIPs...)
+		}
+		if c.srcIPs == nil {
+			c.srcIPs = map[string][]net.IP{}
+		}
+		// cache the lookup in the updater, it's created a new one
+		// per sync and reused between all the backend buildings
+		c.srcIPs[sources] = sourceIPs
+	}
+	d.backend.SourceIPs = sourceIPs
+}
+
 func (c *updater) buildBackendSSL(d *backData) {
 	d.backend.TLS.AddCertHeader = d.mapper.Get(ingtypes.BackAuthTLSCertHeader).Bool()
 	d.backend.TLS.FingerprintLower = d.mapper.Get(ingtypes.BackSSLFingerprintLower).Bool()

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -56,6 +56,7 @@ type updater struct {
 	cache   convtypes.Cache
 	tracker convtypes.Tracker
 	fakeCA  convtypes.CrtFile
+	srcIPs  map[string][]net.IP
 }
 
 type globalData struct {
@@ -220,6 +221,7 @@ func (c *updater) UpdateBackendConfig(backend *hatypes.Backend, mapper *Mapper) 
 	c.buildBackendProxyProtocol(data)
 	c.buildBackendRewriteURL(data)
 	c.buildBackendServerNaming(data)
+	c.buildBackendSourceAddressIntf(data)
 	c.buildBackendSSL(data)
 	c.buildBackendSSLRedirect(data)
 	c.buildBackendTimeout(data)

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -16,6 +16,7 @@ limitations under the License.
 
 package types
 
+// TCP Service Annotations
 const (
 	TCPConfigTCPService     = "config-tcp-service"
 	TCPTCPServiceLogFormat  = "tcp-service-log-format"
@@ -154,6 +155,7 @@ const (
 	BackSessionCookieShared    = "session-cookie-shared"
 	BackSessionCookieStrategy  = "session-cookie-strategy"
 	BackSessionCookieValue     = "session-cookie-value-strategy"
+	BackSourceAddressIntf      = "source-address-intf"
 	BackSSLCipherSuitesBackend = "ssl-cipher-suites-backend"
 	BackSSLCiphersBackend      = "ssl-ciphers-backend"
 	BackSSLFingerprintLower    = "ssl-fingerprint-lower"

--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -313,7 +313,11 @@ func (d *dynUpdater) checkBackendPair(pair *backendPair) bool {
 }
 
 func (d *dynUpdater) checkEndpointPair(backend *hatypes.Backend, pair *epPair) bool {
-	if reflect.DeepEqual(pair.old, pair.cur) {
+	oldEPCopy := *pair.old
+	// SourceIP is lazily updated via FillSourceIPs() after dynupdate run
+	// A reload is already scheduled due to backend.SourceIPs changed
+	oldEPCopy.SourceIP = pair.cur.SourceIP
+	if reflect.DeepEqual(&oldEPCopy, pair.cur) {
 		return true
 	}
 	if backend.Cookie.Preserve && pair.old.CookieValue != pair.cur.CookieValue {

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -272,6 +272,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 		i.config.Backends().ShuffleAllEndpoints()
 		timer.Tick("shuffle_endpoints")
 	}
+	i.config.Backends().FillSourceIPs()
 	if !updated || updater.cmdCnt > 0 {
 		// only need to rewrtite config files if:
 		//   - !updated           - there are changes that cannot be dynamically applied

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -94,6 +94,17 @@ func (b *Backend) addEndpoint(ip string, port int, targetRef string) *Endpoint {
 	return endpoint
 }
 
+func (b *Backend) fillSourceIPs() {
+	l := len(b.SourceIPs)
+	if l > 0 {
+		i := int(b.hash64 % uint64(l))
+		for _, ep := range b.Endpoints {
+			ep.SourceIP = b.SourceIPs[i].String()
+			i = (i + 1) % l
+		}
+	}
+}
+
 func (b *Backend) sortEndpoints(sortBy string) {
 	ep := b.Endpoints
 	switch sortBy {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"container/list"
+	"net"
 	"time"
 )
 
@@ -552,11 +553,13 @@ type Backend struct {
 	//
 	// IMPLEMENT
 	// use BackendID
+	hash64    uint64
 	shard     int
 	ID        string
 	Namespace string
 	Name      string
 	Port      string
+	SourceIPs []net.IP
 	Endpoints []*Endpoint
 	EpNaming  EndpointNaming
 	//
@@ -595,6 +598,7 @@ type Endpoint struct {
 	IP          string
 	Name        string
 	Port        int
+	SourceIP    string
 	Target      string
 	TargetRef   string
 	Weight      int

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -764,6 +764,7 @@ backend {{ $backend.ID }}
         {{- if not $ep.Enabled }} disabled{{ end }}
         {{- "" }} weight {{ $ep.Weight }}
         {{- if and ($backend.CookieAffinity) ($ep.CookieValue) }} cookie {{ $ep.CookieValue }}{{ end }}
+        {{- if $ep.SourceIP }} source {{ $ep.SourceIP }}{{ end }}
         {{- template "backend" map $backend }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
A source address defines the address an outgoing connection will use to send the request to the backend server. Due to the 64k limit of ephemeral TCP ports per IP address, the maximum of concurrent connections cannot exceed 64k. `source-address-intf` allows the global or per ingress/service configuration of network interfaces used to list valid IPv4 from each host. Each IPv4 from the list is fairly distributed among all servers of all configured backends.

This is a static and per server configuration, each server/endpoint line receives its own outgoing source. Because of that, backends that use DNS resolver ignores this configuration since such backends uses server templates instead of static config.