### PR TITLE
Fix set ssl cert end-of-command

### DIFF
--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -379,7 +379,7 @@ func (d *dynUpdater) execUpdateCert(hostname, filename string) bool {
 	// Remove this work around after the factoring of the ssl storage.
 	payloadStr := strings.ReplaceAll(string(payload), "\n\n", "\n")
 	cmd := []string{
-		fmt.Sprintf("set ssl cert %s <<\n%s", filename, payloadStr),
+		fmt.Sprintf("set ssl cert %s <<\n%s\n", filename, payloadStr),
 		fmt.Sprintf("commit ssl cert %s", filename),
 	}
 	msg, err := d.execCommand(d.metrics.HAProxySetSSLCertResponseTime, cmd)

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -886,6 +886,7 @@ INFO-V(2) need to reload due to config changes: [backends]
 			cmd: `
 set ssl cert /tmp/domain2.pem <<
 <content>
+
 commit ssl cert /tmp/domain2.pem
 `,
 			cmdOutput: []string{
@@ -938,6 +939,7 @@ INFO-V(2) need to reload due to config changes: [hosts]
 			cmd: `
 set ssl cert /tmp/domain1.pem <<
 <content>
+
 commit ssl cert /tmp/domain1.pem
 `,
 			cmdOutput: []string{
@@ -966,6 +968,7 @@ INFO certificate updated for domain1.local
 			cmd: `
 set ssl cert /tmp/domain1.pem <<
 <content>
+
 commit ssl cert /tmp/domain1.pem
 `,
 			cmdOutput: []string{

--- a/pkg/haproxy/socket/socket.go
+++ b/pkg/haproxy/socket/socket.go
@@ -102,6 +102,7 @@ func (s *sock) Send(observer func(duration time.Duration), command ...string) ([
 		start := time.Now()
 		response, err := s.send(cmd)
 		if err != nil {
+			s.close()
 			return msg, err
 		}
 		if observer != nil {


### PR DESCRIPTION
haproxy recognizes the end of an instruction after a line break. This however doesn't work with set ssl cert due to the multi line payload, so two line breaks should be sent. set ssl cert was broken after the socket refactor since two consecutive commands - set ssl cert and commit ssl cert - are sent in the same connection. This update adds two line breaks after the first command, and also improves a manual test with set/commit ssl cert.