### PR TITLE
Add option to copy client method to auth-url

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -762,7 +762,7 @@ See also:
 Configures External Authentication options.
 
 * `auth-url`: Configures the endpoint(s) of the authentication service. All requests made to the target backend server will be validated by the authentication service before continue, which should respond with `2xx` HTTP status code, otherwise the request is considered as failed. In the case of a failure, the backend server is not used and the client receives the response from the authentication service.
-* `auth-method`: Configures the HTTP method used in the request to the external authentication service. The default value is `GET`.
+* `auth-method`: Configures the HTTP method used in the request to the external authentication service. Use an asterisk `*` to copy the same method used in the client request. The default value is `GET`.
 * `auth-headers-request`: Configures a comma-separated list of header names that should be copied from the client to the authentication service. All HTTP headers will be copied if not declared.
 * `auth-headers-succeed`: Configures a comma-separated list of header names that should be copied from the authentication service to the backend server if the authentication succeed. All HTTP headers will be copied if not declared.
 * `auth-headers-fail`: Configures a comma-separated list of header names that should be copied from the authentication service to the client if the authentication fail. This option is ignored if `auth-signin` is used. All HTTP headers will be copied if not declared.

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -122,7 +122,7 @@ var (
 	lookupHost func(host string) (addrs []string, err error) = net.LookupHost
 
 	validURLRegex    = regexp.MustCompile(`^[^"' ]*$`)
-	validMethodRegex = regexp.MustCompile(`^[A-Za-z]+$`)
+	validMethodRegex = regexp.MustCompile(`^([A-Za-z]+|\*)$`)
 	authHeaderRegex  = regexp.MustCompile(`^[A-Za-z0-9-]+(:[^:'" ]+)?$`)
 )
 

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -481,6 +481,29 @@ func TestAuthExternal(t *testing.T) {
 			expIP:   []string{"10.0.0.2:80"},
 			logging: `WARN invalid request method 'invalid()' on ingress 'default/ing1', using GET instead`,
 		},
+		// 24
+		{
+			url:    "http://app1.local",
+			method: "*",
+			expBack: hatypes.AuthExternal{
+				AuthBackendName: "_auth_4001",
+				AuthPath:        "/",
+				Method:          "*",
+			},
+			expIP: []string{"10.0.0.2:80"},
+		},
+		// 25
+		{
+			url:    "http://app1.local",
+			method: "**",
+			expBack: hatypes.AuthExternal{
+				AuthBackendName: "_auth_4001",
+				AuthPath:        "/",
+				Method:          "GET",
+			},
+			expIP:   []string{"10.0.0.2:80"},
+			logging: `WARN invalid request method '**' on ingress 'default/ing1', using GET instead`,
+		},
 	}
 	source := &Source{
 		Namespace: "default",

--- a/rootfs/etc/lua/auth-request.lua
+++ b/rootfs/etc/lua/auth-request.lua
@@ -96,7 +96,8 @@ end
 -- used to identify the headers that should be copied between the requests
 -- and responses. A dash `-` means that the headers shouldn't be copied at all.
 -- `hdr_succeed == "-"` means that HAProxy vars should be created instead.
--- `hdt_fail == "-"` means that the Lua script shouldn't terminare the request.
+-- `hdr_fail == "-"` means that the Lua script shouldn't terminare the request.
+-- `method == "*"` means that the same method used by the client should be used to the auth service.
 function auth_request(txn, be, path, method, hdr_req, hdr_succeed, hdr_fail)
 	set_var(txn, "txn.auth_response_successful", false)
 
@@ -139,6 +140,9 @@ function auth_request(txn, be, path, method, hdr_req, hdr_succeed, hdr_fail)
 	end
 
 	-- Make request to backend.
+	if method == "*" then
+		method = txn.sf:method()
+	end
 	local response, err = http.send(method:upper(), {
 		url = "http://" .. addr .. path,
 		headers = headers,


### PR DESCRIPTION
This update adds the ability to call the external authentication service using the same method provided by the user. Current option are only static and pre configured methods. The reading of the request method was delegated to the Lua script, because parameters to a Lua script cannot be interpolated.