### PR TITLE
Option to use client and master socket in keep alive mode

### DIFF
--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -33,8 +33,7 @@ import (
 type dynUpdater struct {
 	logger  types.Logger
 	config  *config
-	socket  string
-	cmd     func(socket string, observer func(duration time.Duration), commands ...string) ([]string, error)
+	socket  socket.HAProxySocket
 	cmdCnt  int
 	metrics types.Metrics
 }
@@ -54,12 +53,11 @@ type epPair struct {
 	cur *hatypes.Endpoint
 }
 
-func (i *instance) newDynUpdater() *dynUpdater {
+func (i *instance) newDynUpdater(socket socket.HAProxySocket) *dynUpdater {
 	return &dynUpdater{
 		logger:  i.logger,
 		config:  i.config.(*config),
-		socket:  i.config.Global().AdminSocket,
-		cmd:     socket.HAProxyCommand,
+		socket:  socket,
 		metrics: i.metrics,
 	}
 }
@@ -457,7 +455,7 @@ func (d *dynUpdater) execEnableEndpoint(backname string, oldEP, curEP *hatypes.E
 }
 
 func (d *dynUpdater) execCommand(observer func(duration time.Duration), cmd []string) ([]string, error) {
-	msg, err := d.cmd(d.socket, observer, cmd...)
+	msg, err := d.socket.Send(observer, cmd...)
 	d.cmdCnt = d.cmdCnt + len(cmd)
 	return msg, err
 }

--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/socket"
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
-	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/utils"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/types"
 )
 
@@ -59,7 +59,7 @@ func (i *instance) newDynUpdater() *dynUpdater {
 		logger:  i.logger,
 		config:  i.config.(*config),
 		socket:  i.config.Global().AdminSocket,
-		cmd:     utils.HAProxyCommand,
+		cmd:     socket.HAProxyCommand,
 		metrics: i.metrics,
 	}
 }

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -1021,14 +1021,10 @@ INFO-V(2) need to reload due to config changes: [hosts]
 		if test.doconfig2 != nil {
 			test.doconfig2(c)
 		}
-		var cmd string
-		dynUpdater := c.instance.newDynUpdater()
-		dynUpdater.cmd = func(socket string, observer func(duration time.Duration), command ...string) ([]string, error) {
-			for _, c := range command {
-				cmd = cmd + c + "\n"
-			}
-			return test.cmdOutput, nil
+		clientMock := &clientMock{
+			cmdOutput: test.cmdOutput,
 		}
+		dynUpdater := c.instance.newDynUpdater(clientMock)
 		dynamic := dynUpdater.update()
 		var actual []string
 		for _, ep := range c.config.Backends().AcquireBackend("default", "app", "8080").Endpoints {
@@ -1041,7 +1037,7 @@ INFO-V(2) need to reload due to config changes: [hosts]
 		if dynamic != test.dynamic {
 			t.Errorf("dynamic expected as '%t' on %d, but was '%t'", test.dynamic, i, dynamic)
 		}
-		cmd = strings.TrimSpace(cmd)
+		cmd := strings.TrimSpace(clientMock.cmd)
 		test.cmd = strings.TrimSpace(test.cmd)
 		if cmd != test.cmd {
 			t.Errorf("cmd differs on %d:\n%s", i, diff.Diff(test.cmd, cmd))
@@ -1049,4 +1045,26 @@ INFO-V(2) need to reload due to config changes: [hosts]
 		c.logger.CompareLogging(test.logging)
 		c.teardown()
 	}
+}
+
+type clientMock struct {
+	cmd       string
+	cmdOutput []string
+}
+
+func (cli *clientMock) Address() string {
+	return ""
+}
+
+func (cli *clientMock) Send(observer func(duration time.Duration), command ...string) ([]string, error) {
+	for _, c := range command {
+		cli.cmd = cli.cmd + c + "\n"
+	}
+	return cli.cmdOutput, nil
+}
+
+func (cli *clientMock) Down() {}
+
+func (cli *clientMock) Close() error {
+	return nil
 }

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -1056,6 +1056,10 @@ func (cli *clientMock) Address() string {
 	return ""
 }
 
+func (cli *clientMock) HasConn() bool {
+	return true
+}
+
 func (cli *clientMock) Send(observer func(duration time.Duration), command ...string) ([]string, error) {
 	for _, c := range command {
 		cli.cmd = cli.cmd + c + "\n"
@@ -1063,7 +1067,9 @@ func (cli *clientMock) Send(observer func(duration time.Duration), command ...st
 	return cli.cmdOutput, nil
 }
 
-func (cli *clientMock) Down() {}
+func (cli *clientMock) Unlistening() error {
+	return nil
+}
 
 func (cli *clientMock) Close() error {
 	return nil

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -192,7 +192,7 @@ func (i *instance) CalcIdleMetric() {
 		return
 	}
 	if i.idleChkSock == nil {
-		i.idleChkSock = socket.NewSocket(i.config.Global().AdminSocket)
+		i.idleChkSock = socket.NewSocket(i.config.Global().AdminSocket, false)
 	}
 	msg, err := i.idleChkSock.Send(i.metrics.HAProxyShowInfoResponseTime, "show info")
 	if err != nil {
@@ -273,7 +273,7 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 		i.logChanged()
 	}
 	if i.adminSock == nil {
-		i.adminSock = socket.NewSocket(i.config.Global().AdminSocket)
+		i.adminSock = socket.NewSocket(i.config.Global().AdminSocket, false)
 	}
 	updater := i.newDynUpdater(i.adminSock)
 	updated := updater.update()
@@ -530,7 +530,7 @@ func (i *instance) reloadEmbedded() error {
 
 func (i *instance) reloadExternal() error {
 	if i.masterSock == nil {
-		i.masterSock = socket.NewSocket(i.config.Global().External.MasterSocket)
+		i.masterSock = socket.NewSocket(i.config.Global().External.MasterSocket, false)
 	}
 	if !i.up {
 		// first run, wait until the external haproxy is running

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -84,6 +84,9 @@ type instance struct {
 	mapsTmpl    *template.Config
 	modsecTmpl  *template.Config
 	config      Config
+	adminSock   socket.HAProxySocket
+	masterSock  socket.HAProxySocket
+	idleChkSock socket.HAProxySocket
 	metrics     types.Metrics
 }
 
@@ -188,7 +191,10 @@ func (i *instance) CalcIdleMetric() {
 	if !i.up {
 		return
 	}
-	msg, err := socket.HAProxyCommand(i.config.Global().AdminSocket, i.metrics.HAProxyShowInfoResponseTime, "show info")
+	if i.idleChkSock == nil {
+		i.idleChkSock = socket.NewSocket(i.config.Global().AdminSocket)
+	}
+	msg, err := i.idleChkSock.Send(i.metrics.HAProxyShowInfoResponseTime, "show info")
 	if err != nil {
 		i.logger.Error("error reading admin socket: %v", err)
 		return
@@ -266,7 +272,10 @@ func (i *instance) haproxyUpdate(timer *utils.Timer) {
 		// TODO update tests and remove `if !fake` above
 		i.logChanged()
 	}
-	updater := i.newDynUpdater()
+	if i.adminSock == nil {
+		i.adminSock = socket.NewSocket(i.config.Global().AdminSocket)
+	}
+	updater := i.newDynUpdater(i.adminSock)
 	updated := updater.update()
 	if i.options.SortEndpointsBy != "random" {
 		i.config.Backends().SortChangedEndpoints(i.options.SortEndpointsBy)
@@ -330,11 +339,27 @@ func (i *instance) Reload(timer *utils.Timer) {
 		return
 	}
 	i.up = true
+	i.releaseSockets()
 	i.updateSuccessful(true)
 	if i.config.Global().External.IsExternal() {
 		i.logger.Info("haproxy successfully reloaded (external)")
 	} else {
 		i.logger.Info("haproxy successfully reloaded (embedded)")
+	}
+}
+
+func (i *instance) releaseSockets() {
+	if i.idleChkSock != nil {
+		i.idleChkSock.Close()
+		i.idleChkSock = nil
+	}
+	if i.adminSock != nil {
+		i.adminSock.Close()
+		i.adminSock = nil
+	}
+	if i.masterSock != nil {
+		i.masterSock.Close()
+		i.masterSock = nil
 	}
 }
 
@@ -504,7 +529,9 @@ func (i *instance) reloadEmbedded() error {
 }
 
 func (i *instance) reloadExternal() error {
-	masterSocket := i.config.Global().External.MasterSocket
+	if i.masterSock == nil {
+		i.masterSock = socket.NewSocket(i.config.Global().External.MasterSocket)
+	}
 	if !i.up {
 		// first run, wait until the external haproxy is running
 		// and successfully listening to the master socket.
@@ -512,12 +539,12 @@ func (i *instance) reloadExternal() error {
 		i.logger.Info("waiting for the external haproxy...")
 		for {
 			var err error
-			if _, err = socket.HAProxyCommand(masterSocket, nil, "show proc"); err == nil {
+			if _, err = i.masterSock.Send(nil, "show proc"); err == nil {
 				break
 			}
 			j++
 			if j%10 == 0 {
-				i.logger.Info("cannot connect to the master socket '%s': %v", masterSocket, err)
+				i.logger.Info("cannot connect to the master socket '%s': %v", i.masterSock.Address(), err)
 			}
 			select {
 			case <-i.options.StopCh:
@@ -526,10 +553,10 @@ func (i *instance) reloadExternal() error {
 			}
 		}
 	}
-	if _, err := socket.HAProxyCommand(masterSocket, nil, "reload"); err != nil {
+	if _, err := i.masterSock.Send(nil, "reload"); err != nil {
 		return fmt.Errorf("error sending reload to master socket: %w", err)
 	}
-	out, err := socket.HAProxyProcs(masterSocket)
+	out, err := socket.HAProxyProcs(i.masterSock)
 	if err != nil {
 		return fmt.Errorf("error reading procs from master socket: %w", err)
 	}

--- a/pkg/haproxy/socket/socket.go
+++ b/pkg/haproxy/socket/socket.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package socket
 
 import (
 	"fmt"

--- a/pkg/haproxy/socket/socket_test.go
+++ b/pkg/haproxy/socket/socket_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package socket
 
 import (
 	"fmt"


### PR DESCRIPTION
Add option to change from the open/send/close sequence when communicating with client and master sockets to always leave the connection open, or reuse the same connection whenever more than one command should be sent. This improves the communication speed, and also makes the first step on behalf of retrieve data from stopping instances whose listening sockets aren't alive anymore.