### PR TITLE
Always deny requests of failed auth configurations

### DIFF
--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -193,17 +193,20 @@ func TestAuthExternal(t *testing.T) {
 		// 0
 		{
 			url:     "10.0.0.1:8080/app",
+			expBack: hatypes.AuthExternal{AlwaysDeny: true},
 			logging: `WARN ignoring URL on ingress 'default/ing1': invalid URL syntax: 10.0.0.1:8080/app`,
 		},
 		// 1
 		{
 			url:     "fail://app1.local",
+			expBack: hatypes.AuthExternal{AlwaysDeny: true},
 			logging: `WARN ignoring auth URL with an invalid protocol on ingress 'default/ing1': fail`,
 		},
 		// 2
 		{
 			url:        "http://app1.local",
 			isExternal: true,
+			expBack:    hatypes.AuthExternal{AlwaysDeny: true},
 			logging:    `WARN external authentication on ingress 'default/ing1' needs Lua json module, install lua-json4 and enable 'external-has-lua' global config`,
 		},
 		// 3
@@ -238,6 +241,7 @@ func TestAuthExternal(t *testing.T) {
 		// 6
 		{
 			url:     "http://appfail.local/app",
+			expBack: hatypes.AuthExternal{AlwaysDeny: true},
 			logging: `WARN ignoring auth URL with an invalid domain on ingress 'default/ing1': host not found: appfail.local`,
 		},
 		// 7
@@ -307,16 +311,19 @@ func TestAuthExternal(t *testing.T) {
 		// 13
 		{
 			url:     "svc://noservice",
+			expBack: hatypes.AuthExternal{AlwaysDeny: true},
 			logging: `WARN skipping auth-url on ingress 'default/ing1': missing service port: svc://noservice`,
 		},
 		// 14
 		{
-			url: "svc://noservice:80",
+			url:     "svc://noservice:80",
+			expBack: hatypes.AuthExternal{AlwaysDeny: true},
 			// svc not found, warn is issued in the ingress parsing
 		},
 		// 15
 		{
 			url:     "svc://authservice",
+			expBack: hatypes.AuthExternal{AlwaysDeny: true},
 			logging: `WARN skipping auth-url on ingress 'default/ing1': missing service port: svc://authservice`,
 		},
 		// 16
@@ -1487,7 +1494,7 @@ func TestOAuth(t *testing.T) {
 				},
 			},
 			authExp: map[string]hatypes.AuthExternal{
-				"/": {},
+				"/": {AlwaysDeny: true},
 			},
 			logging: "WARN ignoring invalid oauth implementation 'none' on ingress 'default/ing1'",
 		},
@@ -1499,7 +1506,7 @@ func TestOAuth(t *testing.T) {
 				},
 			},
 			authExp: map[string]hatypes.AuthExternal{
-				"/": {},
+				"/": {AlwaysDeny: true},
 			},
 			logging: "ERROR path '/oauth2' was not found on namespace 'default'",
 		},
@@ -1655,10 +1662,13 @@ func TestOAuth(t *testing.T) {
 			external: true,
 			backend:  "default:back:/oauth2",
 			authExp: map[string]hatypes.AuthExternal{
-				"/":    {},
-				"/app": {},
+				"/":    {AlwaysDeny: true},
+				"/app": {AlwaysDeny: true},
 			},
-			logging: "WARN oauth2_proxy on ingress 'default/ing1' needs Lua json module, install lua-json4 and enable 'external-has-lua' global config",
+			logging: `
+WARN oauth2_proxy on ingress 'default/ing1' needs Lua json module, install lua-json4 and enable 'external-has-lua' global config
+WARN oauth2_proxy on ingress 'default/ing1' needs Lua json module, install lua-json4 and enable 'external-has-lua' global config
+`,
 		},
 		// 11
 		{

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -655,6 +655,18 @@ d1.local#/ path01`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
+				auth := &b.FindBackendPath(h.FindPath("/app1")[0].Link).AuthExternal
+				auth.AlwaysDeny = true
+			},
+			path: []string{"/app1", "/app2"},
+			expected: `
+    # path01 = d1.local/app1
+    # path02 = d1.local/app2
+    http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
+    http-request deny { var(txn.pathID) path01 }`,
+		},
+		{
+			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
 				b.SourceIPs = []net.IP{net.ParseIP("192.168.0.2"), net.ParseIP("192.168.0.3")}
 			},
 			// IP distribution starts based on the hash of the backend name.

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -757,6 +757,7 @@ type Cookie struct {
 // AuthExternal ...
 type AuthExternal struct {
 	AllowedPath     string
+	AlwaysDeny      bool
 	AuthBackendName string
 	AuthPath        string
 	HeadersFail     []string

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -629,6 +629,10 @@ backend {{ $backend.ID }}
 {{- $authCfg := $backend.PathConfig "AuthExternal" }}
 {{- range $i, $auth := $authCfg.Items }}
 {{- range $pathIDs := $authCfg.PathIDs $i }}
+{{- if $auth.AlwaysDeny }}
+    http-request deny
+        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+{{- else }}
 {{- if $auth.AuthBackendName }}
     http-request set-header X-Real-IP %[src]
         {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
@@ -649,6 +653,7 @@ backend {{ $backend.ID }}
     http-request set-header {{ $header }} %[var({{ $attr }})] if { var({{ $attr }}) -m found }
         {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
         {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
The attempt to configure auth external or oauth means that the backend should be protected. However the current implementation is leaving the backend unprotected if a misconfiguration is found - which can be an external failure like a dns lookup. This update ensures that an attempt to protect a backend will in fact protect it, and misconfigurations or failures during the configuration parsing means an always-deny behavior.