### PR TITLE
Fix validation if ca is used with crt and key

### DIFF
--- a/pkg/common/net/ssl/ssl.go
+++ b/pkg/common/net/ssl/ssl.go
@@ -138,8 +138,13 @@ func AddOrUpdateCertAndKey(name string, cert, key, ca []byte) (*ingress.SSLCert,
 	if len(ca) > 0 {
 		bundle := x509.NewCertPool()
 		bundle.AppendCertsFromPEM(ca)
+
+		intBundle := x509.NewCertPool()
+		intBundle.AppendCertsFromPEM(cert)
+
 		opts := x509.VerifyOptions{
-			Roots: bundle,
+			Roots:         bundle,
+			Intermediates: intBundle,
 		}
 
 		_, err := pemCert.Verify(opts)


### PR DESCRIPTION
An undocumented but inherited behavior from the so called ingress controller common code base allows to use a ca.crt key along with crt and key. However a crt validation was failing due to the missing intermediate crts in the validation. There is no behavioral change when using crt and key without a ca.