### PR TITLE
Add disable-config-keywords command-line options

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -28,6 +28,7 @@ The following command-line options are supported:
 | [`--default-backend-service`](#default-backend-service) | namespace/servicename      | haproxy's 404 page      |       |
 | [`--default-ssl-certificate`](#default-ssl-certificate) | namespace/secretname       | fake, auto generated    |       |
 | [`--disable-api-warnings`](#disable-api-warnings)       | [true\|false]              | `false`                 | v0.12 |
+| [`--disable-config-keywords`](#disable-config-keywords) | comma-separated list of keywords | `""`              | v0.10 |
 | [`--disable-external-name`](#disable-external-name)     | [true\|false]              | `false`                 | v0.10 |
 | [`--disable-pod-list`](#disable-pod-list)               | [true\|false]              | `false`                 | v0.11 |
 | [`--election-id`](#election-id)                         | identifier                 | `ingress-controller-leader` |   |
@@ -178,6 +179,18 @@ Since v0.12.4
 
 Disable warning logs sent from the API server. Most of the warnings are related with API
 deprecation. The default behavior is to log all API server warnings.
+
+---
+
+## --disable-config-keywords
+
+Since v0.10.9
+
+Defines a comma-separated list of HAProxy keywords that should not be used on annotation based configuration snippets. Configuration snippets added as a global config does not follow this option. Use an asterisk `*` to disable configuration snippets using annotations.
+
+Every keyword in the configuration will be compared with the first token of every configuration line, ignoring tabs and spaces. If a match occur, all the configuration snippet will be ignored and a warning is logged.
+
+The default value is an empty string, enabling the configuration and accepting any HAProxy keyword.
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -79,6 +79,7 @@ type Configuration struct {
 	AllowCrossNamespace     bool
 	DisablePodList          bool
 	DisableExternalName     bool
+	DisableConfigKeywords   string
 	AnnPrefix               []string
 
 	AcmeServer              bool

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -213,6 +213,12 @@ blue/green.`)
 		disableExternalName = flags.Bool("disable-external-name", false,
 			`Disables services of type ExternalName`)
 
+		disableConfigKeywords = flags.String("disable-config-keywords", "",
+			`Defines a comma-separated list of HAProxy keywords that should not be used on
+annotation based configuration snippets. Configuration snippets added as a
+global config does not follow this option. Use an asterisk * to disable
+configuration snippets using annotations.`)
+
 		updateStatusOnShutdown = flags.Bool("update-status-on-shutdown", true,
 			`Indicates if the ingress controller should update the Ingress status
 IP/hostname when the controller is being stopped.`)
@@ -474,6 +480,7 @@ tracked.`)
 		AllowCrossNamespace:      *allowCrossNamespace,
 		DisablePodList:           *disablePodList,
 		DisableExternalName:      *disableExternalName,
+		DisableConfigKeywords:    *disableConfigKeywords,
 		UpdateStatusOnShutdown:   *updateStatusOnShutdown,
 		BackendShards:            *backendShards,
 		SortEndpointsBy:          sortEndpoints,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -148,6 +149,7 @@ func (hc *HAProxyController) configController() {
 		DefaultCrtSecret: hc.cfg.DefaultSSLCertificate,
 		FakeCrtFile:      hc.createFakeCrtFile(),
 		FakeCAFile:       hc.createFakeCAFile(),
+		DisableKeywords:  strings.Split(hc.cfg.DisableConfigKeywords, ","),
 		AcmeTrackTLSAnn:  hc.cfg.AcmeTrackTLSAnn,
 		HasGateway:       hc.cache.hasGateway(),
 	}

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -521,6 +521,50 @@ func (c *updater) buildBackendCors(d *backData) {
 	}
 }
 
+func (c *updater) buildBackendCustomConfig(d *backData) {
+	config := d.mapper.Get(ingtypes.BackConfigBackend)
+	if config.Source == nil {
+		return
+	}
+	lines := utils.LineToSlice(config.Value)
+	if len(lines) == 0 {
+		return
+	}
+	for _, keyword := range c.options.DisableKeywords {
+		if keyword == "*" {
+			c.logger.Warn("skipping configuration snippet on %s: custom configuration is disabled", config.Source)
+			return
+		}
+		for _, line := range lines {
+			if firstToken(line) == keyword {
+				c.logger.Warn("skipping configuration snippet on %s: keyword '%s' not allowed", config.Source, keyword)
+				return
+			}
+		}
+	}
+	d.backend.CustomConfig = lines
+}
+
+// kindly provided by strings/strings.go
+var asciiSpace = [256]uint8{'\t': 1, '\n': 1, '\v': 1, '\f': 1, '\r': 1, ' ': 1}
+
+func firstToken(s string) string {
+	// only ascii spaces supported, code<128
+	start := 0
+	for ; len(s) > start; start++ {
+		if asciiSpace[s[start]] == 0 {
+			break
+		}
+	}
+	end := start
+	for ; len(s) > end; end++ {
+		if asciiSpace[s[end]] == 1 {
+			break
+		}
+	}
+	return s[start:end]
+}
+
 func (c *updater) buildBackendDNS(d *backData) {
 	resolverName := d.mapper.Get(ingtypes.BackUseResolver).Value
 	if resolverName == "" {

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -212,7 +212,6 @@ func (c *updater) UpdateBackendConfig(backend *hatypes.Backend, mapper *Mapper) 
 	}
 	// TODO check ModeTCP with HTTP annotations
 	backend.BalanceAlgorithm = mapper.Get(ingtypes.BackBalanceAlgorithm).Value
-	backend.CustomConfig = utils.LineToSlice(mapper.Get(ingtypes.BackConfigBackend).Value)
 	backend.Server.MaxConn = mapper.Get(ingtypes.BackMaxconnServer).Int()
 	backend.Server.MaxQueue = mapper.Get(ingtypes.BackMaxQueueServer).Int()
 	c.buildBackendAffinity(data)
@@ -222,6 +221,7 @@ func (c *updater) UpdateBackendConfig(backend *hatypes.Backend, mapper *Mapper) 
 	c.buildBackendBlueGreenSelector(data)
 	c.buildBackendBodySize(data)
 	c.buildBackendCors(data)
+	c.buildBackendCustomConfig(data)
 	c.buildBackendDNS(data)
 	c.buildBackendDynamic(data)
 	c.buildBackendAgentCheck(data)

--- a/pkg/converters/types/options.go
+++ b/pkg/converters/types/options.go
@@ -33,6 +33,7 @@ type ConverterOptions struct {
 	FakeCrtFile      CrtFile
 	FakeCAFile       CrtFile
 	AnnotationPrefix []string
+	DisableKeywords  []string
 	AcmeTrackTLSAnn  bool
 	HasGateway       bool
 }


### PR DESCRIPTION
This option allows to disable annotation based configuration snippets, partially or completely. Configuration snippets can be the source of failures in the HAProxy reload, and also vulnerable configurations.