### PR TITLE
Fix dynamic update of frontend crt

### DIFF
--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -230,7 +230,7 @@ func (h *Host) AddRedirect(path string, match MatchType, redirTo string) {
 
 type hostResolver struct {
 	useDefaultCrt *bool
-	crtHash       *string
+	crtFilename   *string
 }
 
 func (h *Host) addPath(path string, match MatchType, backend *Backend, redirTo string) {
@@ -247,7 +247,7 @@ func (h *Host) addPath(path string, match MatchType, backend *Backend, redirTo s
 		bpath := backend.AddBackendPath(link)
 		bpath.Host = &hostResolver{
 			useDefaultCrt: &h.TLS.UseDefaultCrt,
-			crtHash:       &h.TLS.TLSHash,
+			crtFilename:   &h.TLS.TLSFilename,
 		}
 	} else if redirTo == "" {
 		hback = HostBackend{ID: "_error404"}
@@ -293,7 +293,7 @@ func (h *Host) HasTLS() bool {
 }
 
 func (h *hostResolver) HasTLS() bool {
-	return *h.useDefaultCrt || *h.crtHash != ""
+	return *h.useDefaultCrt || *h.crtFilename != ""
 }
 
 // HasTLSAuth ...


### PR DESCRIPTION
Since v0.13 certificates can be dynamically updated, however a reload was always scheduled due to an indirect reference from the backend to the frontend's certificate hash. This hash is used to the backend know if the frontend has a TLS certificate. When the certificate is changed, the hash is changed as well, leading to a configuration change that triggers a reload. The reference was moved to the filename, which can also be used to check TLS enabled and cannot be changed.