### PR TITLE
Allow a list of origins in cors-allow-origin config

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -1245,7 +1245,7 @@ See also:
 Add CORS headers on OPTIONS http command (preflight) and reponses.
 
 * `cors-enable`: Enable CORS if defined as `true`.
-* `cors-allow-origin`: Optional, configures `Access-Control-Allow-Origin` header which defines the URL that may access the resource. Defaults to `*`.
+* `cors-allow-origin`: Optional, configures `Access-Control-Allow-Origin` header which defines the URL that may access the resource. Defaults to `*`. This option accepts a comma-separated list of origins, the response will be dynamically built based on the `Origin` request header. If `Origin` belogs to the list, its content will be sent back to the client in the `Access-Control-Allow-Origin` header, otherwise the first item of the list will be used.
 * `cors-allow-methods`: Optional, configures `Access-Control-Allow-Methods` header which defines the allowed methods. Default value is `GET, PUT, POST, DELETE, PATCH, OPTIONS`.
 * `cors-allow-headers`: Optional, configures `Access-Control-Allow-Headers` header which defines the allowed headers. Default value is `DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization`.
 * `cors-allow-credentials`: Optional, configures `Access-Control-Allow-Credentials` header which defines whether or not credentials (cookies, authorization headers or client certificates) should be exposed. Defaults to `true`.

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -528,7 +528,7 @@ func (c *updater) buildBackendCors(d *backData) {
 				AllowCredentials: config.Get(ingtypes.BackCorsAllowCredentials).Bool(),
 				AllowHeaders:     config.Get(ingtypes.BackCorsAllowHeaders).Value,
 				AllowMethods:     config.Get(ingtypes.BackCorsAllowMethods).Value,
-				AllowOrigin:      config.Get(ingtypes.BackCorsAllowOrigin).Value,
+				AllowOrigin:      strings.Split(config.Get(ingtypes.BackCorsAllowOrigin).Value, ","),
 				ExposeHeaders:    config.Get(ingtypes.BackCorsExposeHeaders).Value,
 				MaxAge:           config.Get(ingtypes.BackCorsMaxAge).Int(),
 			}

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -1245,9 +1245,10 @@ func TestBodySize(t *testing.T) {
 const (
 	corsDefaultHeaders = "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization"
 	corsDefaultMethods = "GET, PUT, POST, DELETE, PATCH, OPTIONS"
-	corsDefaultOrigin  = "*"
 	corsDefaultMaxAge  = 86400
 )
+
+var corsDefaultOrigin = []string{"*"}
 
 func TestCors(t *testing.T) {
 	testCases := []struct {
@@ -1305,16 +1306,62 @@ func TestCors(t *testing.T) {
 				},
 			},
 		},
+		// 3
+		{
+			ann: map[string]map[string]string{
+				"/": {
+					ingtypes.BackCorsEnable:      "true",
+					ingtypes.BackCorsAllowOrigin: "http://d1.local,https://d2.local,https://d3.local",
+				},
+			},
+			expected: map[string]hatypes.Cors{
+				"/": {
+					Enabled:          true,
+					AllowCredentials: false,
+					AllowHeaders:     corsDefaultHeaders,
+					AllowMethods:     corsDefaultMethods,
+					AllowOrigin:      []string{"http://d1.local", "https://d2.local", "https://d3.local"},
+					ExposeHeaders:    "",
+					MaxAge:           corsDefaultMaxAge,
+				},
+			},
+		},
+		// 4
+		{
+			ann: map[string]map[string]string{
+				"/": {
+					ingtypes.BackCorsEnable:      "true",
+					ingtypes.BackCorsAllowOrigin: "https://d1.local,https://d2.local,invalid",
+				},
+			},
+			expected: map[string]hatypes.Cors{
+				"/": {
+					Enabled:          true,
+					AllowCredentials: false,
+					AllowHeaders:     corsDefaultHeaders,
+					AllowMethods:     corsDefaultMethods,
+					AllowOrigin:      corsDefaultOrigin,
+					ExposeHeaders:    "",
+					MaxAge:           corsDefaultMaxAge,
+				},
+			},
+			logging: `WARN ignoring invalid cors origin on ingress 'default/ing': invalid`,
+		},
 	}
 	annDefault := map[string]string{
 		ingtypes.BackCorsAllowHeaders: corsDefaultHeaders,
 		ingtypes.BackCorsAllowMethods: corsDefaultMethods,
-		ingtypes.BackCorsAllowOrigin:  corsDefaultOrigin,
+		ingtypes.BackCorsAllowOrigin:  strings.Join(corsDefaultOrigin, ","),
 		ingtypes.BackCorsMaxAge:       strconv.Itoa(corsDefaultMaxAge),
+	}
+	source := &Source{
+		Namespace: "default",
+		Name:      "ing",
+		Type:      "ingress",
 	}
 	for i, test := range testCases {
 		c := setup(t)
-		d := c.createBackendMappingData("default/app", &Source{}, annDefault, test.ann, test.paths)
+		d := c.createBackendMappingData("default/app", source, annDefault, test.ann, test.paths)
 		c.createUpdater().buildBackendCors(d)
 		actual := map[string]hatypes.Cors{}
 		for _, path := range d.backend.Paths {

--- a/pkg/converters/ingress/annotations/validator.go
+++ b/pkg/converters/ingress/annotations/validator.go
@@ -19,6 +19,7 @@ package annotations
 import (
 	"regexp"
 	"strconv"
+	"strings"
 
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/types"
@@ -54,11 +55,13 @@ var validators = map[string]func(v validate) (string, bool){
 		return "", false
 	},
 	ingtypes.BackCorsAllowOrigin: func(v validate) (string, bool) {
-		if corsOriginRegex.MatchString(v.value) {
-			return v.value, true
+		for _, value := range strings.Split(v.value, ",") {
+			if !corsOriginRegex.MatchString(value) {
+				v.logger.Warn("ignoring invalid cors origin on %s: %s", v.source, value)
+				return "", false
+			}
 		}
-		v.logger.Warn("ignoring invalid cors origin on %s: %s", v.source, v.value)
-		return "", false
+		return v.value, true
 	},
 	ingtypes.BackCorsExposeHeaders: func(v validate) (string, bool) {
 		if corsHeadersRegex.MatchString(v.value) {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -778,7 +778,7 @@ type Cors struct {
 	AllowCredentials bool
 	AllowHeaders     string
 	AllowMethods     string
-	AllowOrigin      string
+	AllowOrigin      []string
 	ExposeHeaders    string
 	MaxAge           int
 }

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -600,7 +600,11 @@ backend {{ $backend.ID }}
 {{- /*------------------------------------*/}}
 {{- $corsCfg := $backend.PathConfig "Cors" }}
 {{- range $i, $cors := $corsCfg.Items }}
-{{- if $cors.Enabled }}
+{{- if and $cors.Enabled $cors.AllowOrigin }}
+{{- $dynamicOrigin := gt (len $cors.AllowOrigin) 1 }}
+{{- if $dynamicOrigin }}
+    http-request set-var(txn.hdr_origin{{ $i }}) req.hdr(Origin)
+{{- end }}
 {{- range $pathIDs := $corsCfg.PathIDs $i }}
     http-request set-var(txn.cors_max_age) str({{ $cors.MaxAge }}) if METH_OPTIONS
         {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
@@ -711,10 +715,25 @@ backend {{ $backend.ID }}
 
 {{- /*------------------------------------*/}}
 {{- range $i, $cors := $corsCfg.Items }}
-{{- if $cors.Enabled }}
+{{- if and $cors.Enabled $cors.AllowOrigin }}
+{{- $dynamicOrigin := gt (len $cors.AllowOrigin) 1 }}
+{{- if $dynamicOrigin }}
+{{- range $a1 := short 5 $cors.AllowOrigin }}
+    acl cors_allow_origin{{ $i }} var(txn.hdr_origin{{ $i }}){{ range $a := $a1 }} {{ $a }}{{ end }}
+{{- end }}
+{{- end }}
 {{- range $pathIDs := $corsCfg.PathIDs $i }}
-    http-response set-header Access-Control-Allow-Origin  "{{ $cors.AllowOrigin }}"
-        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+    http-response set-header Access-Control-Allow-Origin
+        {{- if $dynamicOrigin }}  "%[var(txn.hdr_origin{{ $i }})]"{{ else }}  "{{ index $cors.AllowOrigin 0 }}"{{ end }}
+        {{- if or $dynamicOrigin $pathIDs }} if
+            {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+            {{- if $dynamicOrigin }} cors_allow_origin{{ $i }}{{ end }}
+        {{- end }}
+{{- if $dynamicOrigin }}
+    http-response set-header Access-Control-Allow-Origin  "{{ index $cors.AllowOrigin 0 }}"
+        {{- "" }} if{{ if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- "" }} !cors_allow_origin{{ $i }}
+{{- end }}
     http-response set-header Access-Control-Allow-Methods "{{ $cors.AllowMethods }}"
         {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
     http-response set-header Access-Control-Allow-Headers "{{ $cors.AllowHeaders }}"
@@ -725,6 +744,10 @@ backend {{ $backend.ID }}
 {{- end }}
 {{- if $cors.ExposeHeaders }}
     http-response set-header Access-Control-Expose-Headers "{{ $cors.ExposeHeaders }}"
+        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+{{- end }}
+{{- if $dynamicOrigin }}
+    http-response set-header Vary Origin
         {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
`cors-allow-origin` configuration key now allows a list of Origins. The `Access-Control-Allow-Origin` response header will be built based on the provided Origin, falling back to the first option if Origin cannot be found in the list.