### PR TITLE
Ensure that configured global ConfigMap exists

### DIFF
--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -252,6 +252,19 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 
 	ctx := context.Background()
 
+	if *configMap != "" {
+		ns, name, err := k8s.ParseNameNS(*configMap)
+		if err != nil {
+			glog.Fatalf("invalid format for configmap %s: %v", *configMap, err)
+		}
+
+		_, err = kubeClient.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			glog.Fatalf("error reading configmap '%s': %v", *configMap, err)
+		}
+		glog.Infof("watching for global config options from configmap '%s' - --configmap was defined", *configMap)
+	}
+
 	if *defaultSvc != "" {
 		ns, name, err := k8s.ParseNameNS(*defaultSvc)
 		if err != nil {


### PR DESCRIPTION
Launch is actually copying the global configmap name from the command-line straight to the lister without checking its existence. The lister will watch configmap events and will only wake up if the name matches with the one provided in the command-line, so currently a mistyped name is silently ignored.

From now the configmap name is checked in the bootstrap process and will crash if not found or if the controller doesn't have permission to read it.

This should be merged as far as v0.10, but v0.12 and older should only log error instead, due to preserve backward compatibility with the current behavior.