### PR TITLE
Add reload interval command-line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -35,6 +35,7 @@ The following command-line options are supported:
 | [`--profiling`](#stats)                                 | [true\|false]              | `true`                  |       |
 | [`--publish-service`](#publish-service)                 | namespace/servicename      |                         |       |
 | [`--rate-limit-update`](#rate-limit-update)             | uploads per second (float) | `0.5`                   |       |
+| [`--reload-interval`](#reload-interval)                 | time                       | `0`                     | v0.13 |
 | [`--reload-strategy`](#reload-strategy)                 | [native\|reusesocket]      | `reusesocket`           |       |
 | [`--sort-backends`](#sort-backends)                     | [true\|false]              | `false`                 |       |
 | [`--sort-endpoints-by`](#sort-endpoints-by)             | [endpoint\|ip\|name\|random] | `endpoint`            | v0.11 |
@@ -246,15 +247,37 @@ Use `--publish-service=namespace/servicename` to indicate the services fronting 
 
 ## --rate-limit-update
 
-Use `--rate-limit-update` to change how much time to wait between HAProxy reloads. Note that the first
-update is always immediate, the delay will only prevent two or more updates in the same time frame.
-Moreover reloads will only occur if the cluster configuration has changed, otherwise no reload will
-occur despite of the rate limit configuration.
+Use `--rate-limit-update` to change how much time to wait between two consecutive configuration updates.
+A configuration update is the process of read all enqueued Kubernetes events, reflect in the HAProxy
+model and immediately apply everything that does not need a reload, eg server certificate endpoint
+updates. Note that the first configuration update is always immediate, the delay will only prevent
+two or more consecutive updates in the same time frame - the second update will be enqueued and
+processed later, satisfying the rate limit configuration. Moreover, updates will only happen if
+Kubernetes reports changing events. The default value is `0.5` which means to wait two seconds between
+two consecutive configuration changes.
 
-This argument receives the allowed reloads per second. The default value is `0.5` which means no more
-than one reload will occur within `2` seconds. The lower limit is `0.05` which means one reload within
-`20` seconds. The highest one is `10` which will allow ingress controller to reload HAProxy up to 10
-times per second.
+Up to v0.12 this was the only way to limit how often HAProxy would be reloaded, but this also prevents
+to dynamically update HAProxy as fast as possible. v0.13 adds [`--reload-interval`](#reload-interval),
+which allows a higher rate limit update with a lower rate of reloads.
+
+See also [`--reload-interval`](#reload-interval).
+
+---
+
+## --reload-interval
+
+Since v0.13
+
+Configures the minimal time between two consecutive HAProxy reloads. The default value is `0`,
+which means to always reload HAProxy just after a configuration change requires a reload. The
+interval should be configured with a time suffix, e.g., `30s` means that if two distinct and
+consecutive configuration changes enforce a reload, the second reload will be enqueued until 30
+seconds have passed from the first one, applying every new configuration changes made between
+this interval.
+
+Higher values help to limit the number of active instances and save some memory on large clusters
+with long connections. Note however that, if two consecutive updates require a reload, the second
+one will delay up to the configured duration to be reflected by HAProxy.
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -58,6 +58,7 @@ type Configuration struct {
 	MasterSocket string
 
 	RateLimitUpdate  float32
+	ReloadInterval   time.Duration
 	ResyncPeriod     time.Duration
 	WaitBeforeUpdate time.Duration
 

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -124,6 +124,14 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		Default is 0.5, which means wait 2 seconds between Ingress updates in order
 		to add more changes in a single reload`)
 
+		reloadInterval = flags.Duration("reload-interval", 0,
+			`Minimal time between two consecutive HAProxy reloads. The default value is 0,
+which means to always reload HAProxy just after a configuration change enforces
+a reload. The interval should be configured with a time suffix, eg 30s means
+that if two distinct and consecutive configuration changes enforce a reload,
+the second reload will be enqueued until 30 seconds have passed from the first
+one, applying every new configuration changes made between this interval`)
+
 		waitBeforeUpdate = flags.Duration("wait-before-update", 200*time.Millisecond,
 			`Amount of time to wait before start a reconciliation and update haproxy,
 		giving the time to receive all/most of the changes of a batch update.`)
@@ -393,6 +401,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		AcmeTrackTLSAnn:          *acmeTrackTLSAnn,
 		BucketsResponseTime:      *bucketsResponseTime,
 		RateLimitUpdate:          *rateLimitUpdate,
+		ReloadInterval:           *reloadInterval,
 		ResyncPeriod:             *resyncPeriod,
 		WaitBeforeUpdate:         *waitBeforeUpdate,
 		DefaultService:           *defaultSvc,


### PR DESCRIPTION
Creates a reload queue that manages how frequently HAProxy can be reloaded. This configuration allows a higher rate of dynamic updates with a low rate of HAProxy reloads. Two distinct queues controls dynamic updates and reloads, and a mutex ensures that these queues doesn't conflict with each other when reading and updating the in memory HAProxy model.