### PR TITLE
Always deny requests if oauth is misconfigured

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -575,6 +575,9 @@ func (c *updater) buildBackendOAuth(d *backData) {
 		if oauth.Source == nil {
 			continue
 		}
+		// starting here the oauth backend should be configured or requests should be denied
+		// AlwaysDeny will be changed to false if the configuration succeed
+		path.OAuth.AlwaysDeny = true
 		if oauth.Value != "oauth2_proxy" {
 			c.logger.Warn("ignoring invalid oauth implementation '%s' on %v", oauth, oauth.Source)
 			continue
@@ -582,7 +585,7 @@ func (c *updater) buildBackendOAuth(d *backData) {
 		external := c.haproxy.Global().External
 		if external.IsExternal() && !external.HasLua {
 			c.logger.Warn("oauth2_proxy on %v needs Lua socket, install Lua libraries and enable 'external-has-lua' global config", oauth.Source)
-			return
+			continue
 		}
 		uriPrefix := "/oauth2"
 		headers := []string{"X-Auth-Request-Email:auth_response_email"}
@@ -612,6 +615,7 @@ func (c *updater) buildBackendOAuth(d *backData) {
 			h := strings.Split(header, ":")
 			headersMap[h[0]] = h[1]
 		}
+		path.OAuth.AlwaysDeny = false
 		path.OAuth.Impl = oauth.Value
 		path.OAuth.BackendName = backend.ID
 		path.OAuth.URIPrefix = uriPrefix

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -1238,7 +1238,7 @@ func TestOAuth(t *testing.T) {
 				},
 			},
 			oauthExp: map[string]hatypes.OAuthConfig{
-				"/": {},
+				"/": {AlwaysDeny: true},
 			},
 			logging: "WARN ignoring invalid oauth implementation 'none' on ingress 'default/ing1'",
 		},
@@ -1250,7 +1250,7 @@ func TestOAuth(t *testing.T) {
 				},
 			},
 			oauthExp: map[string]hatypes.OAuthConfig{
-				"/": {},
+				"/": {AlwaysDeny: true},
 			},
 			logging: "ERROR path '/oauth2' was not found on namespace 'default'",
 		},
@@ -1398,10 +1398,13 @@ func TestOAuth(t *testing.T) {
 			external: true,
 			backend:  "default:back:/oauth2",
 			oauthExp: map[string]hatypes.OAuthConfig{
-				"/":    {},
-				"/app": {},
+				"/":    {AlwaysDeny: true},
+				"/app": {AlwaysDeny: true},
 			},
-			logging: "WARN oauth2_proxy on ingress 'default/ing1' needs Lua socket, install Lua libraries and enable 'external-has-lua' global config",
+			logging: `
+WARN oauth2_proxy on ingress 'default/ing1' needs Lua socket, install Lua libraries and enable 'external-has-lua' global config
+WARN oauth2_proxy on ingress 'default/ing1' needs Lua socket, install Lua libraries and enable 'external-has-lua' global config
+`,
 		},
 		// 11
 		{

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -489,6 +489,18 @@ d1.local#/ path01`,
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
 				oauth := &b.FindBackendPath(h.FindPath("/app2").Link).OAuth
+				oauth.AlwaysDeny = true
+			},
+			path: []string{"/app1", "/app2"},
+			expected: `
+    # path01 = d1.local/app1
+    # path02 = d1.local/app2
+    http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
+    http-request deny if { var(txn.pathID) path02 }`,
+		},
+		{
+			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
+				oauth := &b.FindBackendPath(h.FindPath("/app2").Link).OAuth
 				oauth.Impl = "oauth2_proxy"
 				oauth.BackendName = "system_oauth_4180"
 				oauth.URIPrefix = "/oauth2"

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -622,6 +622,7 @@ type AccessConfig struct {
 
 // OAuthConfig ...
 type OAuthConfig struct {
+	AlwaysDeny  bool
 	Impl        string
 	BackendName string
 	URIPrefix   string

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -600,7 +600,10 @@ backend {{ $backend.ID }}
 {{- $oauthCfg := $backend.PathConfig "OAuth" }}
 {{- range $i, $oauth := $oauthCfg.Items }}
 {{- range $pathIDs := $oauthCfg.PathIDs $i }}
-{{- if eq $oauth.Impl "oauth2_proxy" }}
+{{- if $oauth.AlwaysDeny }}
+    http-request deny
+        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+{{- else if eq $oauth.Impl "oauth2_proxy" }}
     http-request set-header X-Real-IP %[src]
         {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
     http-request lua.auth-request {{ $oauth.BackendName }} {{ $oauth.URIPrefix }}/auth


### PR DESCRIPTION
An attempt to enable oauth should end up with a proper configuration, or the request should always fail in order to protect the backend service against misconfigurations. This change ensures that an attempt to configure oauth will lead to a proper configuration, or all requests will be denied.

This already works this way on v0.13, should be merged between v0.12 and v0.10.