### PR TITLE
Fix change notification of backend shard

### DIFF
--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -62,7 +62,7 @@ func (b *Backends) Shrink() {
 	changed := false
 	for name, del := range b.itemsDel {
 		if add, found := b.itemsAdd[name]; found {
-			if backendsMatch(add, del) {
+			if len(add.Endpoints) <= len(del.Endpoints) && backendsMatch(add, del) {
 				// Such changed backend, when removed from the tracking, need to
 				// be reincluded into the current state hashmap `items` and also
 				// into its shard hashmap when backend sharding is enabled.
@@ -82,10 +82,10 @@ func (b *Backends) Shrink() {
 	if changed {
 		b.changedShards = map[int]bool{}
 		for _, back := range b.itemsAdd {
-			b.changedShards[back.shard] = true
+			b.BackendChanged(back)
 		}
 		for _, back := range b.itemsDel {
-			b.changedShards[back.shard] = true
+			b.BackendChanged(back)
 		}
 	}
 }
@@ -136,6 +136,11 @@ func (b *Backends) Commit() {
 // Changed ...
 func (b *Backends) Changed() bool {
 	return len(b.itemsAdd) > 0 || len(b.itemsDel) > 0
+}
+
+// BackendChanged ...
+func (b *Backends) BackendChanged(backend *Backend) {
+	b.changedShards[backend.shard] = true
 }
 
 // ChangedShards ...
@@ -226,7 +231,7 @@ func (b *Backends) AcquireBackend(namespace, name, port string) *Backend {
 	if shardCount > 0 {
 		b.shards[backend.shard][backend.ID] = backend
 	}
-	b.changedShards[backend.shard] = true
+	b.BackendChanged(backend)
 	return backend
 }
 
@@ -267,7 +272,7 @@ func (b *Backends) RemoveAll(backendID []BackendID) {
 			if len(b.shards) > 0 {
 				delete(b.shards[item.shard], id)
 			}
-			b.changedShards[item.shard] = true
+			b.BackendChanged(item)
 			b.itemsDel[id] = item
 			if item == b.DefaultBackend {
 				b.DefaultBackend = nil


### PR DESCRIPTION
HAProxy backends can be sharded into smaller pieces, so unchanged backends don't need to be rebuilt, reducing the time spent regenerating the configuration file, specially on deployments with thousands of backends.

HAProxy Ingress controls the shards that should be rebuilt via the partial parsing implementation of ingress converter. Partial parsing tracks everything that need to be rebuilt, including backends. The internal HAProxy model controls the shards that should be rebuilt based on the backends tracked by the ingress converter. This means that changes made outside this controlled environment can be out of sync with configurations saved to disk, which is what HAProxy uses when it is restarted. This synchronization can be eventually fixed depending on new received events, sometimes this doesn't trigger HAProxy reloads, leading to the internal model in sync with disk, but not synced with the HAProxy instance.

This out of sync is happening when HAProxy needs to be reloaded: all backends are iterated and new empty endpoints are added if needed. If the backend that received new endpoints wasn't tracked due to api changes, it is considered as a read only backend and its configuration file won't be updated. However the internal model has this new endpoint and will eventually use it, leading to a "No such server" from HAProxy client socket, which the controller was ignoring up to v0.12.5.

This behavior is mitigated since v0.12.6 where unexpected responses triggers a reload with synced configuration files, and this update fixes a root cause of this behavior.

This should be merged as far as v0.11.

Related with #810 
Should fix the root cause of #807 
