### PR TITLE
Fix config parsing on misconfigured auth external

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -663,7 +663,7 @@ d1.local#/ path01`,
     # path01 = d1.local/app1
     # path02 = d1.local/app2
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request deny { var(txn.pathID) path01 }`,
+    http-request deny if { var(txn.pathID) path01 }`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -634,7 +634,7 @@ backend {{ $backend.ID }}
 {{- range $pathIDs := $authCfg.PathIDs $i }}
 {{- if $auth.AlwaysDeny }}
     http-request deny
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
 {{- else }}
 {{- if $auth.AuthBackendName }}
     http-request set-header X-Real-IP %[src]


### PR DESCRIPTION
A misconfigured auth external generates a http-request deny keyword, which would lead to a configuration parsing error if only some paths of the backend weren't properly configured.

Should be merged to v0.13.