### PR TITLE
Fix ingress update to an existing backend

### DIFF
--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -368,7 +368,7 @@ func (c *converter) syncPartial() {
 //
 // All state change works removing hosts and backs objects in an old state and
 // resyncing ingress objects to recreate hosts and backs in a new state. This
-// works very well, except with new ingress objects that references hosts or
+// works very well, except with ingress objects that starts to reference hosts or
 // backs that already exist - all the tracking starts from the ingress parsing.
 //
 // trackAddedIngress does the same tracking the sync ingress already do, but
@@ -377,7 +377,7 @@ func (c *converter) syncPartial() {
 // here and removed before parse the added ingress which will readd such hosts
 // and backs
 func (c *converter) trackAddedIngress() {
-	for _, ing := range c.changed.IngressesAdd {
+	for _, ing := range append(c.changed.IngressesAdd, c.changed.IngressesUpd...) {
 		name := ing.Namespace + "/" + ing.Name
 		if ing.Spec.DefaultBackend != nil {
 			backend := c.findBackend(ing.Namespace, ing.Spec.DefaultBackend)


### PR DESCRIPTION
Resource tracking is used to identify resources that should be parsed due to a configuration change. Resources directly or indirectly related with what was changed is removed and recreated to ensure that old behavior doesn't survive in the new state. A new ingress is already tracked to ensure that the referenced hosts and backends are removed, but this wasn't happening with existent ingress that reference a new backend that was already referenced elsewhere - such hosts and backends was being properly tracked for future updates, but would be missing some new configurations provided by the ingress that started to reference them.