### PR TITLE
Add close-sessions-duration config key

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -50,6 +50,7 @@ The following command-line options are supported:
 | [`--stats-collect-processing-period`](#stats)           | time                       | `500ms`                 | v0.10 |
 | [`--sync-period`](#sync-period)                         | time                       | `10m`                   |       |
 | [`--tcp-services-configmap`](#tcp-services-configmap)   | namespace/configmapname    | no tcp svc              |       |
+| [`--track-old-instances`](#track-old-instances)         | [true\|false]              | `false`                 | v0.14 |
 | [`--update-status`](#update-status)                     | [true\|false]              | `true`                  |       |
 | [`--update-status-on-shutdown`](#update-status-on-shutdown) | [true\|false]          | `true`                  |       |
 | [`--v`](#v)                                             | log level as integer       | `1`                     |       |
@@ -483,6 +484,24 @@ Note: Check interval was added in v0.10 and defaults to `2s`. All declared servi
 See also:
 
 * [TCP Services]({{% relref "keys#tcp-services" %}}) configuration keys
+
+---
+
+## --track-old-instances
+
+Since v0.14
+
+Creates an internal list of connections to old HAProxy instances. These connections are used to
+read or send data to stopping instances, which is usually serving long lived connections like
+TCP services or websockets.
+
+Enabling this option will make old HAProxy instances to not stop before `timeout-stop` timeout,
+even if all the remaining sessions finish, so only enable it if using a feature that requests
+it.
+
+See also:
+
+* [`close-sessions-duration`]({{% relref "keys#close-sessions-duration" %}}) configuration key
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -99,6 +99,7 @@ type Configuration struct {
 	DefaultHealthzURL      string
 	StatsCollectProcPeriod time.Duration
 	PublishService         string
+	TrackOldInstances      bool
 	Backend                ingress.Controller
 
 	UpdateStatus           bool

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -236,6 +236,11 @@ k8s endpoint order (default); 'name' - server/endpoint name;
 'ip' - server/endpoint IP and port; 'random' - shuffle endpoints on every
 haproxy reload`)
 
+		trackOldInstances = flags.Bool("track-old-instances", false,
+			`Creates an internal list of connections to old HAProxy instances. These
+connections are used to read or send data to stopping instances, which is
+usually serving long lived connections like TCP services or websockets.`)
+
 		useNodeInternalIP = flags.Bool("report-node-internal-ip-address", false,
 			`Defines if the nodes IP address to be returned in the ingress status should be
 the internal instead of the external IP address`)
@@ -481,6 +486,7 @@ tracked.`)
 		DisablePodList:           *disablePodList,
 		DisableExternalName:      *disableExternalName,
 		DisableConfigKeywords:    *disableConfigKeywords,
+		TrackOldInstances:        *trackOldInstances,
 		UpdateStatusOnShutdown:   *updateStatusOnShutdown,
 		BackendShards:            *backendShards,
 		SortEndpointsBy:          sortEndpoints,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -122,6 +122,8 @@ func (hc *HAProxyController) configController() {
 	instanceOptions := haproxy.InstanceOptions{
 		HAProxyCfgDir:     "/etc/haproxy",
 		HAProxyMapsDir:    ingress.DefaultMapsDirectory,
+		MasterSocket:      hc.cfg.MasterSocket,
+		AdminSocket:       "/var/run/haproxy/admin.sock",
 		BackendShards:     hc.cfg.BackendShards,
 		AcmeSigner:        acmeSigner,
 		AcmeQueue:         hc.acmeQueue,
@@ -132,6 +134,7 @@ func (hc *HAProxyController) configController() {
 		MaxOldConfigFiles: hc.cfg.MaxOldConfigFiles,
 		SortEndpointsBy:   hc.cfg.SortEndpointsBy,
 		StopCh:            hc.stopCh,
+		TrackInstances:    hc.cfg.TrackOldInstances,
 		ValidateConfig:    hc.cfg.ValidateConfig,
 	}
 	hc.instance = haproxy.CreateInstance(hc.logger, instanceOptions)
@@ -143,7 +146,8 @@ func (hc *HAProxyController) configController() {
 		Cache:            hc.cache,
 		Tracker:          hc.tracker,
 		DynamicConfig:    hc.dynamicConfig,
-		MasterSocket:     hc.cfg.MasterSocket,
+		MasterSocket:     instanceOptions.MasterSocket,
+		AdminSocket:      instanceOptions.AdminSocket,
 		AnnotationPrefix: hc.cfg.AnnPrefix,
 		DefaultBackend:   hc.cfg.DefaultService,
 		DefaultCrtSecret: hc.cfg.DefaultSSLCertificate,
@@ -151,6 +155,7 @@ func (hc *HAProxyController) configController() {
 		FakeCAFile:       hc.createFakeCAFile(),
 		DisableKeywords:  strings.Split(hc.cfg.DisableConfigKeywords, ","),
 		AcmeTrackTLSAnn:  hc.cfg.AcmeTrackTLSAnn,
+		TrackInstances:   hc.cfg.TrackOldInstances,
 		HasGateway:       hc.cache.hasGateway(),
 	}
 }

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -142,8 +142,7 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 		global:   haproxyConfig.Global(),
 		mapper:   mapper,
 	}
-	// TODO Move all magic strings to a single place
-	d.global.AdminSocket = "/var/run/haproxy/admin.sock"
+	d.global.AdminSocket = c.options.AdminSocket
 	d.global.MaxConn = mapper.Get(ingtypes.GlobalMaxConnections).Int()
 	d.global.DefaultBackendRedir = mapper.Get(ingtypes.GlobalDefaultBackendRedirect).String()
 	d.global.DefaultBackendRedirCode = mapper.Get(ingtypes.GlobalDefaultBackendRedirectCode).Int()
@@ -164,6 +163,7 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	c.buildGlobalAcme(d)
 	c.buildGlobalAuthProxy(d)
 	c.buildGlobalBind(d)
+	c.buildGlobalCloseSessions(d)
 	c.buildGlobalCustomConfig(d)
 	c.buildGlobalDNS(d)
 	c.buildGlobalDynamic(d)

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -33,6 +33,7 @@ const (
 	GlobalBindIPAddrPrometheus         = "bind-ip-addr-prometheus"
 	GlobalBindIPAddrStats              = "bind-ip-addr-stats"
 	GlobalBindIPAddrTCP                = "bind-ip-addr-tcp"
+	GlobalCloseSessionsDuration        = "close-sessions-duration"
 	GlobalConfigDefaults               = "config-defaults"
 	GlobalConfigFrontend               = "config-frontend"
 	GlobalConfigGlobal                 = "config-global"

--- a/pkg/converters/types/options.go
+++ b/pkg/converters/types/options.go
@@ -27,6 +27,7 @@ type ConverterOptions struct {
 	Tracker          Tracker
 	DynamicConfig    *DynamicConfig
 	MasterSocket     string
+	AdminSocket      string
 	DefaultConfig    func() map[string]string
 	DefaultBackend   string
 	DefaultCrtSecret string
@@ -35,6 +36,7 @@ type ConverterOptions struct {
 	AnnotationPrefix []string
 	DisableKeywords  []string
 	AcmeTrackTLSAnn  bool
+	TrackInstances   bool
 	HasGateway       bool
 }
 

--- a/pkg/haproxy/connections.go
+++ b/pkg/haproxy/connections.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2021 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package haproxy
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/socket"
+)
+
+func newConnections(masterSock, adminSock string) *connections {
+	return &connections{
+		mutex:      sync.Mutex{},
+		masterSock: masterSock,
+		adminSock:  adminSock,
+	}
+}
+
+type connections struct {
+	mutex        sync.Mutex
+	masterSock   string
+	adminSock    string
+	oldInstances []socket.HAProxySocket
+	master       socket.HAProxySocket
+	dynUpdate    socket.HAProxySocket
+	idleChk      socket.HAProxySocket
+}
+
+func (c *connections) TrackCurrentInstance(timeoutStopDur, closeSessDur time.Duration) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.shrinkConns()
+	sock := socket.NewSocketConcurrent(c.adminSock, true)
+	sock.Unlistening()
+	c.oldInstances = append(c.oldInstances, sock)
+
+	if closeSessDur > 0 && closeSessDur < timeoutStopDur {
+		// schedule shutdown sessions
+		time.AfterFunc(timeoutStopDur-closeSessDur, func() {
+			// All the shuwdowns run synchronously and exits after all the
+			// remaining sessions have been shutdown, or in the case of an error.
+			// When it finishes we can safely close the connection
+			shutdownSessionsSync(sock, closeSessDur)
+			sock.Close()
+		})
+	} else {
+		// This connection can be used by other jobs, and this schedule is
+		// responsible for closing it if closeSessDur wasn't configured.
+		time.AfterFunc(timeoutStopDur, func() { sock.Close() })
+	}
+}
+
+func (c *connections) ReleaseLastInstance() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	l := len(c.oldInstances)
+	if l > 0 {
+		c.oldInstances[l-1].Close()
+		c.oldInstances = c.oldInstances[:l-1]
+	}
+}
+
+func (c *connections) OldInstancesCount() int {
+	return len(c.oldInstances)
+}
+
+func (c *connections) shrinkConns() {
+	i := 0
+	for j, old := range c.oldInstances {
+		if i < j {
+			c.oldInstances[i] = old
+		}
+		if old.HasConn() {
+			i++
+		}
+	}
+	c.oldInstances = c.oldInstances[:i]
+}
+
+func shutdownSessionsSync(sock socket.HAProxySocket, duration time.Duration) {
+	sess, err := sock.Send(nil, "show sess")
+	if err != nil {
+		return
+	}
+	// sess output:
+	//
+	// 0x7f9440810000: proto=unix_stream src=...
+	// 0x7f943f87f200: proto=unix_stream src=...
+	// 0x7f9442808200: proto=unix_stream src=...
+	// ...
+	var sessionList []string
+	for _, s := range strings.Split(sess[0], "\n") {
+		i := strings.Index(s, ":")
+		if i > 0 {
+			sessionList = append(sessionList, s[:i])
+		}
+	}
+	interval := duration / time.Duration((len(sessionList) + 1))
+	for _, s := range sessionList {
+		_, err := sock.Send(nil, "shutdown session "+s)
+		if err != nil {
+			// maybe the connection or the instance is gone,
+			// haproxy takes care of the remaining sessions if any
+			return
+		}
+		// we can enqueue shutdowns and sleeps, this is a dedicated go routine
+		// TODO interval should be the duration between two shutdown starts,
+		// but it's currently between the end of the former and the start of the next.
+		time.Sleep(interval)
+	}
+}
+
+func (c *connections) Master() socket.HAProxySocket {
+	if c.master == nil {
+		c.master = socket.NewSocket(c.masterSock, false)
+	}
+	return c.master
+}
+
+func (c *connections) DynUpdate() socket.HAProxySocket {
+	if c.dynUpdate == nil {
+		// using a non persistent connection (keep alive false)
+		// to ensure that the current instance will be used
+		c.dynUpdate = socket.NewSocket(c.adminSock, false)
+	}
+	return c.dynUpdate
+}
+
+func (c *connections) IdleChk() socket.HAProxySocket {
+	if c.idleChk == nil {
+		c.idleChk = socket.NewSocket(c.adminSock, false)
+	}
+	return c.idleChk
+}

--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -53,11 +53,11 @@ type epPair struct {
 	cur *hatypes.Endpoint
 }
 
-func (i *instance) newDynUpdater(socket socket.HAProxySocket) *dynUpdater {
+func (i *instance) newDynUpdater() *dynUpdater {
 	return &dynUpdater{
 		logger:  i.logger,
 		config:  i.config.(*config),
-		socket:  socket,
+		socket:  i.conns.DynUpdate(),
 		metrics: i.metrics,
 	}
 }

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -1024,7 +1024,8 @@ INFO-V(2) need to reload due to config changes: [hosts]
 		clientMock := &clientMock{
 			cmdOutput: test.cmdOutput,
 		}
-		dynUpdater := c.instance.newDynUpdater(clientMock)
+		dynUpdater := c.instance.newDynUpdater()
+		dynUpdater.socket = clientMock
 		dynamic := dynUpdater.update()
 		var actual []string
 		for _, ep := range c.config.Backends().AcquireBackend("default", "app", "8080").Endpoints {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -72,6 +72,8 @@ type Global struct {
 	Prometheus              PromConfig
 	Security                SecurityConfig
 	Stats                   StatsConfig
+	CloseSessionsDuration   time.Duration
+	TimeoutStopDuration     time.Duration
 	StrictHost              bool
 	UseHTX                  bool
 	DefaultBackendRedir     string
@@ -124,6 +126,7 @@ type TimeoutConfig struct {
 	BackendTimeoutConfig
 	Client    string
 	ClientFin string
+	Stats     string
 	Stop      string
 }
 

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -86,6 +86,9 @@ global
 {{- end }}
     stats socket {{ default "--" $global.AdminSocket }} level admin expose-fd listeners mode 600
         {{- if gt $global.Procs.Nbproc 1 }} process 1{{ end }}
+{{- if $global.Timeout.Stats }}
+    stats timeout {{ $global.Timeout.Stats }}
+{{- end }}
 {{- if $global.LoadServerState }}
     server-state-file state-global
     server-state-base /var/lib/haproxy/


### PR DESCRIPTION
Active sessions of a stopping instance (`haproxy -sf -x`) are terminated just after `hard-stop-after` (our `timeout-stop`) times out and just before the old haproxy instance terminates. All the sessions at the same time. This option adds the ability to start the shutdown session at a configured time before the instance times out.

This is done on top of two new implementations: now sockets can be configured to leave the connection open, so we have a way to reach the stopping instance since its admin socket isn't being listened anymore (standalone/embedded only, we could reach an old instance using master/worker mode).

The other one is a new struct and associated funcs called connections, that holds the master socket (if used), admin sockets, a list of stopping instances, and also controls concurrent access. The instances list can be used by functionalities that need to read or change their state.

`close-sessions-duration` is built on top of them. A new goroutine starts when `timeout - duration` time has passed after the reload, and fairly distributes shutdowns along the remaining time of the instance.