### PR TITLE
Add ssl-always-add-https config key

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -433,7 +433,7 @@ The table below describes all supported configuration keys.
 | [`session-cookie-value-strategy`](#affinity)         | [server-name\|pod-uid]                  | Backend | `server-name`      |
 | [`slots-min-free`](#dynamic-scaling)                 | minimum number of free slots            | Backend | `0`                |
 | [`source-address-intf`](#source-address-intf)        | `<intf1>[,<intf2>...]`                  | Backend |                    |
-| [`ssl-always-add-https`](#ssl-always-add-https)      | [true\|false]                           | Host    | `true`             |
+| [`ssl-always-add-https`](#ssl-always-add-https)      | [true\|false]                           | Host    | `false`            |
 | [`ssl-cipher-suites`](#ssl-ciphers)                  | colon-separated list                    | Host    | [see description](#ssl-ciphers) |
 | [`ssl-cipher-suites-backend`](#ssl-ciphers)          | colon-separated list                    | Backend | [see description](#ssl-ciphers) |
 | [`ssl-ciphers`](#ssl-ciphers)                        | colon-separated list                    | Host    | [see description](#ssl-ciphers) |
@@ -2174,13 +2174,13 @@ See also:
 
 | Configuration key      | Scope | Default | Since   |
 |------------------------|-------|---------|---------|
-| `ssl-always-add-https` | Host  | `true`  | v0.12.4 |
+| `ssl-always-add-https` | Host  | `false` | v0.12.4 |
 
 Every hostname declared on an Ingress resource is added to an internal HTTP map. If at least one Ingress adds the hostname in the `tls` attribute, the hostname is also added to an internal HTTPS map and does ssl offload using the default certificate. A secret name can also be added in the `tls` attribute, overriding the certificate used in the TLS handshake.
 
 `ssl-always-add-https` asks the controller to always add the domain in the internal HTTP and HTTPS maps, even if the `tls` attribute isn't declared. If `false`, a missing `tls` attribute will only declare the domain in the HTTP map and `ssl-redirect` is ignored. If `true`, a missing `tls` attribute adds the domain in the HTTPS map, and the TLS handshake will use the default certificate. If `tls` attribute is used, this configuration is ignored.
 
-The default value is `true` up to v0.12 releases to preserve historical behavior of this controller. The default value can be globally changed in the global ConfigMap.
+The default value is `false` since v0.13 to correctly implement Ingress spec. The default value can be globally changed in the global ConfigMap.
 
 ---
 

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -433,6 +433,7 @@ The table below describes all supported configuration keys.
 | [`session-cookie-value-strategy`](#affinity)         | [server-name\|pod-uid]                  | Backend | `server-name`      |
 | [`slots-min-free`](#dynamic-scaling)                 | minimum number of free slots            | Backend | `0`                |
 | [`source-address-intf`](#source-address-intf)        | `<intf1>[,<intf2>...]`                  | Backend |                    |
+| [`ssl-always-add-https`](#ssl-always-add-https)      | [true\|false]                           | Host    | `true`             |
 | [`ssl-cipher-suites`](#ssl-ciphers)                  | colon-separated list                    | Host    | [see description](#ssl-ciphers) |
 | [`ssl-cipher-suites-backend`](#ssl-ciphers)          | colon-separated list                    | Backend | [see description](#ssl-ciphers) |
 | [`ssl-ciphers`](#ssl-ciphers)                        | colon-separated list                    | Host    | [see description](#ssl-ciphers) |
@@ -2169,6 +2170,20 @@ See also:
 
 ---
 
+## SSL always add HTTPS
+
+| Configuration key      | Scope | Default | Since   |
+|------------------------|-------|---------|---------|
+| `ssl-always-add-https` | Host  | `true`  | v0.12.4 |
+
+Every hostname declared on an Ingress resource is added to an internal HTTP map. If at least one Ingress adds the hostname in the `tls` attribute, the hostname is also added to an internal HTTPS map and does ssl offload using the default certificate. A secret name can also be added in the `tls` attribute, overriding the certificate used in the TLS handshake.
+
+`ssl-always-add-https` asks the controller to always add the domain in the internal HTTP and HTTPS maps, even if the `tls` attribute isn't declared. If `false`, a missing `tls` attribute will only declare the domain in the HTTP map and `ssl-redirect` is ignored. If `true`, a missing `tls` attribute adds the domain in the HTTPS map, and the TLS handshake will use the default certificate. If `tls` attribute is used, this configuration is ignored.
+
+The default value is `true` up to v0.12 releases to preserve historical behavior of this controller. The default value can be globally changed in the global ConfigMap.
+
+---
+
 ## SSL ciphers
 
 | Configuration key           | Scope     | Default | Since |
@@ -2330,6 +2345,7 @@ Configures if an encripted connection should be used.
 
 See also:
 
+* [`ssl-always-add-https`](#ssl-always-add-https) configuration key
 * http://cbonte.github.io/haproxy-dconv/2.0/configuration.html#redirect
 
 ---

--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -318,6 +318,7 @@ func (c *converter) createHTTPHosts(source *Source, hostnames []gatewayv1alpha1.
 				hstr = hatypes.DefaultHost
 			}
 			h := c.haproxy.Hosts().AcquireHost(hstr)
+			h.TLS.UseDefaultCrt = false
 			h.AddPath(backend, path, haMatch)
 			handlePassthrough(path, h, backend)
 			hosts = append(hosts, h)
@@ -339,7 +340,8 @@ func handlePassthrough(path string, h *hatypes.Host, b *hatypes.Backend) {
 		return
 	}
 	for _, hpath := range h.FindPath("/") {
-		if !hpath.Backend.ModeTCP {
+		modeTCP := hpath.Backend.ModeTCP
+		if modeTCP != nil && !*modeTCP {
 			// current path has a HTTP backend in the root path of a passthrough
 			// domain, and the current haproxy.Host implementation uses this as the
 			// target HTTPS backend. So we need to:

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -884,8 +884,8 @@ func (c *updater) buildBackendSSL(d *backData) {
 func (c *updater) buildBackendSSLRedirect(d *backData) {
 	noTLSRedir := utils.Split(d.mapper.Get(ingtypes.GlobalNoTLSRedirectLocations).Value, ",")
 	for _, path := range d.backend.Paths {
-		config := d.mapper.GetConfig(path.Link)
-		redir := config.Get(ingtypes.BackSSLRedirect).Bool()
+		redir := path.Host != nil && path.Host.HasTLS() &&
+			d.mapper.GetConfig(path.Link).Get(ingtypes.BackSSLRedirect).Bool()
 		if redir {
 			for _, noredir := range noTLSRedir {
 				if strings.HasPrefix(path.Path(), noredir) {

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -184,6 +184,7 @@ func (c *updater) UpdateHostConfig(host *hatypes.Host, mapper *Mapper) {
 	host.RootRedirect = mapper.Get(ingtypes.HostAppRoot).Value
 	host.Alias.AliasName = mapper.Get(ingtypes.HostServerAlias).Value
 	host.Alias.AliasRegex = mapper.Get(ingtypes.HostServerAliasRegex).Value
+	host.TLS.UseDefaultCrt = mapper.Get(ingtypes.HostSSLAlwaysAddHTTPS).Bool()
 	host.VarNamespace = mapper.Get(ingtypes.HostVarNamespace).Bool()
 	c.buildHostAuthTLS(data)
 	c.buildHostCertSigner(data)

--- a/pkg/converters/ingress/annotations/updater_test.go
+++ b/pkg/converters/ingress/annotations/updater_test.go
@@ -163,6 +163,12 @@ func (c *testConfig) createBackendData(svcFullName string, source *Source, ann, 
 
 const testingHostname = "host.local"
 
+type hostResolver struct{}
+
+func (h *hostResolver) HasTLS() bool {
+	return true
+}
+
 func (c *testConfig) createBackendMappingData(
 	svcFullName string,
 	source *Source,
@@ -183,6 +189,7 @@ func (c *testConfig) createBackendMappingData(
 		// ignoring ID which isn't the focus of the test
 		// removing on createBackendPaths() as well
 		b.ID = ""
+		b.Host = &hostResolver{}
 	}
 	for uri, ann := range urlAnnValue {
 		d.mapper.AddAnnotations(source, hatypes.CreatePathLink(testingHostname, uri, hatypes.MatchBegin), ann)

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -32,11 +32,12 @@ func createDefaults() map[string]string {
 	return map[string]string{
 		types.TCPTCPServiceLogFormat: "default",
 		//
-		types.HostAuthTLSStrict:   "false",
-		types.HostSSLCiphers:      defaultSSLCiphers,
-		types.HostSSLCipherSuites: defaultSSLCipherSuites,
-		types.HostSSLOptionsHost:  "",
-		types.HostTLSALPN:         "h2,http/1.1",
+		types.HostAuthTLSStrict:     "false",
+		types.HostSSLAlwaysAddHTTPS: "true",
+		types.HostSSLCiphers:        defaultSSLCiphers,
+		types.HostSSLCipherSuites:   defaultSSLCipherSuites,
+		types.HostSSLOptionsHost:    "",
+		types.HostTLSALPN:           "h2,http/1.1",
 		//
 		types.BackAuthHeadersFail:        "*",
 		types.BackAuthHeadersRequest:     "*",

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -33,7 +33,7 @@ func createDefaults() map[string]string {
 		types.TCPTCPServiceLogFormat: "default",
 		//
 		types.HostAuthTLSStrict:     "false",
-		types.HostSSLAlwaysAddHTTPS: "true",
+		types.HostSSLAlwaysAddHTTPS: "false",
 		types.HostSSLCiphers:        defaultSSLCiphers,
 		types.HostSSLCipherSuites:   defaultSSLCipherSuites,
 		types.HostSSLOptionsHost:    "",

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -46,6 +46,7 @@ const (
 	HostRedirectFromRegex      = "redirect-from-regex"
 	HostServerAlias            = "server-alias"
 	HostServerAliasRegex       = "server-alias-regex"
+	HostSSLAlwaysAddHTTPS      = "ssl-always-add-https"
 	HostSSLCiphers             = "ssl-ciphers"
 	HostSSLCipherSuites        = "ssl-cipher-suites"
 	HostSSLOptionsHost         = "ssl-options-host"
@@ -68,6 +69,7 @@ var (
 		HostRedirectFrom:           {},
 		HostRedirectFromRegex:      {},
 		HostServerAliasRegex:       {},
+		HostSSLAlwaysAddHTTPS:      {},
 		HostSSLCiphers:             {},
 		HostSSLCipherSuites:        {},
 		HostSSLOptionsHost:         {},

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -217,7 +217,7 @@ func (c *config) WriteFrontendMaps() error {
 							backendID = "_redirect_https"
 						}
 					}
-				} else {
+				} else if host.HasTLS() {
 					// ssl offload in place
 					if host.HasTLSAuth() {
 						fmaps.HTTPSSNIMap.AddHostnamePathMapping(host.Hostname, path, backendID)

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -864,6 +864,24 @@ backend d1_app_8080
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
+func TestInstanceClean(t *testing.T) {
+	c := setup(t)
+	defer c.teardown()
+
+	c.Update()
+	c.checkConfig(`
+<<global>>
+<<defaults>>
+<<backends-default>>
+<<frontend-http-clean>>
+    default_backend _error404
+<<frontend-https-clean>>
+    default_backend _error404
+<<support>>
+`)
+	c.logger.CompareLogging(defaultLogging)
+}
+
 func TestInstanceBare(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()
@@ -885,6 +903,36 @@ backend d1_app_8080
     server s1 172.17.0.11:8080 weight 100
 <<backends-default>>
 <<frontends-default>>
+<<support>>
+`)
+	c.logger.CompareLogging(defaultLogging)
+}
+
+func TestInstanceBareHTTP(t *testing.T) {
+	c := setup(t)
+	defer c.teardown()
+
+	var h *hatypes.Host
+	var b *hatypes.Backend
+
+	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
+	b.Endpoints = []*hatypes.Endpoint{endpointS1}
+	h = c.config.Hosts().AcquireHost("d1.local")
+	h.TLS.UseDefaultCrt = false
+	h.AddPath(b, "/", hatypes.MatchBegin)
+
+	c.Update()
+	c.checkConfig(`
+<<global>>
+<<defaults>>
+backend d1_app_8080
+    mode http
+    server s1 172.17.0.11:8080 weight 100
+<<backends-default>>
+<<frontend-http>>
+    default_backend _error404
+<<frontend-https-clean>>
+    default_backend _error404
 <<support>>
 `)
 	c.logger.CompareLogging(defaultLogging)
@@ -2128,6 +2176,48 @@ d2.local#/app11 path01`)
 	c.logger.CompareLogging(defaultLogging)
 }
 
+func TestInstanceUseDefaultCrt(t *testing.T) {
+	c := setup(t)
+	defer c.teardown()
+
+	var h *hatypes.Host
+	var b *hatypes.Backend
+
+	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
+	b.Endpoints = []*hatypes.Endpoint{endpointS1}
+	h = c.config.Hosts().AcquireHost("d1.local")
+	h.TLS.UseDefaultCrt = false
+	h.AddPath(b, "/", hatypes.MatchBegin)
+
+	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
+	b.Endpoints = []*hatypes.Endpoint{endpointS21}
+	h = c.config.Hosts().AcquireHost("d2.local")
+	h.TLS.UseDefaultCrt = true
+	h.AddPath(b, "/", hatypes.MatchBegin)
+
+	c.Update()
+	c.checkConfig(`
+<<global>>
+<<defaults>>
+backend d1_app_8080
+    mode http
+    server s1 172.17.0.11:8080 weight 100
+backend d2_app_8080
+    mode http
+    server s21 172.17.0.121:8080 weight 100
+<<backends-default>>
+<<frontends-default>>
+<<support>>
+`)
+	c.checkMap("_front_http_host__begin.map", `
+d1.local#/ d1_app_8080
+d2.local#/ d2_app_8080
+`)
+	c.checkMap("_front_https_host__begin.map", `
+d2.local#/ d2_app_8080
+`)
+	c.logger.CompareLogging(defaultLogging)
+}
 func TestInstanceStrictHost(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -278,7 +278,7 @@ func (b *Backend) createPathConfig() map[string]*BackendPathConfig {
 	for i := 0; i < pathType.NumField(); i++ {
 		name := pathType.Field(i).Name
 		// filter out core fields
-		if name != "ID" && name != "Link" {
+		if name != "ID" && name != "Link" && name != "Host" {
 			pathconfig[name] = &BackendPathConfig{}
 		}
 	}

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -489,7 +489,7 @@ type HostBackend struct {
 	Namespace string
 	Name      string
 	Port      string
-	ModeTCP   bool
+	ModeTCP   *bool
 }
 
 // HostAliasConfig ...
@@ -507,7 +507,8 @@ type HostRedirectConfig struct {
 // HostTLSConfig ...
 type HostTLSConfig struct {
 	TLSConfig
-	CAErrorPage string
+	CAErrorPage   string
+	UseDefaultCrt bool
 }
 
 // EndpointNaming ...
@@ -623,6 +624,11 @@ type BackendPathItem struct {
 	config interface{}
 }
 
+// HostResolver ...
+type HostResolver interface {
+	HasTLS() bool
+}
+
 // BackendPath ...
 type BackendPath struct {
 	//
@@ -630,6 +636,7 @@ type BackendPath struct {
 	//
 	ID   string
 	Link PathLink
+	Host HostResolver
 	//
 	// config fields
 	//


### PR DESCRIPTION
Since at least v0.8, controller adds domains in both HTTP and HTTPS maps despite the use of the `tls` attribute. This behavior goes against the Ingress spec but cannot be simply fixed due to backward compatibility. This config key adds the ability to configure HTTPS without the need of the `tls` attribute and can be globally changed. Its default value is
`true` to preserve the behavior of current and older versions.

Should be merged to v0.12.

# Compatibility notes

v0.13 will merge this update changing the default value to `false`, which will impact deployments with Ingress resources that doesn't configure `tls` attribute. Such deployments by default will not configure HTTPS anymore. This configuration can be changed to `true` to bring back the v0.12 behavior, or `tls` attribute should be configured on every domain that needs HTTPS.