### PR TITLE
Fix reading of tls secret without crt or key

### DIFF
--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -402,7 +402,7 @@ func (c *k8scache) GetTLSSecretPath(defaultNamespace, secretName string, track c
 		c.tracker.Track(true, track, convtypes.SecretType, namespace+"/"+name)
 		return file, err
 	}
-	if sslCert.PemFileName == "" {
+	if sslCert.PemFileName == "" || sslCert.Certificate == nil {
 		c.tracker.Track(true, track, convtypes.SecretType, namespace+"/"+name)
 		return file, fmt.Errorf("secret '%s/%s' does not have keys 'tls.crt' and 'tls.key'", namespace, name)
 	}


### PR DESCRIPTION
Secrets with a CA bundle or crt+key pair uses the same internal struct to represent them. Distinct functions verify if the proper fields are filled to determine if the secret is correctly configured. The crt+key reading however is checking a common field used by CA and crt secrets, leading to a nil dereference when a certificate isn't properly configured. This update ensures that a certificate is properly configured. Thanks Maurilio for finding this.

Should be merged as far as v0.10.