### PR TITLE
Fix backend match if no ingress use host match

### DIFF
--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1242,11 +1242,9 @@ frontend {{ $proxy__front_https }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- if or $fmaps.RedirFromRootMap.HasHost $fmaps.HTTPSHostMap.HasHost $fmaps.HTTPSSNIMap.HasHost $fmaps.TLSAuthList.HasHost $fmaps.TLSNeedCrtList.HasHost $fmaps.VarNamespaceMap.HasHost }}
     http-request set-var(req.path) path
     http-request set-var(req.host) hdr(host),field(1,:),lower
     http-request set-var(req.base) var(req.host),concat(\#,req.path)
-{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- template "redirectTo" map $frontend $fmaps }}


### PR DESCRIPTION
HAProxy proxies use conditional configuration everywhere in order to HAProxy spend time only on tasks that has some value to the current configuration. Since the last default backend improvement (pr777), a new feature was added in the backend matching but some vars wasn't previously assigned. Such assignment is already under a big exception list, so it's currently more a rule than an exception. This update removes the conditional configuration on the https frontend, which fix workloads with only ingress without hostnames. Thanks Andrew for the fast report.

Should be merged up to v0.12 branch.