### PR TITLE
docs: add modsec resource limits to controls V2 memory consumption

### DIFF
--- a/docs/content/en/docs/examples/modsecurity.md
+++ b/docs/content/en/docs/examples/modsecurity.md
@@ -33,6 +33,11 @@ $ kubectl create -f https://haproxy-ingress.github.io/resources/modsecurity-depl
 deployment.apps/modsecurity-spoa created
 ```
 
+{{% alert title="Note" %}}
+This deployment configures a small amount of requests and limits resources,
+remember to adjust them before moving to production.
+{{% /alert %}}
+
 
 Check if the agent is up and running:
 

--- a/docs/static/resources/modsecurity-deployment-auditlog-sidecar.yaml
+++ b/docs/static/resources/modsecurity-deployment-auditlog-sidecar.yaml
@@ -29,6 +29,21 @@ spec:
         - containerPort: 12345
           name: spop
           protocol: TCP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 150Mi
+          requests:
+            cpu: 200m
+            memory: 150Mi
+        livenessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          tcpSocket:
+            port: 12345
+          timeoutSeconds: 4
         volumeMounts:
         - name: varlog
           mountPath: /var/log

--- a/docs/static/resources/modsecurity-deployment.yaml
+++ b/docs/static/resources/modsecurity-deployment.yaml
@@ -26,3 +26,18 @@ spec:
         - containerPort: 12345
           name: spop
           protocol: TCP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 150Mi
+          requests:
+            cpu: 200m
+            memory: 150Mi
+        livenessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          tcpSocket:
+            port: 12345
+          timeoutSeconds: 4


### PR DESCRIPTION
From our deployment/daemonset of ModSecurity, we have been noticing the ModSecurity pods hogging memory after our performance tests finish. There is no garbage collection done and the memory consumed only increases over time.

We believe this is due to documented memory leak issues with V2 of ModSecurity.
Our kubernetes native solution to this is to provide memory allocations to the deployment, to force restarts of the pods instead of hogging memory on nodes.
We've ran performance tests against this change to the deployment and there is no performance regression.