### PR TITLE
docs: update api group of rbac config

### DIFF
--- a/docs/haproxy-ingress.yaml
+++ b/docs/haproxy-ingress.yaml
@@ -41,6 +41,7 @@ rules:
       - list
       - watch
   - apiGroups:
+      - extensions
       - networking.k8s.io
     resources:
       - ingressclasses
@@ -57,6 +58,7 @@ rules:
       - create
       - patch
   - apiGroups:
+      - extensions
       - networking.k8s.io
     resources:
       - ingresses/status

--- a/docs/haproxy-ingress.yaml
+++ b/docs/haproxy-ingress.yaml
@@ -41,9 +41,9 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
-      - "networking.k8s.io"
+      - networking.k8s.io
     resources:
+      - ingressclasses
       - ingresses
     verbs:
       - get
@@ -57,8 +57,7 @@ rules:
       - create
       - patch
   - apiGroups:
-      - "extensions"
-      - "networking.k8s.io"
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:

--- a/examples/rbac/ingress-controller-rbac.yml
+++ b/examples/rbac/ingress-controller-rbac.yml
@@ -41,6 +41,7 @@ rules:
       - list
       - watch
   - apiGroups:
+      - extensions
       - networking.k8s.io
     resources:
       - ingressclasses
@@ -57,6 +58,7 @@ rules:
       - create
       - patch
   - apiGroups:
+      - extensions
       - networking.k8s.io
     resources:
       - ingresses/status

--- a/examples/rbac/ingress-controller-rbac.yml
+++ b/examples/rbac/ingress-controller-rbac.yml
@@ -41,8 +41,9 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
+      - networking.k8s.io
     resources:
+      - ingressclasses
       - ingresses
     verbs:
       - get
@@ -56,7 +57,7 @@ rules:
       - create
       - patch
   - apiGroups:
-      - "extensions"
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:


### PR DESCRIPTION
Due to the deprecation of beta Ingress APIs, they should also been removed/modified in the way supported in Kubernetes v1.22+. Also, `ingressclasses` has been missing since some time haproxy-ingress started to integrate with them.
https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/

Thanks in advance!