### PR TITLE
Fix domain validation on secure backend keys

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -747,7 +747,7 @@ func (c *updater) findBackend(namespace, uriPrefix string) *hatypes.HostBackend 
 	return nil
 }
 
-var validDomainRegex = regexp.MustCompile(`^[A-Za-z0-9.]*$`)
+var validDomainRegex = regexp.MustCompile(`^([A-Za-z0-9-]{1,63}\.)+[A-Za-z]{2,6}$`)
 
 func (c *updater) buildBackendProtocol(d *backData) {
 	proto := d.mapper.Get(ingtypes.BackBackendProtocol)

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -2119,6 +2119,49 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 			},
 			logging: `WARN skipping invalid domain (verify-hostname) on ingress 'default/app': invalid/domain`,
 		},
+		// 18
+		{
+			ann: map[string]map[string]string{
+				"/": {
+					ingtypes.BackBackendProtocol:      "h1-ssl",
+					ingtypes.BackSecureVerifyHostname: "valid-domain.tld",
+				},
+			},
+			expected: hatypes.ServerConfig{
+				Protocol:   "h1",
+				Secure:     true,
+				VerifyHost: "valid-domain.tld",
+			},
+		},
+		// 19
+		{
+			ann: map[string]map[string]string{
+				"/": {
+					ingtypes.BackBackendProtocol:      "h1-ssl",
+					ingtypes.BackSecureVerifyHostname: "sub.valid-domain.tld",
+				},
+			},
+			expected: hatypes.ServerConfig{
+				Protocol:   "h1",
+				Secure:     true,
+				VerifyHost: "sub.valid-domain.tld",
+			},
+		},
+		// 20
+		{
+			source: Source{Namespace: "default", Name: "app", Type: "ingress"},
+			ann: map[string]map[string]string{
+				"/": {
+					ingtypes.BackBackendProtocol:      "h1-ssl",
+					ingtypes.BackSecureVerifyHostname: "invalid-domain",
+				},
+			},
+			expected: hatypes.ServerConfig{
+				Protocol: "h1",
+				Secure:   true,
+			},
+			logging: `WARN skipping invalid domain (verify-hostname) on ingress 'default/app': invalid-domain`,
+		},
 	}
 	for i, test := range testCase {
 		c := setup(t)


### PR DESCRIPTION
The domain validation on `secure-sni` and `secure-verify-hostname` config keys were missing a dash `-`, incorrectly issuing a valid `some-domain.tld` domain as invalid. This update also check if a dot is used and the tld is 2 <= size <= 6.