### PR TITLE
Add disable-external-name commnand-line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -26,6 +26,7 @@ The following command-line options are supported:
 | [`--default-backend-service`](#default-backend-service) | namespace/servicename      | haproxy's 404 page      |       |
 | [`--default-ssl-certificate`](#default-ssl-certificate) | namespace/secretname       | fake, auto generated    |       |
 | [`--disable-api-warnings`](#disable-api-warnings)       | [true\|false]              | `false`                 | v0.12 |
+| [`--disable-external-name`](#disable-external-name)     | [true\|false]              | `false`                 | v0.10 |
 | [`--disable-pod-list`](#disable-pod-list)               | [true\|false]              | `false`                 | v0.11 |
 | [`--healthz-port`](#stats)                              | port number                | `10254`                 |       |
 | [`--ingress-class`](#ingress-class)                     | name                       | `haproxy`               |       |
@@ -141,6 +142,14 @@ Since v0.12.4
 
 Disable warning logs sent from the API server. Most of the warnings are related with API
 deprecation. The default behavior is to log all API server warnings.
+
+---
+
+## --disable-external-name
+
+Since v0.10.9
+
+Services of type ExternalName uses DNS lookup to define the target server IP list. Declare `--disable-external-name` to disable a DNS based target IP list, refusing services of type ExternalName.
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -74,6 +74,7 @@ type Configuration struct {
 	AllowCrossNamespace     bool
 	DisableNodeList         bool
 	DisablePodList          bool
+	DisableExternalName     bool
 	AnnPrefix               []string
 
 	AcmeServer              bool

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -177,6 +177,9 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 			`Defines if HAProxy Ingress should disable pod watch and in memory list. Pod list is
 		mandatory for drain-support (should not be disabled) and optional for blue/green.`)
 
+		disableExternalName = flags.Bool("disable-external-name", false,
+			`Disables services of type ExternalName`)
+
 		updateStatusOnShutdown = flags.Bool("update-status-on-shutdown", true, `Indicates if the
 		ingress controller should update the Ingress status IP/hostname when the controller
 		is being stopped. Default is true`)
@@ -415,6 +418,7 @@ func NewIngressController(backend ingress.Controller) *GenericController {
 		AllowCrossNamespace:      *allowCrossNamespace,
 		DisableNodeList:          *disableNodeList,
 		DisablePodList:           *disablePodList,
+		DisableExternalName:      *disableExternalName,
 		UpdateStatusOnShutdown:   *updateStatusOnShutdown,
 		BackendShards:            *backendShards,
 		SortEndpointsBy:          sortEndpoints,

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -25,6 +25,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"reflect"
 	"regexp"
@@ -148,6 +149,13 @@ func createCache(
 
 func (c *k8scache) RunAsync(stopCh <-chan struct{}) {
 	c.listers.RunAsync(stopCh)
+}
+
+func (c *k8scache) ExternalNameLookup(externalName string) ([]net.IP, error) {
+	if c.cfg.DisableExternalName {
+		return nil, fmt.Errorf("external name lookup is disabled")
+	}
+	return net.LookupIP(externalName)
 }
 
 func (c *k8scache) GetIngressPodName() (namespace, podname string, err error) {

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -19,6 +19,7 @@ package helper_test
 import (
 	"crypto/sha1"
 	"fmt"
+	"net"
 	"strings"
 	"time"
 
@@ -42,6 +43,7 @@ type CacheMock struct {
 	GwList        []*gateway.Gateway
 	GwClassList   []*gateway.GatewayClass
 	HTTPRouteList []*gateway.HTTPRoute
+	LookupList    map[string][]net.IP
 	EpList        map[string]*api.Endpoints
 	ConfigMapList map[string]*api.ConfigMap
 	TermPodList   map[string][]*api.Pod
@@ -59,6 +61,7 @@ func NewCacheMock(tracker convtypes.Tracker) *CacheMock {
 		tracker:     tracker,
 		Changed:     &convtypes.ChangedObjects{},
 		SvcList:     []*api.Service{},
+		LookupList:  map[string][]net.IP{},
 		EpList:      map[string]*api.Endpoints{},
 		TermPodList: map[string][]*api.Pod{},
 		SecretTLSPath: map[string]string{
@@ -72,6 +75,14 @@ func (c *CacheMock) buildResourceName(defaultNamespace, resourceName string) str
 		return resourceName
 	}
 	return defaultNamespace + "/" + resourceName
+}
+
+// ExternalNameLookup ...
+func (c *CacheMock) ExternalNameLookup(externalName string) ([]net.IP, error) {
+	if ip, found := c.LookupList[externalName]; found {
+		return ip, nil
+	}
+	return nil, fmt.Errorf("hostname not found")
 }
 
 // GetIngress ...

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"net"
 	"time"
 
 	api "k8s.io/api/core/v1"
@@ -28,6 +29,7 @@ import (
 
 // Cache ...
 type Cache interface {
+	ExternalNameLookup(externalName string) ([]net.IP, error)
 	GetIngress(ingressName string) (*networking.Ingress, error)
 	GetIngressList() ([]*networking.Ingress, error)
 	GetIngressClass(className string) (*networking.IngressClass, error)

--- a/pkg/converters/utils/services_test.go
+++ b/pkg/converters/utils/services_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package utils
 
 import (
-	"fmt"
 	"net"
 	"reflect"
 	"testing"
@@ -34,15 +33,10 @@ func TestCreateEndpointsExternalName(t *testing.T) {
 	svc, _ := helper_test.CreateService("default/echo", "8080", "")
 	svc.Spec.Type = api.ServiceTypeExternalName
 	svc.Spec.ExternalName = "domain.local"
-	lookup = func(host string) ([]net.IP, error) {
-		if host == "domain.local" {
-			return []net.IP{net.ParseIP("10.0.1.10"), net.ParseIP("10.0.1.11")}, nil
-		}
-		return nil, fmt.Errorf("hostname not found")
-	}
-
+	cache := helper_test.NewCacheMock(nil)
+	cache.LookupList["domain.local"] = []net.IP{net.ParseIP("10.0.1.10"), net.ParseIP("10.0.1.11")}
 	svcPort := FindServicePort(svc, "8080")
-	ready, notReady, err := CreateEndpoints(nil, svc, svcPort)
+	ready, notReady, err := CreateEndpoints(cache, svc, svcPort)
 	expected := []*Endpoint{
 		{
 			IP:   "10.0.1.10",


### PR DESCRIPTION
`--disable-external-name` option refuses to configure services of type ExternalName, thus disallowing DNS lookups to configure the target address of backend servers.