### PR TITLE
Gateway API: when using v1alpha1, certificateRef.group now accepts "core"

### DIFF
--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -430,11 +430,15 @@ func (c *converter) applyCertRef(gwSource, routeSource *Source, hosts []*hatypes
 }
 
 func (c *converter) readCertRef(namespace string, certRef *gatewayv1alpha1.LocalObjectReference) (crtFile convtypes.CrtFile, err error) {
-	if certRef.Group != "" {
-		return crtFile, fmt.Errorf("unsupported Group '%s'", certRef.Group)
+	// In v1alpha1, the `group` cannot be left empty and is expected to be equal
+	// to "core" for the Secret kind. In v1alpha2, the `group` can be left empty
+	// and "core" is implied when the group is left empty. The discussion is
+	// available at https://github.com/kubernetes-sigs/gateway-api/pull/562.
+	if certRef.Group != "" && certRef.Group != "core" {
+		return crtFile, fmt.Errorf("unsupported Group '%s', supported groups are 'core' and ''", certRef.Group)
 	}
 	if certRef.Kind != "" && strings.ToLower(certRef.Kind) != "secret" {
-		return crtFile, fmt.Errorf("unsupported Kind '%s'", certRef.Kind)
+		return crtFile, fmt.Errorf("unsupported Kind '%s', the only supported kind is 'Secret'", certRef.Kind)
 	}
 	return c.cache.GetTLSSecretPath(namespace, certRef.Name, convtypes.TrackingTarget{Gateway: true})
 }

--- a/pkg/converters/gateway/gateway_test.go
+++ b/pkg/converters/gateway/gateway_test.go
@@ -767,7 +767,7 @@ paths:
 				c.createService1("default/echoserver", "8080", "172.17.0.11")
 				gw.Spec.Listeners[0].TLS.CertificateRef.Group = "acme.io"
 			},
-			expLogging: `WARN skipping certificate reference on Gateway 'default/web': unsupported Group 'acme.io'`,
+			expLogging: `WARN skipping certificate reference on Gateway 'default/web': unsupported Group 'acme.io', supported groups are 'core' and ''`,
 			expDefaultHost: `
 hostname: <default>
 paths:
@@ -791,7 +791,7 @@ paths:
 				c.createService1("default/echoserver", "8080", "172.17.0.11")
 				gw.Spec.Listeners[0].TLS.CertificateRef.Kind = "ConfigMap"
 			},
-			expLogging: `WARN skipping certificate reference on Gateway 'default/web': unsupported Kind 'ConfigMap'`,
+			expLogging: `WARN skipping certificate reference on Gateway 'default/web': unsupported Kind 'ConfigMap', the only supported kind is 'Secret'`,
 			expDefaultHost: `
 hostname: <default>
 paths:


### PR DESCRIPTION
The change was required due to the Gateway API v1alpha1 requiring a non-empty string in `certificateRef.group`. With v1alpha2, `""` is now a valid value as per https://github.com/kubernetes-sigs/gateway-api/pull/562.

Fixes #830.