### PR TITLE
Fix typo in 'tcp-service-proxy-protocol' annotation

### DIFF
--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -21,7 +21,7 @@ const (
 	TCPConfigTCPService     = "config-tcp-service"
 	TCPTCPServiceLogFormat  = "tcp-service-log-format"
 	TCPTCPServicePort       = "tcp-service-port"
-	TCPTCPServiceProxyProto = "tcp-service-proxy-protool"
+	TCPTCPServiceProxyProto = "tcp-service-proxy-protocol"
 )
 
 var (


### PR DESCRIPTION
The annotation 'tcp-service-proxy-protool' was missing a 'c' in the word 'protocol'