### PR TITLE
Use the port name on DNS resolver template

### DIFF
--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -851,6 +851,8 @@ func (c *converter) addBackendWithClass(source *annotations.Source, pathLink hat
 	}
 	backend := c.haproxy.Backends().AcquireBackend(namespace, svcName, port.TargetPort.String())
 	c.tracker.TrackBackend(convtypes.IngressType, source.FullName(), backend.BackendID())
+	// TODO converg backend Port and DNSPort; see also tmpl's server-template
+	backend.DNSPort = readDNSPort(svc.Spec.ClusterIP == api.ClusterIPNone, port)
 	mapper, found := c.backendAnnotations[backend]
 	if !found {
 		// New backend, initialize with service annotations, giving precedence
@@ -904,6 +906,21 @@ func (c *converter) addBackendWithClass(source *annotations.Source, pathLink hat
 		}
 	}
 	return backend, nil
+}
+
+func readDNSPort(headlessService bool, port *api.ServicePort) string {
+	targetPort := port.TargetPort.String()
+	targetPortNum, _ := strconv.Atoi(targetPort)
+	if targetPortNum > 0 {
+		if headlessService {
+			return targetPort
+		}
+		return strconv.Itoa(int(port.Port))
+	}
+	if port.Name == "" {
+		return targetPort
+	}
+	return port.Name
 }
 
 func (c *converter) syncBackendEndpointCookies(backend *hatypes.Backend) {

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -3737,6 +3737,13 @@ func TestDNS(t *testing.T) {
 	h = c.config.Hosts().AcquireHost("d2.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
+	b = c.config.Backends().AcquireBackend("d3", "app", "http")
+	b.DNSPort = "named"
+	b.Endpoints = []*hatypes.Endpoint{endpointS21, endpointS22}
+	b.Resolver = "k8s"
+	h = c.config.Hosts().AcquireHost("d3.local")
+	h.AddPath(b, "/", hatypes.MatchBegin)
+
 	c.Update()
 	c.checkConfig(`
 <<global>>
@@ -3755,6 +3762,9 @@ backend d1_app_8080
 backend d2_app_http
     mode http
     server-template srv 2 _http._tcp.app.d2.svc.cluster.local resolvers k8s resolve-prefer ipv4 init-addr none weight 1
+backend d3_app_http
+    mode http
+    server-template srv 2 _named._tcp.app.d3.svc.cluster.local resolvers k8s resolve-prefer ipv4 init-addr none weight 1
 <<backends-default>>
 <<frontends-default>>
 <<support>>

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -561,6 +561,7 @@ type Backend struct {
 	Namespace string
 	Name      string
 	Port      string
+	DNSPort   string
 	SourceIPs []net.IP
 	Endpoints []*Endpoint
 	EpNaming  EndpointNaming

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -735,11 +735,12 @@ backend {{ $backend.ID }}
 
 {{- /*------------------------------------*/}}
 {{- if $backend.Resolver }}
-{{- $portIsNumber := ne (int64 $backend.Port) 0 }}
+{{- $dnsPort := iif (ne $backend.DNSPort "") $backend.DNSPort $backend.Port }}
+{{- $portIsNumber := ne (int64 $dnsPort) 0 }}
     server-template srv {{ len $backend.Endpoints }}
-        {{- " " }}{{ if not $portIsNumber }}_{{ $backend.Port }}._tcp.{{ end }}
+        {{- " " }}{{ if not $portIsNumber }}_{{ $dnsPort }}._tcp.{{ end }}
         {{- $backend.Name }}.{{ $backend.Namespace }}.svc.{{ $global.DNS.ClusterDomain }}
-        {{- if $portIsNumber }}:{{ $backend.Port }}{{ end }}
+        {{- if $portIsNumber }}:{{ $dnsPort }}{{ end }}
         {{- "" }} resolvers {{ $backend.Resolver }} resolve-prefer ipv4 init-addr none
         {{- "" }} weight {{ $backend.Server.InitialWeight }}
         {{- template "backend" map $backend }}


### PR DESCRIPTION
A haproxy backend naming uses the service namespace and name, and also the port of the service. Kubernetes has a number of ways to reference a port, which can be a number or a name, and both can be of the service itself or the target (a pod). Current implementation just use the target reference, and being a number make it in sync with the port number in the target server. Anyway this is just a naming convention, except when DNS resolvers are in place.

The DNS resolver feature expects the name of the service port because this is the name the DNS knows. When port name and target port differs, the server-template is wrongly built with the target name. This commit adds a new `DNSPort` attribute that the DNS template should use to build the correct configuration.