### PR TITLE
Fix auth-url parsing if hostname misses a dot

### DIFF
--- a/pkg/converters/ingress/utils/utils.go
+++ b/pkg/converters/ingress/utils/utils.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 )
 
-var parseURLRegex = regexp.MustCompile(`^([a-z]+)://([-a-z0-9]+/)?([^][/: ]+)(:[-a-z0-9]+)?([^"' ]*)$`)
+var parseURLRegex = regexp.MustCompile(`^([a-z]+)://([-a-z0-9]+/)?([^][/: ]+)(:[-a-z0-9]+)?(/[^"' ]*)?$`)
 
 // ParseURL ...
 func ParseURL(url string) (urlProto, urlHost, urlPort, urlPath string, err error) {
@@ -33,22 +33,24 @@ func ParseURL(url string) (urlProto, urlHost, urlPort, urlPath string, err error
 	}
 	urlProto = urlParse[1]
 	namespace := urlParse[2]
-	urlHost = urlParse[3]
+	name := urlParse[3]
 	urlPort = strings.TrimLeft(urlParse[4], ":")
 	urlPath = urlParse[5]
 	if namespace != "" {
-		if urlPort == "" && urlPath == "" {
-			// the `proto://name/name` case, we want `name/path` instead of `namespace/name`
-			// this will probably never happen because, if proto == http/s, the first name
-			// should be an IP or a valid hostname, which doesn't match the namespace submatch;
-			// if proto == svc, port number is mandatory and would move the second name to the
-			// urlPath submatch
-			urlPath = "/" + urlHost
-			urlHost = strings.TrimSuffix(namespace, "/")
+		// <proto>://<namespace/><name>[:<urlPort>][<urlPath>]`
+		if urlPort != "" {
+			// port is mandatory on svc proto
+			// a matching namespace and a declared port
+			// ensures that we have a namespaced service name
+			urlHost = namespace + name
 		} else {
-			// this is really a namespace, so concatenate
-			urlHost = namespace + urlHost
+			// otherwise namespace is the host and name is the start of the path
+			urlHost = strings.TrimSuffix(namespace, "/")
+			urlPath = "/" + name + urlPath
 		}
+	} else {
+		// <proto>://<name>[:<urlPort>][<urlPath>]`
+		urlHost = name
 	}
 	return
 }

--- a/pkg/converters/ingress/utils/utils_test.go
+++ b/pkg/converters/ingress/utils/utils_test.go
@@ -69,18 +69,43 @@ func TestParseURL(t *testing.T) {
 		},
 		// 8
 		{
+			url: "proto://name/",
+			exp: "proto | name |  | /",
+		},
+		// 9
+		{
 			url: "proto://name/app",
 			exp: "proto | name |  | /app",
 		},
-		// 9
+		// 10
+		{
+			url: "proto://name/app/sub",
+			exp: "proto | name |  | /app/sub",
+		},
+		// 11
 		{
 			url: "proto://name/app:8080",
 			exp: "proto | name/app | 8080 | ",
 		},
-		// 10
+		// 12
+		{
+			url: "proto://name/app:8080/sub",
+			exp: "proto | name/app | 8080 | /sub",
+		},
+		// 13
 		{
 			url: "proto://name:8080/app",
 			exp: "proto | name | 8080 | /app",
+		},
+		// 14
+		{
+			url: "proto://name:8080/app/sub",
+			exp: "proto | name | 8080 | /app/sub",
+		},
+		// 15
+		{
+			url: "proto://ns/name:8080/app/sub",
+			exp: "proto | ns/name | 8080 | /app/sub",
 		},
 	}
 	for i, test := range testCases {


### PR DESCRIPTION
`auth-url` accepts http/s or service protocol, and the later accepts namespaced service names, if the configuration allows, since `v0.13-snapshot.3`. Namespaced names has a slash just like URIs, so parsing the whole URL is somewhat tricky. A domain name without dots was being matched as a namespace and concatenated with the first dir of the path, leading to a lookup error. This update fixes this behavior and also adds a few more unit tests covering more URL formats.