### PR TITLE
Fix endpoint update of configmap based tcp services

### DIFF
--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -82,7 +82,7 @@ func (c *converters) Sync() {
 	//
 	// configmap converters
 	//
-	if needFullSync || changed.TCPConfigMapDataNew != nil {
+	if changed.TCPConfigMapDataCur != nil {
 		tcpSvcConverter := configmap.NewTCPServicesConverter(c.options, c.haproxy, changed)
 		tcpSvcConverter.Sync()
 		c.timer.Tick("parse_tcp_svc")


### PR DESCRIPTION
Legacy ConfigMap based TCP services has its own endpoint list that doesn't track partial parsing. The entry point was changed when Gateway API was added, it was was incorrectly configured to only run when a full sync is needed, or when the ConfigMap was changed, leading to new state not being reflected in the configuration. This update ensures that ConfigMap based TCP services is always parsed when something changes in the cluster.