### PR TITLE
Change nbthread to use all CPUs by default

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -405,7 +405,7 @@ The table below describes all supported configuration keys.
 | [`modsecurity-timeout-idle`](#modsecurity)           | time with suffix                        | Global  | `30s`              |
 | [`modsecurity-timeout-processing`](#modsecurity)     | time with suffix                        | Global  | `1s`               |
 | [`nbproc-ssl`](#nbproc)                              | number of process                       | Global  | `0`                |
-| [`nbthread`](#nbthread)                              | number of threads                       | Global  | `2`                |
+| [`nbthread`](#nbthread)                              | number of threads                       | Global  |                    |
 | [`no-tls-redirect-locations`](#ssl-redirect)         | comma-separated list of URIs            | Global  | `/.well-known/acme-challenge` |
 | [`oauth`](#oauth)                                    | "oauth2_proxy"                          | Path    |                    |
 | [`oauth-headers`](#oauth)                            | `<header>:<var>,...`                    | Path    |                    |
@@ -1815,14 +1815,14 @@ See also:
 
 | Configuration key | Scope    | Default | Since |
 |-------------------|----------|---------|-------|
-| `nbthread`        | `Global` | `2`     |       |
+| `nbthread`        | `Global` |         |       |
 
 Define the number of threads a single HAProxy process should use to all its
-processing. If using with [nbproc](#nbproc), every single HAProxy process will
-share this same configuration.
+processing. If not declared, the number of threads will be adjusted to the
+number of available CPUs on platforms that support CPU affinity.
 
-If using two or more threads on a single HAProxy process, `cpu-map` is used to
-bind each thread on its own CPU core.
+If using two or more threads, `cpu-map` is used by default to bind each
+thread on its own CPU core.
 
 See also:
 

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -141,9 +141,9 @@ func (c *updater) buildGlobalProc(d *globalData) {
 	}
 	procs := balance + ssl
 	threads := d.mapper.Get(ingtypes.GlobalNbthread).Int()
-	if threads < 1 {
-		c.logger.Warn("invalid value of nbthread configmap option (%v), using 1", threads)
-		threads = 1
+	if threads < 0 {
+		c.logger.Warn("ignoring invalid value of nbthread: %d", threads)
+		threads = 0
 	}
 	bindprocBalance := "1"
 	if balance > 1 {

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -96,7 +96,6 @@ func createDefaults() map[string]string {
 		types.GlobalModsecurityTimeoutProcessing: "1s",
 		types.GlobalModsecurityTimeoutServer:     "5s",
 		types.GlobalNbprocBalance:                "1",
-		types.GlobalNbthread:                     "2",
 		types.GlobalNoTLSRedirectLocations:       "/.well-known/acme-challenge",
 		types.GlobalPathTypeOrder:                "exact,prefix,begin,regex",
 		types.GlobalRedirectFromCode:             "302",

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -78,7 +78,7 @@ global
 {{- if gt $global.Procs.Nbproc 1 }}
     nbproc {{ $global.Procs.Nbproc }}
 {{- end }}
-{{- if gt $global.Procs.Nbthread 1 }}
+{{- if $global.Procs.Nbthread }}
     nbthread {{ $global.Procs.Nbthread }}
 {{- end }}
 {{- if $global.Procs.CPUMap }}


### PR DESCRIPTION
Removes the default value of 2 threads and let HAProxy configures threads automatically if the configuration is not provided. It's preferable more than less threads on a poorly configured system (or benchmark).

Compatibility notes: this might change the number of configured threads on deployments that doesn't configure an explicit value. The number should be updated to the number of CPUs available to the HAProxy process, or to one thread if the platform doesn't support CPU affinity.