### PR TITLE
Refactor tracker to an abstract implementation

### DIFF
--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -1052,7 +1052,7 @@ func (c *k8scache) SwapChangedObjects() *convtypes.ChangedObjects {
 		addChanges(convtypes.ResourceBackendPolicy, eventAdd, bp.Namespace, bp.Name)
 	}
 	for _, ep := range ch.EndpointsNew {
-		addChanges(convtypes.ResourceService, eventUpdate, ep.Namespace, ep.Name)
+		addChanges(convtypes.ResourceEndpoints, eventUpdate, ep.Namespace, ep.Name)
 	}
 	for _, svc := range ch.ServicesDel {
 		addChanges(convtypes.ResourceService, eventDel, svc.Namespace, svc.Name)

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -947,129 +947,145 @@ func (c *k8scache) SwapChangedObjects() *convtypes.ChangedObjects {
 	c.stateMutex.Lock()
 	defer c.stateMutex.Unlock()
 	//
+	var changedObj []string
+	changedLinks := convtypes.TrackingLinks{}
+	type event string
+	var eventDel event = "del"
+	var eventUpdate event = "update"
+	var eventAdd event = "add"
+	addChanges := func(ctx convtypes.ResourceType, ev event, ns, n string) {
+		var fullname string
+		if ns != "" {
+			fullname = ns + "/" + n
+		} else {
+			fullname = n
+		}
+		changedObj = append(changedObj, fmt.Sprintf("%s/%s:%s", ev, ctx, fullname))
+		changedLinks[ctx] = append(changedLinks[ctx], fullname)
+	}
 	ch := c.changed
-	var obj []string
 	if ch.GlobalConfigMapDataNew != nil && !reflect.DeepEqual(ch.GlobalConfigMapDataCur, ch.GlobalConfigMapDataNew) {
-		obj = append(obj, "update/global")
+		changedObj = append(changedObj, "update/global")
 	}
 	if ch.TCPConfigMapDataNew != nil && !reflect.DeepEqual(ch.TCPConfigMapDataCur, ch.TCPConfigMapDataNew) {
-		obj = append(obj, "update/tcp-services")
+		changedObj = append(changedObj, "update/tcp-services")
 	}
 	for _, ing := range ch.IngressesDel {
-		obj = append(obj, "del/ingress:"+ing.Namespace+"/"+ing.Name)
+		addChanges(convtypes.ResourceIngress, eventDel, ing.Namespace, ing.Name)
 	}
 	for _, ing := range ch.IngressesUpd {
-		obj = append(obj, "update/ingress:"+ing.Namespace+"/"+ing.Name)
+		addChanges(convtypes.ResourceIngress, eventUpdate, ing.Namespace, ing.Name)
 	}
 	for _, ing := range ch.IngressesAdd {
-		obj = append(obj, "add/ingress:"+ing.Namespace+"/"+ing.Name)
+		addChanges(convtypes.ResourceIngress, eventAdd, ing.Namespace, ing.Name)
 	}
 	for _, cls := range ch.IngressClassesDel {
-		obj = append(obj, "del/ingressClass:"+cls.Name)
+		addChanges(convtypes.ResourceIngressClass, eventDel, "", cls.Name)
 	}
 	for _, cls := range ch.IngressClassesUpd {
-		obj = append(obj, "update/ingressClass:"+cls.Name)
+		addChanges(convtypes.ResourceIngressClass, eventUpdate, "", cls.Name)
 	}
 	for _, cls := range ch.IngressClassesAdd {
-		obj = append(obj, "add/ingressClass:"+cls.Name)
+		addChanges(convtypes.ResourceIngressClass, eventAdd, "", cls.Name)
 	}
 	for _, gw := range ch.GatewaysDel {
-		obj = append(obj, "del/gateway:"+gw.Namespace+"/"+gw.Name)
+		addChanges(convtypes.ResourceGateway, eventDel, gw.Namespace, gw.Name)
 	}
 	for _, gw := range ch.GatewaysUpd {
-		obj = append(obj, "update/gateway:"+gw.Namespace+"/"+gw.Name)
+		addChanges(convtypes.ResourceGateway, eventUpdate, gw.Namespace, gw.Name)
 	}
 	for _, gw := range ch.GatewaysAdd {
-		obj = append(obj, "add/gateway:"+gw.Namespace+"/"+gw.Name)
+		addChanges(convtypes.ResourceGateway, eventAdd, gw.Namespace, gw.Name)
 	}
 	for _, cls := range ch.GatewayClassesDel {
-		obj = append(obj, "del/gatewayClass:"+cls.Name)
+		addChanges(convtypes.ResourceGatewayClass, eventDel, "", cls.Name)
 	}
 	for _, cls := range ch.GatewayClassesUpd {
-		obj = append(obj, "update/gatewayClass:"+cls.Name)
+		addChanges(convtypes.ResourceGatewayClass, eventUpdate, "", cls.Name)
 	}
 	for _, cls := range ch.GatewayClassesAdd {
-		obj = append(obj, "add/gatewayClass:"+cls.Name)
+		addChanges(convtypes.ResourceGatewayClass, eventAdd, "", cls.Name)
 	}
 	for _, hr := range ch.HTTPRoutesDel {
-		obj = append(obj, "del/httpRoute:"+hr.Namespace+"/"+hr.Name)
+		addChanges(convtypes.ResourceHTTPRoute, eventDel, hr.Namespace, hr.Name)
 	}
 	for _, hr := range ch.HTTPRoutesUpd {
-		obj = append(obj, "update/httpRoute:"+hr.Namespace+"/"+hr.Name)
+		addChanges(convtypes.ResourceHTTPRoute, eventUpdate, hr.Namespace, hr.Name)
 	}
 	for _, hr := range ch.HTTPRoutesAdd {
-		obj = append(obj, "add/httpRoute:"+hr.Namespace+"/"+hr.Name)
+		addChanges(convtypes.ResourceHTTPRoute, eventAdd, hr.Namespace, hr.Name)
 	}
 	for _, tr := range ch.TLSRoutesDel {
-		obj = append(obj, "del/tlsRoute:"+tr.Namespace+"/"+tr.Name)
+		addChanges(convtypes.ResourceTLSRoute, eventDel, tr.Namespace, tr.Name)
 	}
 	for _, tr := range ch.TLSRoutesUpd {
-		obj = append(obj, "update/tlsRoute:"+tr.Namespace+"/"+tr.Name)
+		addChanges(convtypes.ResourceTLSRoute, eventUpdate, tr.Namespace, tr.Name)
 	}
 	for _, tr := range ch.TLSRoutesAdd {
-		obj = append(obj, "add/tlsRoute:"+tr.Namespace+"/"+tr.Name)
+		addChanges(convtypes.ResourceTLSRoute, eventAdd, tr.Namespace, tr.Name)
 	}
 	for _, tr := range ch.TCPRoutesDel {
-		obj = append(obj, "del/tcpRoute:"+tr.Namespace+"/"+tr.Name)
+		addChanges(convtypes.ResourceTCPRoute, eventDel, tr.Namespace, tr.Name)
 	}
 	for _, tr := range ch.TCPRoutesUpd {
-		obj = append(obj, "update/tcpRoute:"+tr.Namespace+"/"+tr.Name)
+		addChanges(convtypes.ResourceTCPRoute, eventUpdate, tr.Namespace, tr.Name)
 	}
 	for _, tr := range ch.TCPRoutesAdd {
-		obj = append(obj, "add/tcpRoute:"+tr.Namespace+"/"+tr.Name)
+		addChanges(convtypes.ResourceTCPRoute, eventAdd, tr.Namespace, tr.Name)
 	}
 	for _, ur := range ch.UDPRoutesDel {
-		obj = append(obj, "del/udpRoute:"+ur.Namespace+"/"+ur.Name)
+		addChanges(convtypes.ResourceUDPRoute, eventDel, ur.Namespace, ur.Name)
 	}
 	for _, ur := range ch.UDPRoutesUpd {
-		obj = append(obj, "update/udpRoute:"+ur.Namespace+"/"+ur.Name)
+		addChanges(convtypes.ResourceUDPRoute, eventUpdate, ur.Namespace, ur.Name)
 	}
 	for _, ur := range ch.UDPRoutesAdd {
-		obj = append(obj, "add/udpRoute:"+ur.Namespace+"/"+ur.Name)
+		addChanges(convtypes.ResourceUDPRoute, eventAdd, ur.Namespace, ur.Name)
 	}
 	for _, bp := range ch.BackendPoliciesDel {
-		obj = append(obj, "del/backendPolicy:"+bp.Namespace+"/"+bp.Name)
+		addChanges(convtypes.ResourceBackendPolicy, eventDel, bp.Namespace, bp.Name)
 	}
 	for _, bp := range ch.BackendPoliciesUpd {
-		obj = append(obj, "update/backendPolicy:"+bp.Namespace+"/"+bp.Name)
+		addChanges(convtypes.ResourceBackendPolicy, eventUpdate, bp.Namespace, bp.Name)
 	}
 	for _, bp := range ch.BackendPoliciesAdd {
-		obj = append(obj, "add/backendPolicy:"+bp.Namespace+"/"+bp.Name)
+		addChanges(convtypes.ResourceBackendPolicy, eventAdd, bp.Namespace, bp.Name)
 	}
 	for _, ep := range ch.EndpointsNew {
-		obj = append(obj, "update/endpoint:"+ep.Namespace+"/"+ep.Name)
+		addChanges(convtypes.ResourceService, eventUpdate, ep.Namespace, ep.Name)
 	}
 	for _, svc := range ch.ServicesDel {
-		obj = append(obj, "del/service:"+svc.Namespace+"/"+svc.Name)
+		addChanges(convtypes.ResourceService, eventDel, svc.Namespace, svc.Name)
 	}
 	for _, svc := range ch.ServicesUpd {
-		obj = append(obj, "update/service:"+svc.Namespace+"/"+svc.Name)
+		addChanges(convtypes.ResourceService, eventUpdate, svc.Namespace, svc.Name)
 	}
 	for _, svc := range ch.ServicesAdd {
-		obj = append(obj, "add/service:"+svc.Namespace+"/"+svc.Name)
+		addChanges(convtypes.ResourceService, eventAdd, svc.Namespace, svc.Name)
 	}
 	for _, secret := range ch.SecretsDel {
-		obj = append(obj, "del/secret:"+secret.Namespace+"/"+secret.Name)
+		addChanges(convtypes.ResourceSecret, eventDel, secret.Namespace, secret.Name)
 	}
 	for _, secret := range ch.SecretsUpd {
-		obj = append(obj, "update/secret:"+secret.Namespace+"/"+secret.Name)
+		addChanges(convtypes.ResourceSecret, eventUpdate, secret.Namespace, secret.Name)
 	}
 	for _, secret := range ch.SecretsAdd {
-		obj = append(obj, "add/secret:"+secret.Namespace+"/"+secret.Name)
+		addChanges(convtypes.ResourceSecret, eventAdd, secret.Namespace, secret.Name)
 	}
 	for _, cm := range ch.ConfigMapsDel {
-		obj = append(obj, "del/configmap:"+cm.Namespace+"/"+cm.Name)
+		addChanges(convtypes.ResourceConfigMap, eventDel, cm.Namespace, cm.Name)
 	}
 	for _, cm := range ch.ConfigMapsUpd {
-		obj = append(obj, "update/configmap:"+cm.Namespace+"/"+cm.Name)
+		addChanges(convtypes.ResourceConfigMap, eventUpdate, cm.Namespace, cm.Name)
 	}
 	for _, cm := range ch.ConfigMapsAdd {
-		obj = append(obj, "add/configmap:"+cm.Namespace+"/"+cm.Name)
+		addChanges(convtypes.ResourceConfigMap, eventAdd, cm.Namespace, cm.Name)
 	}
 	for _, pod := range ch.PodsNew {
-		obj = append(obj, "update/pod:"+pod.Namespace+"/"+pod.Name)
+		addChanges(convtypes.ResourcePod, eventUpdate, pod.Namespace, pod.Name)
 	}
-	ch.Objects = obj
+	ch.Objects = changedObj
+	ch.Links = changedLinks
 	//
 	// leave ch with the current state, cleanup c.changed to receive new events
 	c.changed = convtypes.ChangedObjects{

--- a/pkg/converters/configmap/tcpservices.go
+++ b/pkg/converters/configmap/tcpservices.go
@@ -97,7 +97,7 @@ func (c *tcpSvcConverter) Sync() {
 		}
 		var crtfile convtypes.CrtFile
 		if svc.secretTLS != "" {
-			crtfile, err = c.cache.GetTLSSecretPath("", svc.secretTLS, convtypes.TrackingTarget{})
+			crtfile, err = c.cache.GetTLSSecretPath("", svc.secretTLS, nil)
 			if err != nil {
 				c.logger.Warn("skipping TCP service on public port %d: %v", publicport, err)
 				continue
@@ -105,7 +105,7 @@ func (c *tcpSvcConverter) Sync() {
 		}
 		var cafile, crlfile convtypes.File
 		if svc.secretCA != "" {
-			cafile, crlfile, err = c.cache.GetCASecretPath("", svc.secretCA, convtypes.TrackingTarget{})
+			cafile, crlfile, err = c.cache.GetCASecretPath("", svc.secretCA, nil)
 			if err != nil {
 				c.logger.Warn("skipping TCP service on public port %d: %v", publicport, err)
 				continue

--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -54,6 +54,7 @@ func (c *converters) Sync() {
 		gatewayConverter.NeedFullSync() ||
 		ingressConverter.NeedFullSync()
 	if needFullSync {
+		c.options.Tracker.ClearLinks()
 		c.haproxy.Clear()
 	}
 	l := len(changed.Objects)

--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -66,8 +66,9 @@ func (c *converter) NeedFullSync() bool {
 	// changes. Check if other changed resources
 	// impact anyone related with the Gateway API.
 	links := c.tracker.QueryLinks(convtypes.TrackingLinks{
-		convtypes.ResourceSecret:  c.changed.Links[convtypes.ResourceSecret],
-		convtypes.ResourceService: c.changed.Links[convtypes.ResourceService],
+		convtypes.ResourceSecret:    c.changed.Links[convtypes.ResourceSecret],
+		convtypes.ResourceService:   c.changed.Links[convtypes.ResourceService],
+		convtypes.ResourceEndpoints: c.changed.Links[convtypes.ResourceEndpoints],
 	}, false)
 	_, changed := links[convtypes.ResourceGateway]
 	return changed
@@ -198,7 +199,10 @@ func (c *converter) createBackend(source *Source, index string, forwardTo []gate
 			continue
 		}
 		svcName := source.namespace + "/" + *fw.ServiceName
-		c.tracker.TrackNames(convtypes.ResourceService, svcName, convtypes.ResourceGateway, "gw")
+		c.tracker.TrackRefName([]convtypes.TrackingRef{
+			{Context: convtypes.ResourceService, UniqueName: svcName},
+			{Context: convtypes.ResourceEndpoints, UniqueName: svcName},
+		}, convtypes.ResourceGateway, "gw")
 		svc, err := c.cache.GetService("", svcName)
 		if err != nil {
 			c.logger.Warn("skipping service '%s' on %s: %v", *fw.ServiceName, source, err)

--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -65,48 +65,11 @@ func (c *converter) NeedFullSync() bool {
 	// full sync from the Gateway API resource
 	// changes. Check if other changed resources
 	// impact anyone related with the Gateway API.
-	//
-	// TODO reused from ingress, move tracking code to a common place.
-	secret2names := func(secrets []*api.Secret) []string {
-		secretList := make([]string, len(secrets))
-		for i, secret := range secrets {
-			secretList[i] = secret.Namespace + "/" + secret.Name
-		}
-		return secretList
-	}
-	svc2names := func(services []*api.Service) []string {
-		serviceList := make([]string, len(services))
-		for i, service := range services {
-			serviceList[i] = service.Namespace + "/" + service.Name
-		}
-		return serviceList
-	}
-	ep2names := func(endpoints []*api.Endpoints) []string {
-		epList := make([]string, len(endpoints))
-		for i, ep := range endpoints {
-			epList[i] = ep.Namespace + "/" + ep.Name
-		}
-		return epList
-	}
-	delSecretNames := secret2names(c.changed.SecretsDel)
-	updSecretNames := secret2names(c.changed.SecretsUpd)
-	addSecretNames := secret2names(c.changed.SecretsAdd)
-	oldSecretNames := append(delSecretNames, updSecretNames...)
-	delSvcNames := svc2names(c.changed.ServicesDel)
-	updSvcNames := svc2names(c.changed.ServicesUpd)
-	addSvcNames := svc2names(c.changed.ServicesAdd)
-	oldSvcNames := append(delSvcNames, updSvcNames...)
-	updEndpointsNames := ep2names(c.changed.EndpointsNew)
-	oldSvcNames = append(oldSvcNames, updEndpointsNames...)
-	links := c.tracker.QueryLinks(map[convtypes.ResourceType][]string{
-		convtypes.ResourceSecret:  append(oldSecretNames, addSecretNames...),
-		convtypes.ResourceService: append(oldSvcNames, addSvcNames...),
+	links := c.tracker.QueryLinks(convtypes.TrackingLinks{
+		convtypes.ResourceSecret:  c.changed.Links[convtypes.ResourceSecret],
+		convtypes.ResourceService: c.changed.Links[convtypes.ResourceService],
 	}, false)
 	_, changed := links[convtypes.ResourceGateway]
-	if changed {
-		// only remove old links if they will be recreated
-		c.tracker.ClearLinks()
-	}
 	return changed
 }
 

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -298,7 +298,7 @@ func (c *CacheMock) SwapChangedObjects() *convtypes.ChangedObjects {
 		addChanges(convtypes.ResourceSecret, secret.Namespace, secret.Name)
 	}
 	for _, ep := range changed.EndpointsNew {
-		addChanges(convtypes.ResourceService, ep.Namespace, ep.Name)
+		addChanges(convtypes.ResourceEndpoints, ep.Namespace, ep.Name)
 	}
 	changed.Links = changedLinks
 	// update c.IngList based on notifications

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -174,7 +174,7 @@ func (c *CacheMock) GetConfigMap(configMapName string) (*api.ConfigMap, error) {
 }
 
 // GetTerminatingPods ...
-func (c *CacheMock) GetTerminatingPods(service *api.Service, track convtypes.TrackingTarget) ([]*api.Pod, error) {
+func (c *CacheMock) GetTerminatingPods(service *api.Service, track []convtypes.TrackingRef) ([]*api.Pod, error) {
 	serviceName := service.Namespace + "/" + service.Name
 	if pods, found := c.TermPodList[serviceName]; found {
 		return pods, nil
@@ -196,10 +196,10 @@ func (c *CacheMock) GetPodNamespace() string {
 }
 
 // GetTLSSecretPath ...
-func (c *CacheMock) GetTLSSecretPath(defaultNamespace, secretName string, track convtypes.TrackingTarget) (convtypes.CrtFile, error) {
+func (c *CacheMock) GetTLSSecretPath(defaultNamespace, secretName string, track []convtypes.TrackingRef) (convtypes.CrtFile, error) {
 	fullname := c.buildResourceName(defaultNamespace, secretName)
+	c.tracker.TrackRefName(track, convtypes.ResourceSecret, fullname)
 	if path, found := c.SecretTLSPath[fullname]; found {
-		c.tracker.Track(false, track, convtypes.SecretType, fullname)
 		return convtypes.CrtFile{
 			Filename:   path,
 			SHA1Hash:   fmt.Sprintf("%x", sha1.Sum([]byte(path))),
@@ -207,20 +207,19 @@ func (c *CacheMock) GetTLSSecretPath(defaultNamespace, secretName string, track 
 			NotAfter:   time.Now().AddDate(0, 0, 30),
 		}, nil
 	}
-	c.tracker.Track(true, track, convtypes.SecretType, fullname)
 	return convtypes.CrtFile{}, fmt.Errorf("secret not found: '%s'", fullname)
 }
 
 // GetCASecretPath ...
-func (c *CacheMock) GetCASecretPath(defaultNamespace, secretName string, track convtypes.TrackingTarget) (ca, crl convtypes.File, err error) {
+func (c *CacheMock) GetCASecretPath(defaultNamespace, secretName string, track []convtypes.TrackingRef) (ca, crl convtypes.File, err error) {
 	fullname := c.buildResourceName(defaultNamespace, secretName)
+	c.tracker.TrackRefName(track, convtypes.ResourceSecret, fullname)
 	if path, found := c.SecretCAPath[fullname]; found {
 		ca = convtypes.File{
 			Filename: path,
 			SHA1Hash: fmt.Sprintf("%x", sha1.Sum([]byte(path))),
 		}
 	} else {
-		c.tracker.Track(true, track, convtypes.SecretType, fullname)
 		return ca, crl, fmt.Errorf("secret not found: '%s'", fullname)
 	}
 	if path, found := c.SecretCRLPath[fullname]; found {
@@ -229,7 +228,6 @@ func (c *CacheMock) GetCASecretPath(defaultNamespace, secretName string, track c
 			SHA1Hash: fmt.Sprintf("%x", sha1.Sum([]byte(path))),
 		}
 	}
-	c.tracker.Track(false, track, convtypes.SecretType, fullname)
 	return ca, crl, nil
 }
 
@@ -246,18 +244,16 @@ func (c *CacheMock) GetDHSecretPath(defaultNamespace, secretName string) (convty
 }
 
 // GetPasswdSecretContent ...
-func (c *CacheMock) GetPasswdSecretContent(defaultNamespace, secretName string, track convtypes.TrackingTarget) ([]byte, error) {
+func (c *CacheMock) GetPasswdSecretContent(defaultNamespace, secretName string, track []convtypes.TrackingRef) ([]byte, error) {
 	fullname := c.buildResourceName(defaultNamespace, secretName)
+	c.tracker.TrackRefName(track, convtypes.ResourceSecret, fullname)
 	if content, found := c.SecretContent[fullname]; found {
 		keyName := "auth"
 		if val, found := content[keyName]; found {
-			c.tracker.Track(false, track, convtypes.SecretType, fullname)
 			return val, nil
 		}
-		c.tracker.Track(true, track, convtypes.SecretType, fullname)
 		return nil, fmt.Errorf("secret '%s' does not have file/key '%s'", fullname, keyName)
 	}
-	c.tracker.Track(true, track, convtypes.SecretType, fullname)
 	return nil, fmt.Errorf("secret not found: '%s'", fullname)
 }
 

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -264,6 +264,43 @@ func (c *CacheMock) SwapChangedObjects() *convtypes.ChangedObjects {
 		GlobalConfigMapDataCur: changed.GlobalConfigMapDataNew,
 		TCPConfigMapDataCur:    changed.TCPConfigMapDataNew,
 	}
+	// update changed.Links based on notifications
+	changedLinks := convtypes.TrackingLinks{}
+	addChanges := func(ctx convtypes.ResourceType, ns, n string) {
+		fullname := ns + "/" + n
+		changedLinks[ctx] = append(changedLinks[ctx], fullname)
+	}
+	for _, ing := range changed.IngressesDel {
+		addChanges(convtypes.ResourceIngress, ing.Namespace, ing.Name)
+	}
+	for _, ing := range changed.IngressesUpd {
+		addChanges(convtypes.ResourceIngress, ing.Namespace, ing.Name)
+	}
+	for _, ing := range changed.IngressesAdd {
+		addChanges(convtypes.ResourceIngress, ing.Namespace, ing.Name)
+	}
+	for _, svc := range changed.ServicesDel {
+		addChanges(convtypes.ResourceService, svc.Namespace, svc.Name)
+	}
+	for _, svc := range changed.ServicesUpd {
+		addChanges(convtypes.ResourceService, svc.Namespace, svc.Name)
+	}
+	for _, svc := range changed.ServicesAdd {
+		addChanges(convtypes.ResourceService, svc.Namespace, svc.Name)
+	}
+	for _, secret := range changed.SecretsDel {
+		addChanges(convtypes.ResourceSecret, secret.Namespace, secret.Name)
+	}
+	for _, secret := range changed.SecretsUpd {
+		addChanges(convtypes.ResourceSecret, secret.Namespace, secret.Name)
+	}
+	for _, secret := range changed.SecretsAdd {
+		addChanges(convtypes.ResourceSecret, secret.Namespace, secret.Name)
+	}
+	for _, ep := range changed.EndpointsNew {
+		addChanges(convtypes.ResourceService, ep.Namespace, ep.Name)
+	}
+	changed.Links = changedLinks
 	// update c.IngList based on notifications
 	for i, ing := range c.IngList {
 		for _, ingUpd := range changed.IngressesUpd {

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -254,9 +254,9 @@ func (c *updater) buildBackendAuthHTTP(d *backData) {
 			userb, err := c.cache.GetPasswdSecretContent(
 				authSecret.Source.Namespace,
 				authSecret.Value,
-				convtypes.TrackingTarget{
-					Backend:  d.backend.BackendID(),
-					Userlist: listName,
+				[]convtypes.TrackingRef{
+					{Context: convtypes.ResourceHABackend, UniqueName: d.backend.ID},
+					{Context: convtypes.ResourceHAUserlist, UniqueName: listName},
 				},
 			)
 			if err != nil {
@@ -277,7 +277,7 @@ func (c *updater) buildBackendAuthHTTP(d *backData) {
 		// Backends need always to be tracked because only hosts and backends tracking can properly start a partial update
 		// Tracker will take care of deduplicate trackings
 		// TODO build a stronger tracking
-		c.tracker.TrackBackend(convtypes.SecretType, secretName, d.backend.BackendID())
+		c.tracker.TrackNames(convtypes.ResourceSecret, secretName, convtypes.ResourceHABackend, d.backend.ID)
 		realm := "localhost" // HAProxy's backend name would be used if missing
 		authRealm := config.Get(ingtypes.BackAuthRealm)
 		if authRealm == nil || authRealm.Source == nil {
@@ -771,7 +771,7 @@ func (c *updater) buildBackendProtocol(d *backData) {
 		if crtFile, err := c.cache.GetTLSSecretPath(
 			crt.Source.Namespace,
 			crt.Value,
-			convtypes.TrackingTarget{Backend: d.backend.BackendID()},
+			[]convtypes.TrackingRef{{Context: convtypes.ResourceHABackend, UniqueName: d.backend.ID}},
 		); err == nil {
 			d.backend.Server.CrtFilename = crtFile.Filename
 			d.backend.Server.CrtHash = crtFile.SHA1Hash
@@ -804,7 +804,7 @@ func (c *updater) buildBackendProtocol(d *backData) {
 		if caFile, crlFile, err := c.cache.GetCASecretPath(
 			ca.Source.Namespace,
 			ca.Value,
-			convtypes.TrackingTarget{Backend: d.backend.BackendID()},
+			[]convtypes.TrackingRef{{Context: convtypes.ResourceHABackend, UniqueName: d.backend.ID}},
 		); err == nil {
 			d.backend.Server.CAFilename = caFile.Filename
 			d.backend.Server.CAHash = caFile.SHA1Hash

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
-	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
 )
@@ -236,7 +235,7 @@ func (c *updater) buildGlobalStats(d *globalData) {
 	d.global.Stats.BindIP = d.mapper.Get(ingtypes.GlobalBindIPAddrStats).Value
 	d.global.Stats.Port = d.mapper.Get(ingtypes.GlobalStatsPort).Int()
 	if tlsSecret := d.mapper.Get(ingtypes.GlobalStatsSSLCert).Value; tlsSecret != "" {
-		if tls, err := c.cache.GetTLSSecretPath("", tlsSecret, convtypes.TrackingTarget{}); err == nil {
+		if tls, err := c.cache.GetTLSSecretPath("", tlsSecret, nil); err == nil {
 			d.global.Stats.TLSFilename = tls.Filename
 			d.global.Stats.TLSHash = tls.SHA1Hash
 		} else {

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -34,7 +34,7 @@ func (c *updater) buildHostAuthTLS(d *hostData) {
 	if cafile, crlfile, err := c.cache.GetCASecretPath(
 		tlsSecret.Source.Namespace,
 		tlsSecret.Value,
-		convtypes.TrackingTarget{Hostname: d.host.Hostname},
+		[]convtypes.TrackingRef{{Context: convtypes.ResourceHAHostname, UniqueName: d.host.Hostname}},
 	); err == nil {
 		tls.CAFilename = cafile.Filename
 		tls.CAHash = cafile.SHA1Hash

--- a/pkg/converters/ingress/annotations/mapper.go
+++ b/pkg/converters/ingress/annotations/mapper.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
+	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/types"
 )
@@ -53,7 +54,7 @@ type PathConfig struct {
 type Source struct {
 	Namespace string
 	Name      string
-	Type      string
+	Type      convtypes.ResourceType
 }
 
 // ConfigValue ...
@@ -229,5 +230,5 @@ func (m *PathConfig) String() string {
 
 // String ...
 func (s *Source) String() string {
-	return s.Type + " '" + s.FullName() + "'"
+	return fmt.Sprintf("%s '%s'", s.Type, s.FullName())
 }

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -749,7 +749,10 @@ func (c *converter) addBackendWithClass(source *annotations.Source, pathLink hat
 	// TODO build a stronger tracking
 	svc, err := c.cache.GetService(source.Namespace, fullSvcName)
 	hostname := pathLink.Hostname()
-	c.tracker.TrackNames(convtypes.ResourceService, fullSvcName, convtypes.ResourceHAHostname, hostname)
+	c.tracker.TrackRefName([]convtypes.TrackingRef{
+		{Context: convtypes.ResourceService, UniqueName: fullSvcName},
+		{Context: convtypes.ResourceEndpoints, UniqueName: fullSvcName},
+	}, convtypes.ResourceHAHostname, hostname)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -698,7 +698,7 @@ func TestSyncIngressClass(t *testing.T) {
 				Parameters: test.parameters,
 			},
 		}
-		_ = conv.readParameters(&ingClass, "echo.example.com")
+		_ = conv.readParameters(&ingClass)
 		c.logger.CompareLogging(test.logging)
 		c.teardown()
 	}

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -60,7 +60,7 @@ func TestSyncSvcNotFound(t *testing.T) {
 	c.compareConfigBack(defaultBackendConfig)
 
 	c.logger.CompareLogging(`
-WARN skipping backend config of ingress 'default/echo': service not found: 'default/notfound'`)
+WARN skipping backend config of Ingress 'default/echo': service not found: 'default/notfound'`)
 }
 
 func TestSyncDefaultSvcNotFound(t *testing.T) {
@@ -107,7 +107,7 @@ func TestSyncSvcPortNotFound(t *testing.T) {
 `)
 
 	c.logger.CompareLogging(`
-WARN skipping backend config of ingress 'default/echo': port not found: 'non'
+WARN skipping backend config of Ingress 'default/echo': port not found: 'non'
 `)
 }
 
@@ -152,7 +152,7 @@ func TestSyncSvcNamedPort(t *testing.T) {
 `)
 
 	c.logger.CompareLogging(`
-WARN skipping backend config of ingress 'default/echo4': port not found: '9000'
+WARN skipping backend config of Ingress 'default/echo4': port not found: '9000'
 `)
 }
 
@@ -462,7 +462,7 @@ func TestSyncRedeclarePath(t *testing.T) {
     port: 8080` + defaultBackendConfig)
 
 	c.logger.CompareLogging(`
-WARN skipping redeclared path '/p1' type 'begin' on ingress 'default/echo1'`)
+WARN skipping redeclared path '/p1' type 'begin' on Ingress 'default/echo1'`)
 }
 
 func TestSyncTLSDefault(t *testing.T) {
@@ -497,7 +497,7 @@ func TestSyncTLSSecretNotFound(t *testing.T) {
     tlsfilename: /tls/tls-default.pem`)
 
 	c.logger.CompareLogging(`
-WARN using default certificate due to an error reading secret 'ing-tls' on ingress 'default/echo': secret not found: 'default/ing-tls'`)
+WARN using default certificate due to an error reading secret 'ing-tls' on Ingress 'default/echo': secret not found: 'default/ing-tls'`)
 }
 
 func TestSyncTLSCustom(t *testing.T) {
@@ -535,7 +535,7 @@ func TestSyncRedeclareTLS(t *testing.T) {
     tlsfilename: /tls/default/tls-echo1.pem`)
 
 	c.logger.CompareLogging(`
-WARN skipping TLS secret 'tls-echo2' of ingress 'default/echo1': TLS of host 'echo.example.com' was already assigned`)
+WARN skipping TLS secret 'tls-echo2' of Ingress 'default/echo1': TLS of host 'echo.example.com' was already assigned`)
 }
 
 func TestSyncRedeclareSameTLS(t *testing.T) {
@@ -582,7 +582,7 @@ func TestSyncRedeclareTLSDefaultFirst(t *testing.T) {
     tlsfilename: /tls/tls-default.pem`)
 
 	c.logger.CompareLogging(`
-WARN skipping TLS secret 'tls-echo1' of ingress 'default/echo2': TLS of host 'echo.example.com' was already assigned`)
+WARN skipping TLS secret 'tls-echo1' of Ingress 'default/echo2': TLS of host 'echo.example.com' was already assigned`)
 }
 
 func TestSyncRedeclareTLSCustomFirst(t *testing.T) {
@@ -607,7 +607,7 @@ func TestSyncRedeclareTLSCustomFirst(t *testing.T) {
     tlsfilename: /tls/default/tls-echo1.pem`)
 
 	c.logger.CompareLogging(`
-WARN skipping default TLS secret of ingress 'default/echo2': TLS of host 'echo.example.com' was already assigned`)
+WARN skipping default TLS secret of Ingress 'default/echo2': TLS of host 'echo.example.com' was already assigned`)
 }
 
 func TestSyncInvalidTLS(t *testing.T) {
@@ -627,7 +627,7 @@ func TestSyncInvalidTLS(t *testing.T) {
     tlsfilename: /tls/tls-default.pem`)
 
 	c.logger.CompareLogging(`
-WARN using default certificate due to an error reading secret 'tls-invalid' on ingress 'default/echo': secret not found: 'default/tls-invalid'`)
+WARN using default certificate due to an error reading secret 'tls-invalid' on Ingress 'default/echo': secret not found: 'default/tls-invalid'`)
 }
 
 func TestSyncTLSSecretWithoutHost(t *testing.T) {
@@ -821,7 +821,7 @@ func TestPathType(t *testing.T) {
 		{
 			pathType: &pathNewFromSpec,
 			expected: hatypes.MatchBegin,
-			logging:  "WARN unsupported 'NewFromSpec' pathType from ingress spec, using 'ImplementationSpecific' instead.",
+			logging:  "WARN unsupported 'NewFromSpec' pathType from Ingress spec, using 'ImplementationSpecific' instead.",
 		},
 	}
 	for i, test := range testCases {
@@ -871,7 +871,7 @@ func TestSyncBackendSvcNotFound(t *testing.T) {
 	c.compareConfigBack(defaultBackendConfig)
 
 	c.logger.CompareLogging(`
-WARN skipping default backend of ingress 'default/echo': service not found: 'default/notfound'`)
+WARN skipping default backend of Ingress 'default/echo': service not found: 'default/notfound'`)
 }
 
 func TestSyncBackendReuseDefaultSvc(t *testing.T) {
@@ -910,7 +910,7 @@ func TestSyncDefaultBackendReusedPath1(t *testing.T) {
     port: 8080` + defaultBackendConfig)
 
 	c.logger.CompareLogging(`
-WARN skipping default backend of ingress 'default/echo2': path / was already defined on default host`)
+WARN skipping default backend of Ingress 'default/echo2': path / was already defined on default host`)
 }
 
 func TestSyncDefaultBackendReusedPath2(t *testing.T) {
@@ -933,7 +933,7 @@ func TestSyncDefaultBackendReusedPath2(t *testing.T) {
     port: 8080` + defaultBackendConfig)
 
 	c.logger.CompareLogging(`
-WARN skipping redeclared path '/' type 'begin' on ingress 'default/echo2'`)
+WARN skipping redeclared path '/' type 'begin' on Ingress 'default/echo2'`)
 }
 
 func TestSyncEmptyHTTP(t *testing.T) {
@@ -1228,7 +1228,7 @@ func TestSyncPartial(t *testing.T) {
 				{"default/echo2", "8080", "172.17.0.12"},
 			},
 			logging: explogging + `
-WARN skipping backend config of ingress 'default/echo2': service not found: 'default/echo2'`,
+WARN skipping backend config of Ingress 'default/echo2': service not found: 'default/echo2'`,
 			expFront: `
 - hostname: echo.example.com
   paths:
@@ -1281,8 +1281,8 @@ WARN skipping backend config of ingress 'default/echo2': service not found: 'def
 			ingtls: ingTLSDefault,
 			secDel: secTLSDefault,
 			logging: explogging + `
-WARN using default certificate due to an error reading secret 'tls1' on ingress 'default/echo1': secret not found: 'default/tls1'
-WARN using default certificate due to an error reading secret 'default/tls1' on ingress 'default/echo2': secret not found: 'default/tls1'`,
+WARN using default certificate due to an error reading secret 'tls1' on Ingress 'default/echo1': secret not found: 'default/tls1'
+WARN using default certificate due to an error reading secret 'default/tls1' on Ingress 'default/echo2': secret not found: 'default/tls1'`,
 			expFront: expFrontDefault + `
   tls:
     tlsfilename: /tls/tls-default.pem`,
@@ -1567,7 +1567,7 @@ func TestSyncTCPServicePort(t *testing.T) {
 				{"7001", "/", "echonotfound:8080"},
 			},
 			expect:  `[]`,
-			logging: `WARN skipping path declaration on ingress 'default/echo1': service not found: 'default/echonotfound'`,
+			logging: `WARN skipping path declaration on Ingress 'default/echo1': service not found: 'default/echonotfound'`,
 		},
 		// 3
 		{
@@ -1575,7 +1575,7 @@ func TestSyncTCPServicePort(t *testing.T) {
 				{"7001", "/", "echo1:notvalidport"},
 			},
 			expect:  `[]`,
-			logging: `WARN skipping path declaration on ingress 'default/echo1': port not found: 'notvalidport'`,
+			logging: `WARN skipping path declaration on Ingress 'default/echo1': port not found: 'notvalidport'`,
 		},
 		// 4
 		{
@@ -1601,7 +1601,7 @@ func TestSyncTCPServicePort(t *testing.T) {
   port: 7001
   proxyprot: false
   tls: {}`,
-			logging: `WARN skipping path declaration on ingress 'default/echo2': tcp service :7001 was already assigned to default_echo1_8080`,
+			logging: `WARN skipping path declaration on Ingress 'default/echo2': tcp service :7001 was already assigned to default_echo1_8080`,
 		},
 		// 6
 		{
@@ -1628,7 +1628,7 @@ func TestSyncTCPServicePort(t *testing.T) {
   proxyprot: false
   tls:
     tlsfilename: /tls/tls-default.pem`,
-			logging: `WARN using default certificate due to an error reading secret 'tls-invalid' on ingress 'default/echo1': secret not found: 'default/tls-invalid'`,
+			logging: `WARN using default certificate due to an error reading secret 'tls-invalid' on Ingress 'default/echo1': secret not found: 'default/tls-invalid'`,
 		},
 		// 8
 		{
@@ -1636,7 +1636,7 @@ func TestSyncTCPServicePort(t *testing.T) {
 				{"7001", "tls1"},
 			},
 			expect:  `[]`,
-			logging: `WARN skipping TLS of tcp service on ingress 'default/echo1': backend was not configured`,
+			logging: `WARN skipping TLS of tcp service on Ingress 'default/echo1': backend was not configured`,
 		},
 		// 9
 		{
@@ -1651,7 +1651,7 @@ func TestSyncTCPServicePort(t *testing.T) {
   proxyprot: false
   tls:
     tlsfilename: /tls/default/tls1.pem`,
-			logging: `WARN skipping path declaration on ingress 'default/echo2': tcp service :7001 was already assigned to default_echo1_8080`,
+			logging: `WARN skipping path declaration on Ingress 'default/echo2': tcp service :7001 was already assigned to default_echo1_8080`,
 		},
 		// 10
 		{
@@ -1667,8 +1667,8 @@ func TestSyncTCPServicePort(t *testing.T) {
   tls:
     tlsfilename: /tls/default/tls1.pem`,
 			logging: `
-WARN skipping path declaration on ingress 'default/echo2': tcp service :7001 was already assigned to default_echo1_8080
-WARN skipping TLS secret 'tls2' of ingress 'default/echo2': TLS of tcp service port '7001' was already assigned`,
+WARN skipping path declaration on Ingress 'default/echo2': tcp service :7001 was already assigned to default_echo1_8080
+WARN skipping TLS secret 'tls2' of Ingress 'default/echo2': TLS of tcp service port '7001' was already assigned`,
 		},
 		// 11
 		{
@@ -1696,7 +1696,7 @@ WARN skipping TLS secret 'tls2' of ingress 'default/echo2': TLS of tcp service p
   port: 7001
   proxyprot: false
   tls: {}`,
-			logging: `WARN skipping path declaration on ingress 'default/echo1': tcp service echo.local:7001 was already assigned to default_echo1_8080`,
+			logging: `WARN skipping path declaration on Ingress 'default/echo1': tcp service echo.local:7001 was already assigned to default_echo1_8080`,
 		},
 		// 13
 		{
@@ -1728,7 +1728,7 @@ WARN skipping TLS secret 'tls2' of ingress 'default/echo2': TLS of tcp service p
   port: 7001
   proxyprot: false
   tls: {}`,
-			logging: `WARN skipping path declaration on ingress 'default/echo3': tcp service echo2.local:7001 was already assigned to default_echo2_8080`,
+			logging: `WARN skipping path declaration on Ingress 'default/echo3': tcp service echo2.local:7001 was already assigned to default_echo2_8080`,
 		},
 		// 15
 		{
@@ -1752,7 +1752,7 @@ WARN skipping TLS secret 'tls2' of ingress 'default/echo2': TLS of tcp service p
 				{"7001", "/app", "echo1:8080"},
 			},
 			expect:  `[]`,
-			logging: `WARN skipping backend declaration on path '/app' of ingress 'default/echo1': tcp services do not support path`,
+			logging: `WARN skipping backend declaration on path '/app' of Ingress 'default/echo1': tcp services do not support path`,
 		},
 		// 17
 		{
@@ -1903,7 +1903,7 @@ func TestAnnPrefix(t *testing.T) {
   - ip: 172.17.0.99
     port: 8080
 `)
-	c.logger.CompareLogging(`WARN annotation 'ingress.kubernetes.io/balance-algorithm' on ingress 'default/app1' was ignored due to conflict with another annotation(s) for the same 'balance-algorithm' configuration key`)
+	c.logger.CompareLogging(`WARN annotation 'ingress.kubernetes.io/balance-algorithm' on Ingress 'default/app1' was ignored due to conflict with another annotation(s) for the same 'balance-algorithm' configuration key`)
 }
 
 func TestSyncAnnFront(t *testing.T) {
@@ -2057,7 +2057,7 @@ func TestSyncAnnBackSvcIngConflict(t *testing.T) {
   balancealgorithm: leastconn` + defaultBackendConfig)
 
 	c.logger.CompareLogging(`
-WARN skipping backend 'echo:8080' annotation(s) from ingress 'default/echo' due to conflict: [balance-algorithm]`)
+WARN skipping backend 'echo:8080' annotation(s) from Ingress 'default/echo' due to conflict: [balance-algorithm]`)
 }
 
 func TestSyncAnnBacksSvcIng(t *testing.T) {
@@ -2163,8 +2163,8 @@ func TestSyncAnnBackDefault(t *testing.T) {
   balancealgorithm: roundrobin`)
 
 	c.logger.CompareLogging(`
-WARN skipping backend 'echo5:8080' annotation(s) from ingress 'default/echo5' due to conflict: [balance-algorithm]
-WARN skipping backend 'echo7:8080' annotation(s) from ingress 'default/echo7' due to conflict: [balance-algorithm]`)
+WARN skipping backend 'echo5:8080' annotation(s) from Ingress 'default/echo5' due to conflict: [balance-algorithm]
+WARN skipping backend 'echo7:8080' annotation(s) from Ingress 'default/echo7' due to conflict: [balance-algorithm]`)
 }
 
 func TestSyncAnnAuthURL(t *testing.T) {
@@ -2198,7 +2198,7 @@ func TestSyncAnnAuthURL(t *testing.T) {
   - ip: 172.17.0.99
     port: 8080
 `)
-	c.logger.CompareLogging(`WARN skipping auth-url on ingress 'default/echo2': service not found: 'default/authsvc2'`)
+	c.logger.CompareLogging(`WARN skipping auth-url on Ingress 'default/echo2': service not found: 'default/authsvc2'`)
 }
 
 func TestSyncAnnPassthrough(t *testing.T) {
@@ -2283,8 +2283,8 @@ rootredirect: /login
 `)
 
 	c.logger.CompareLogging(`
-WARN skipping http port config of ssl-passthrough on ingress 'default/echo2': port not found: '9000'
-WARN skipping redeclared ssl-passthrough root path on ingress 'default/echo2a'
+WARN skipping http port config of ssl-passthrough on Ingress 'default/echo2': port not found: '9000'
+WARN skipping redeclared ssl-passthrough root path on Ingress 'default/echo2a'
 `)
 }
 

--- a/pkg/converters/tracker/tracker.go
+++ b/pkg/converters/tracker/tracker.go
@@ -17,740 +17,112 @@ limitations under the License.
 package tracker
 
 import (
-	"fmt"
 	"sort"
-	"strings"
 
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
-	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 )
 
 // NewTracker ...
 func NewTracker() convtypes.Tracker {
-	return &tracker{}
+	return &tracker{
+		tracking: trackingMap{},
+	}
 }
 
-type (
-	stringStringMap  map[string]map[string]empty
-	stringBackendMap map[string]map[hatypes.BackendID]empty
-	backendStringMap map[hatypes.BackendID]map[string]empty
-	//
-	empty struct{}
-)
+type link struct{}
+type trackingMap map[convtypes.ResourceType]map[string]map[convtypes.TrackingRef]link
 
 type tracker struct {
-	// ingress
-	ingressHostname stringStringMap
-	hostnameIngress stringStringMap
-	ingressBackend  stringBackendMap
-	backendIngress  backendStringMap
-	ingressStorages stringStringMap
-	storagesIngress stringStringMap
-	// ingressClass
-	ingressClassHostname stringStringMap
-	hostnameIngressClass stringStringMap
-	// configMap
-	configMapHostname stringStringMap
-	hostnameConfigMap stringStringMap
-	// service
-	serviceHostname stringStringMap
-	hostnameService stringStringMap
-	// secret
-	secretHostname stringStringMap
-	hostnameSecret stringStringMap
-	secretBackend  stringBackendMap
-	backendSecret  backendStringMap
-	secretUserlist stringStringMap
-	userlistSecret stringStringMap
-	// pod
-	podBackend stringBackendMap
-	backendPod backendStringMap
-	// ingressClass (missing)
-	ingressClassHostnameMissing stringStringMap
-	hostnameIngressClassMissing stringStringMap
-	// configMap (missing)
-	configMapHostnameMissing stringStringMap
-	hostnameConfigMapMissing stringStringMap
-	// service (missing)
-	serviceHostnameMissing stringStringMap
-	hostnameServiceMissing stringStringMap
-	// secret (missing)
-	secretHostnameMissing stringStringMap
-	hostnameSecretMissing stringStringMap
-	secretBackendMissing  stringBackendMap
-	backendSecretMissing  backendStringMap
-	// gateway
-	secretGateway  map[string]empty
-	serviceGateway map[string]empty
+	tracking trackingMap
 }
 
-func (t *tracker) Track(isMissing bool, track convtypes.TrackingTarget, rtype convtypes.ResourceType, name string) {
-	if track.Hostname != "" {
-		if isMissing {
-			t.TrackMissingOnHostname(rtype, name, track.Hostname)
-		} else {
-			t.TrackHostname(rtype, name, track.Hostname)
-		}
-	}
-	if track.Backend.Name != "" {
-		if isMissing {
-			t.TrackMissingOnBackend(rtype, name, track.Backend)
-		} else {
-			t.TrackBackend(rtype, name, track.Backend)
-		}
-	}
-	if track.Userlist != "" {
-		if !isMissing {
-			t.TrackUserlist(rtype, name, track.Userlist)
-		}
-	}
-	if track.Gateway {
-		t.TrackGateway(rtype, name)
+func (t *tracker) TrackNames(leftContext convtypes.ResourceType, leftName string, rightContext convtypes.ResourceType, rightName string) {
+	t.TrackRefs(
+		convtypes.TrackingRef{Context: leftContext, UniqueName: leftName},
+		convtypes.TrackingRef{Context: rightContext, UniqueName: rightName},
+	)
+}
+
+func (t *tracker) TrackRefName(left []convtypes.TrackingRef, rightContext convtypes.ResourceType, rightName string) {
+	for _, track := range left {
+		t.TrackRefs(track, convtypes.TrackingRef{Context: rightContext, UniqueName: rightName})
 	}
 }
 
-func (t *tracker) TrackHostname(rtype convtypes.ResourceType, name, hostname string) {
-	validName(rtype, name)
-	switch rtype {
-	case convtypes.IngressType:
-		addStringTracking(&t.ingressHostname, name, hostname)
-		addStringTracking(&t.hostnameIngress, hostname, name)
-	case convtypes.IngressClassType:
-		addStringTracking(&t.ingressClassHostname, name, hostname)
-		addStringTracking(&t.hostnameIngressClass, hostname, name)
-	case convtypes.ConfigMapType:
-		addStringTracking(&t.configMapHostname, name, hostname)
-		addStringTracking(&t.hostnameConfigMap, hostname, name)
-	case convtypes.ServiceType:
-		addStringTracking(&t.serviceHostname, name, hostname)
-		addStringTracking(&t.hostnameService, hostname, name)
-	case convtypes.SecretType:
-		addStringTracking(&t.secretHostname, name, hostname)
-		addStringTracking(&t.hostnameSecret, hostname, name)
-	default:
-		panic(fmt.Errorf("unsupported resource type %d", rtype))
-	}
-}
+var emptyRef convtypes.TrackingRef = convtypes.TrackingRef{}
 
-func (t *tracker) TrackBackend(rtype convtypes.ResourceType, name string, backendID hatypes.BackendID) {
-	validName(rtype, name)
-	switch rtype {
-	case convtypes.IngressType:
-		addStringBackendTracking(&t.ingressBackend, name, backendID)
-		addBackendStringTracking(&t.backendIngress, backendID, name)
-	case convtypes.SecretType:
-		addStringBackendTracking(&t.secretBackend, name, backendID)
-		addBackendStringTracking(&t.backendSecret, backendID, name)
-	case convtypes.PodType:
-		addStringBackendTracking(&t.podBackend, name, backendID)
-		addBackendStringTracking(&t.backendPod, backendID, name)
-	default:
-		panic(fmt.Errorf("unsupported resource type %d", rtype))
-	}
-}
-
-func (t *tracker) TrackUserlist(rtype convtypes.ResourceType, name, userlist string) {
-	validName(rtype, name)
-	switch rtype {
-	case convtypes.SecretType:
-		addStringTracking(&t.secretUserlist, name, userlist)
-		addStringTracking(&t.userlistSecret, userlist, name)
-	default:
-		panic(fmt.Errorf("unsupported resource type %d", rtype))
-	}
-}
-
-func (t *tracker) TrackStorage(rtype convtypes.ResourceType, name, storage string) {
-	validName(rtype, name)
-	switch rtype {
-	case convtypes.IngressType:
-		addStringTracking(&t.ingressStorages, name, storage)
-		addStringTracking(&t.storagesIngress, storage, name)
-	default:
-		panic(fmt.Errorf("unsupported resource type %d", rtype))
-	}
-}
-
-func (t *tracker) TrackGateway(rtype convtypes.ResourceType, name string) {
-	validName(rtype, name)
-	switch rtype {
-	case convtypes.SecretType:
-		if t.secretGateway == nil {
-			t.secretGateway = map[string]empty{}
-		}
-		t.secretGateway[name] = empty{}
-	case convtypes.ServiceType:
-		if t.serviceGateway == nil {
-			t.serviceGateway = map[string]empty{}
-		}
-		t.serviceGateway[name] = empty{}
-	default:
-		panic(fmt.Errorf("unsupported resource type %d", rtype))
-	}
-}
-
-func (t *tracker) TrackMissingOnHostname(rtype convtypes.ResourceType, name, hostname string) {
-	validName(rtype, name)
-	switch rtype {
-	case convtypes.IngressClassType:
-		addStringTracking(&t.ingressClassHostnameMissing, name, hostname)
-		addStringTracking(&t.hostnameIngressClassMissing, hostname, name)
-	case convtypes.ConfigMapType:
-		addStringTracking(&t.configMapHostnameMissing, name, hostname)
-		addStringTracking(&t.hostnameConfigMapMissing, hostname, name)
-	case convtypes.ServiceType:
-		addStringTracking(&t.serviceHostnameMissing, name, hostname)
-		addStringTracking(&t.hostnameServiceMissing, hostname, name)
-	case convtypes.SecretType:
-		addStringTracking(&t.secretHostnameMissing, name, hostname)
-		addStringTracking(&t.hostnameSecretMissing, hostname, name)
-	default:
-		panic(fmt.Errorf("unsupported resource type %d", rtype))
-	}
-}
-
-func (t *tracker) TrackMissingOnBackend(rtype convtypes.ResourceType, name string, backendID hatypes.BackendID) {
-	validName(rtype, name)
-	switch rtype {
-	case convtypes.SecretType:
-		addStringBackendTracking(&t.secretBackendMissing, name, backendID)
-		addBackendStringTracking(&t.backendSecretMissing, backendID, name)
-	default:
-		panic(fmt.Errorf("unsupported resource type %d", rtype))
-	}
-}
-
-func (t *tracker) GetGatewayChanged(oldSecretList, addSecretList, oldServiceList, addServiceList []string) bool {
-	if t.secretGateway != nil {
-		for _, secret := range oldSecretList {
-			if _, found := t.secretGateway[secret]; found {
-				return true
-			}
-		}
-		for _, secret := range addSecretList {
-			if _, found := t.secretGateway[secret]; found {
-				return true
-			}
-		}
-	}
-	if t.serviceGateway != nil {
-		for _, service := range oldServiceList {
-			if _, found := t.serviceGateway[service]; found {
-				return true
-			}
-		}
-		for _, service := range addServiceList {
-			if _, found := t.serviceGateway[service]; found {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func (t *tracker) DeleteGateway() {
-	t.secretGateway = nil
-	t.serviceGateway = nil
-}
-
-func validName(rtype convtypes.ResourceType, name string) {
-	if name == "" {
-		panic(fmt.Errorf("tracking resource name cannot be empty"))
-	}
-	namespaced := rtype != convtypes.IngressClassType
-	slashCount := strings.Count(name, "/")
-	if (!namespaced && slashCount != 0) || (namespaced && slashCount != 1) {
-		panic(fmt.Errorf("invalid resource name: %s", name))
-	}
-}
-
-// GetDirtyLinks lists all hostnames and backendIDs that a
-// list of ingress touches directly or indirectly:
-//
-//   * when a hostname is listed, all other hostnames of all ingress that
-//     references it should also be listed;
-//   * when a backendID (service+port) is listed, all other backendIDs of
-//     all ingress that references it should also be listed.
-//
-func (t *tracker) GetDirtyLinks(
-	oldIngressList, addIngressList []string,
-	oldIngressClassList, addIngressClassList []string,
-	oldConfigMapList, addConfigMapList []string,
-	oldServiceList, addServiceList []string,
-	oldSecretList, addSecretList []string,
-	addPodList []string,
-) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers, dirtyStorages []string) {
-	ingsMap := make(map[string]empty)
-	hostsMap := make(map[string]empty)
-	backsMap := make(map[hatypes.BackendID]empty)
-	usersMap := make(map[string]empty)
-	storagesMap := make(map[string]empty)
-
-	// recursively fill hostsMap and backsMap from ingress and secrets
-	// that directly or indirectly are referenced by them
-	var build func([]string)
-	build = func(ingNames []string) {
-		for _, ingName := range ingNames {
-			ingsMap[ingName] = empty{}
-			for _, hostname := range t.getHostnamesByIngress(ingName) {
-				if _, found := hostsMap[hostname]; !found {
-					hostsMap[hostname] = empty{}
-					build(t.getIngressByHostname(hostname))
-				}
-			}
-			for _, backend := range t.getBackendsByIngress(ingName) {
-				if _, found := backsMap[backend]; !found {
-					backsMap[backend] = empty{}
-					build(t.getIngressByBackend(backend))
-				}
-			}
-			for _, storage := range t.getStoragesByIngress(ingName) {
-				if _, found := storagesMap[storage]; !found {
-					storagesMap[storage] = empty{}
-					build(t.getIngressByStorage(storage))
-				}
-			}
-		}
-	}
-	build(oldIngressList)
-	build(addIngressList)
-	//
-	for _, className := range oldIngressClassList {
-		for _, hostname := range t.getHostnamesByIngressClass(className) {
-			if _, found := hostsMap[hostname]; !found {
-				hostsMap[hostname] = empty{}
-				build(t.getIngressByHostname(hostname))
-			}
-		}
-	}
-	for _, className := range addIngressClassList {
-		for _, hostname := range t.getHostnamesByIngressClassMissing(className) {
-			if _, found := hostsMap[hostname]; !found {
-				hostsMap[hostname] = empty{}
-				build(t.getIngressByHostname(hostname))
-			}
-		}
-	}
-	//
-	for _, className := range oldConfigMapList {
-		for _, hostname := range t.getHostnamesByConfigMap(className) {
-			if _, found := hostsMap[hostname]; !found {
-				hostsMap[hostname] = empty{}
-				build(t.getIngressByHostname(hostname))
-			}
-		}
-	}
-	for _, className := range addConfigMapList {
-		for _, hostname := range t.getHostnamesByConfigMapMissing(className) {
-			if _, found := hostsMap[hostname]; !found {
-				hostsMap[hostname] = empty{}
-				build(t.getIngressByHostname(hostname))
-			}
-		}
-	}
-	//
-	for _, svcName := range oldServiceList {
-		for _, hostname := range t.getHostnamesByService(svcName) {
-			if _, found := hostsMap[hostname]; !found {
-				hostsMap[hostname] = empty{}
-				build(t.getIngressByHostname(hostname))
-			}
-		}
-	}
-	for _, svcName := range addServiceList {
-		for _, hostname := range t.getHostnamesByServiceMissing(svcName) {
-			if _, found := hostsMap[hostname]; !found {
-				hostsMap[hostname] = empty{}
-				build(t.getIngressByHostname(hostname))
-			}
-		}
-	}
-	//
-	for _, secretName := range oldSecretList {
-		for _, hostname := range t.getHostnamesBySecret(secretName) {
-			if _, found := hostsMap[hostname]; !found {
-				hostsMap[hostname] = empty{}
-				build(t.getIngressByHostname(hostname))
-			}
-		}
-		for _, backend := range t.getBackendsBySecret(secretName) {
-			if _, found := backsMap[backend]; !found {
-				backsMap[backend] = empty{}
-				build(t.getIngressByBackend(backend))
-			}
-		}
-		for _, userlist := range t.getUserlistsBySecret(secretName) {
-			if _, found := usersMap[userlist]; !found {
-				usersMap[userlist] = empty{}
-			}
-		}
-	}
-	for _, secretName := range addSecretList {
-		for _, hostname := range t.getHostnamesBySecretMissing(secretName) {
-			if _, found := hostsMap[hostname]; !found {
-				hostsMap[hostname] = empty{}
-				build(t.getIngressByHostname(hostname))
-			}
-		}
-		for _, backend := range t.getBackendsBySecretMissing(secretName) {
-			if _, found := backsMap[backend]; !found {
-				backsMap[backend] = empty{}
-				build(t.getIngressByBackend(backend))
-			}
-		}
-	}
-	//
-	for _, podName := range addPodList {
-		for _, backend := range t.getBackendsByPod(podName) {
-			if _, found := backsMap[backend]; !found {
-				backsMap[backend] = empty{}
-				build(t.getIngressByBackend(backend))
-			}
-		}
-	}
-
-	// convert hostsMap and backsMap to slices
-	if len(ingsMap) > 0 {
-		dirtyIngs = make([]string, 0, len(ingsMap))
-		for ing := range ingsMap {
-			dirtyIngs = append(dirtyIngs, ing)
-		}
-		sort.Strings(dirtyIngs)
-	}
-	if len(hostsMap) > 0 {
-		dirtyHosts = make([]string, 0, len(hostsMap))
-		for host := range hostsMap {
-			dirtyHosts = append(dirtyHosts, host)
-		}
-		sort.Strings(dirtyHosts)
-	}
-	if len(backsMap) > 0 {
-		dirtyBacks = make([]hatypes.BackendID, 0, len(backsMap))
-		for back := range backsMap {
-			dirtyBacks = append(dirtyBacks, back)
-		}
-		sort.Slice(dirtyBacks, func(i, j int) bool {
-			return dirtyBacks[i].String() < dirtyBacks[j].String()
-		})
-	}
-	if len(usersMap) > 0 {
-		dirtyUsers = make([]string, 0, len(usersMap))
-		for user := range usersMap {
-			dirtyUsers = append(dirtyUsers, user)
-		}
-		sort.Strings(dirtyUsers)
-	}
-	if len(storagesMap) > 0 {
-		dirtyStorages = make([]string, 0, len(storagesMap))
-		for storage := range storagesMap {
-			dirtyStorages = append(dirtyStorages, storage)
-		}
-		sort.Strings(dirtyStorages)
-	}
-	return dirtyIngs, dirtyHosts, dirtyBacks, dirtyUsers, dirtyStorages
-}
-
-func (t *tracker) DeleteHostnames(hostnames []string) {
-	for _, hostname := range hostnames {
-		for ing := range t.hostnameIngress[hostname] {
-			deleteStringTracking(&t.ingressHostname, ing, hostname)
-		}
-		deleteStringMapKey(&t.hostnameIngress, hostname)
-		for class := range t.hostnameIngressClass[hostname] {
-			deleteStringTracking(&t.ingressClassHostname, class, hostname)
-		}
-		deleteStringMapKey(&t.hostnameIngressClass, hostname)
-		for class := range t.hostnameIngressClassMissing[hostname] {
-			deleteStringTracking(&t.ingressClassHostnameMissing, class, hostname)
-		}
-		deleteStringMapKey(&t.hostnameIngressClassMissing, hostname)
-		for class := range t.hostnameConfigMap[hostname] {
-			deleteStringTracking(&t.configMapHostname, class, hostname)
-		}
-		deleteStringMapKey(&t.hostnameConfigMap, hostname)
-		for class := range t.hostnameConfigMapMissing[hostname] {
-			deleteStringTracking(&t.configMapHostnameMissing, class, hostname)
-		}
-		deleteStringMapKey(&t.hostnameConfigMapMissing, hostname)
-		for service := range t.hostnameService[hostname] {
-			deleteStringTracking(&t.serviceHostname, service, hostname)
-		}
-		deleteStringMapKey(&t.hostnameService, hostname)
-		for service := range t.hostnameServiceMissing[hostname] {
-			deleteStringTracking(&t.serviceHostnameMissing, service, hostname)
-		}
-		deleteStringMapKey(&t.hostnameServiceMissing, hostname)
-		for secret := range t.hostnameSecret[hostname] {
-			deleteStringTracking(&t.secretHostname, secret, hostname)
-		}
-		deleteStringMapKey(&t.hostnameSecret, hostname)
-		for secret := range t.hostnameSecretMissing[hostname] {
-			deleteStringTracking(&t.secretHostnameMissing, secret, hostname)
-		}
-		deleteStringMapKey(&t.hostnameSecretMissing, hostname)
-	}
-}
-
-func (t *tracker) DeleteBackends(backends []hatypes.BackendID) {
-	for _, backend := range backends {
-		for ing := range t.backendIngress[backend] {
-			deleteStringBackendTracking(&t.ingressBackend, ing, backend)
-		}
-		deleteBackendStringMapKey(&t.backendIngress, backend)
-		for secret := range t.backendSecret[backend] {
-			deleteStringBackendTracking(&t.secretBackend, secret, backend)
-		}
-		deleteBackendStringMapKey(&t.backendSecret, backend)
-		for secret := range t.backendSecretMissing[backend] {
-			deleteStringBackendTracking(&t.secretBackendMissing, secret, backend)
-		}
-		deleteBackendStringMapKey(&t.backendSecretMissing, backend)
-		for pod := range t.backendPod[backend] {
-			deleteStringBackendTracking(&t.podBackend, pod, backend)
-		}
-		deleteBackendStringMapKey(&t.backendPod, backend)
-	}
-}
-
-func (t *tracker) DeleteUserlists(userlists []string) {
-	for _, userlist := range userlists {
-		for secret := range t.userlistSecret[userlist] {
-			deleteStringTracking(&t.secretUserlist, secret, userlist)
-		}
-		deleteStringMapKey(&t.userlistSecret, userlist)
-	}
-}
-
-func (t *tracker) DeleteStorages(storages []string) {
-	for _, storage := range storages {
-		for ing := range t.storagesIngress[storage] {
-			deleteStringTracking(&t.ingressStorages, ing, storage)
-		}
-		deleteStringMapKey(&t.storagesIngress, storage)
-	}
-}
-
-func (t *tracker) getIngressByHostname(hostname string) []string {
-	if t.hostnameIngress == nil {
-		return nil
-	}
-	return getStringTracking(t.hostnameIngress[hostname])
-}
-
-func (t *tracker) getHostnamesByIngress(ingName string) []string {
-	if t.ingressHostname == nil {
-		return nil
-	}
-	return getStringTracking(t.ingressHostname[ingName])
-}
-
-func (t *tracker) getIngressByBackend(backendID hatypes.BackendID) []string {
-	if t.backendIngress == nil {
-		return nil
-	}
-	return getStringTracking(t.backendIngress[backendID])
-}
-
-func (t *tracker) getBackendsByIngress(ingName string) []hatypes.BackendID {
-	if t.ingressBackend == nil {
-		return nil
-	}
-	return getBackendTracking(t.ingressBackend[ingName])
-}
-
-func (t *tracker) getIngressByStorage(storages string) []string {
-	if t.storagesIngress == nil {
-		return nil
-	}
-	return getStringTracking(t.storagesIngress[storages])
-}
-
-func (t *tracker) getStoragesByIngress(ingName string) []string {
-	if t.ingressStorages == nil {
-		return nil
-	}
-	return getStringTracking(t.ingressStorages[ingName])
-}
-
-func (t *tracker) getHostnamesByIngressClass(ingressClassName string) []string {
-	if t.ingressClassHostname == nil {
-		return nil
-	}
-	return getStringTracking(t.ingressClassHostname[ingressClassName])
-}
-
-func (t *tracker) getHostnamesByIngressClassMissing(ingressClassName string) []string {
-	if t.ingressClassHostnameMissing == nil {
-		return nil
-	}
-	return getStringTracking(t.ingressClassHostnameMissing[ingressClassName])
-}
-
-func (t *tracker) getHostnamesByConfigMap(configMapName string) []string {
-	if t.configMapHostname == nil {
-		return nil
-	}
-	return getStringTracking(t.configMapHostname[configMapName])
-}
-
-func (t *tracker) getHostnamesByConfigMapMissing(configMapName string) []string {
-	if t.configMapHostnameMissing == nil {
-		return nil
-	}
-	return getStringTracking(t.configMapHostnameMissing[configMapName])
-}
-
-func (t *tracker) getHostnamesByService(serviceName string) []string {
-	if t.serviceHostname == nil {
-		return nil
-	}
-	return getStringTracking(t.serviceHostname[serviceName])
-}
-
-func (t *tracker) getHostnamesByServiceMissing(serviceName string) []string {
-	if t.serviceHostnameMissing == nil {
-		return nil
-	}
-	return getStringTracking(t.serviceHostnameMissing[serviceName])
-}
-
-func (t *tracker) getHostnamesBySecret(secretName string) []string {
-	if t.secretHostname == nil {
-		return nil
-	}
-	return getStringTracking(t.secretHostname[secretName])
-}
-
-func (t *tracker) getHostnamesBySecretMissing(secretName string) []string {
-	if t.secretHostnameMissing == nil {
-		return nil
-	}
-	return getStringTracking(t.secretHostnameMissing[secretName])
-}
-
-func (t *tracker) getBackendsBySecret(secretName string) []hatypes.BackendID {
-	if t.secretBackend == nil {
-		return nil
-	}
-	return getBackendTracking(t.secretBackend[secretName])
-}
-
-func (t *tracker) getBackendsBySecretMissing(secretName string) []hatypes.BackendID {
-	if t.secretBackendMissing == nil {
-		return nil
-	}
-	return getBackendTracking(t.secretBackendMissing[secretName])
-}
-
-func (t *tracker) getUserlistsBySecret(secretName string) []string {
-	if t.secretUserlist == nil {
-		return nil
-	}
-	return getStringTracking(t.secretUserlist[secretName])
-}
-
-func (t *tracker) getBackendsByPod(podName string) []hatypes.BackendID {
-	if t.podBackend == nil {
-		return nil
-	}
-	return getBackendTracking(t.podBackend[podName])
-}
-
-func addStringTracking(trackingRef *stringStringMap, key, value string) {
-	if *trackingRef == nil {
-		*trackingRef = stringStringMap{}
-	}
-	tracking := *trackingRef
-	trackingMap, found := tracking[key]
-	if !found {
-		trackingMap = map[string]empty{}
-		tracking[key] = trackingMap
-	}
-	trackingMap[value] = empty{}
-}
-
-func addBackendStringTracking(trackingRef *backendStringMap, key hatypes.BackendID, value string) {
-	if *trackingRef == nil {
-		*trackingRef = backendStringMap{}
-	}
-	tracking := *trackingRef
-	trackingMap, found := tracking[key]
-	if !found {
-		trackingMap = map[string]empty{}
-		tracking[key] = trackingMap
-	}
-	trackingMap[value] = empty{}
-}
-
-func addStringBackendTracking(trackingRef *stringBackendMap, key string, value hatypes.BackendID) {
-	if *trackingRef == nil {
-		*trackingRef = stringBackendMap{}
-	}
-	tracking := *trackingRef
-	trackingMap, found := tracking[key]
-	if !found {
-		trackingMap = map[hatypes.BackendID]empty{}
-		tracking[key] = trackingMap
-	}
-	trackingMap[value] = empty{}
-}
-
-func getStringTracking(tracking map[string]empty) []string {
-	stringList := make([]string, 0, len(tracking))
-	for value := range tracking {
-		stringList = append(stringList, value)
-	}
-	return stringList
-}
-
-func getBackendTracking(tracking map[hatypes.BackendID]empty) []hatypes.BackendID {
-	backendList := make([]hatypes.BackendID, 0, len(tracking))
-	for value := range tracking {
-		backendList = append(backendList, value)
-	}
-	return backendList
-}
-
-func deleteStringTracking(trackingRef *stringStringMap, key, value string) {
-	if *trackingRef == nil {
+func (t *tracker) TrackRefs(left, right convtypes.TrackingRef) {
+	if left == emptyRef || right == emptyRef {
 		return
 	}
-	tracking := *trackingRef
-	trackingMap := tracking[key]
-	delete(trackingMap, value)
-	if len(trackingMap) == 0 {
-		delete(tracking, key)
-	}
-	if len(tracking) == 0 {
-		*trackingRef = nil
-	}
+	t.track(&left, &right)
+	t.track(&right, &left)
 }
 
-func deleteStringBackendTracking(trackingRef *stringBackendMap, key string, value hatypes.BackendID) {
-	if *trackingRef == nil {
-		return
+func (t *tracker) track(dest, source *convtypes.TrackingRef) {
+	names, found := t.tracking[dest.Context]
+	if !found {
+		names = map[string]map[convtypes.TrackingRef]link{}
+		t.tracking[dest.Context] = names
 	}
-	tracking := *trackingRef
-	trackingMap := tracking[key]
-	delete(trackingMap, value)
-	if len(trackingMap) == 0 {
-		delete(tracking, key)
+	refs, found := names[dest.UniqueName]
+	if !found {
+		refs = map[convtypes.TrackingRef]link{}
+		names[dest.UniqueName] = refs
 	}
-	if len(tracking) == 0 {
-		*trackingRef = nil
-	}
+	refs[*source] = link{}
 }
 
-func deleteStringMapKey(stringMap *stringStringMap, key string) {
-	delete(*stringMap, key)
-	if len(*stringMap) == 0 {
-		*stringMap = nil
+// QueryLinks recursively lists all resource IDs that a list of input
+// resources are linked to, and remove the input IDs from the maps
+func (t *tracker) QueryLinks(input convtypes.TrackingLinks, removeMatches bool) convtypes.TrackingLinks {
+	outputrefs := map[convtypes.ResourceType]map[string]link{}
+	var updateOutput func(convtypes.ResourceType, []string)
+	updateOutput = func(ctx convtypes.ResourceType, namelist []string) {
+		if refs, found := t.tracking[ctx]; found {
+			for _, name := range namelist {
+				for ref := range refs[name] {
+					outputlist, found := outputrefs[ref.Context]
+					if !found {
+						outputlist = map[string]link{}
+						outputrefs[ref.Context] = outputlist
+					}
+					if _, found := outputlist[ref.UniqueName]; !found {
+						outputlist[ref.UniqueName] = link{}
+						updateOutput(ref.Context, []string{ref.UniqueName})
+					}
+				}
+			}
+		}
 	}
+	for ctx, namelist := range input {
+		updateOutput(ctx, namelist)
+	}
+	output := map[convtypes.ResourceType][]string{}
+	for ctx, idmap := range outputrefs {
+		idlist := make([]string, 0, len(idmap))
+		for id := range idmap {
+			idlist = append(idlist, id)
+			if removeMatches {
+				t.removeRef(ctx, id)
+			}
+		}
+		sort.Strings(idlist)
+		output[ctx] = idlist
+	}
+	return output
 }
 
-func deleteBackendStringMapKey(backendMap *backendStringMap, key hatypes.BackendID) {
-	delete(*backendMap, key)
-	if len(*backendMap) == 0 {
-		*backendMap = nil
+func (t *tracker) ClearLinks() {
+	t.tracking = trackingMap{}
+}
+
+func (t *tracker) removeRef(ctx convtypes.ResourceType, name string) {
+	if refs, found := t.tracking[ctx]; found {
+		n := refs[name]
+		delete(refs, name)
+		for ref := range n {
+			t.removeRef(ref.Context, ref.UniqueName)
+		}
 	}
 }

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -87,6 +87,7 @@ type ChangedObjects struct {
 	NeedFullSync bool
 	//
 	Objects []string
+	Links   TrackingLinks
 }
 
 // ResourceType ...

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -108,6 +108,7 @@ const (
 
 	ResourceConfigMap ResourceType = "ConfigMap"
 	ResourceService   ResourceType = "Service"
+	ResourceEndpoints ResourceType = "Endpoints"
 	ResourceSecret    ResourceType = "Secret"
 	ResourcePod       ResourceType = "Pod"
 

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -39,13 +39,13 @@ type Cache interface {
 	GetService(defaultNamespace, serviceName string) (*api.Service, error)
 	GetEndpoints(service *api.Service) (*api.Endpoints, error)
 	GetConfigMap(configMapName string) (*api.ConfigMap, error)
-	GetTerminatingPods(service *api.Service, track TrackingTarget) ([]*api.Pod, error)
+	GetTerminatingPods(service *api.Service, track []TrackingRef) ([]*api.Pod, error)
 	GetPod(podName string) (*api.Pod, error)
 	GetPodNamespace() string
-	GetTLSSecretPath(defaultNamespace, secretName string, track TrackingTarget) (CrtFile, error)
-	GetCASecretPath(defaultNamespace, secretName string, track TrackingTarget) (ca, crl File, err error)
+	GetTLSSecretPath(defaultNamespace, secretName string, track []TrackingRef) (CrtFile, error)
+	GetCASecretPath(defaultNamespace, secretName string, track []TrackingRef) (ca, crl File, err error)
 	GetDHSecretPath(defaultNamespace, secretName string) (File, error)
-	GetPasswdSecretContent(defaultNamespace, secretName string, track TrackingTarget) ([]byte, error)
+	GetPasswdSecretContent(defaultNamespace, secretName string, track []TrackingRef) ([]byte, error)
 	SwapChangedObjects() *ChangedObjects
 }
 
@@ -89,29 +89,50 @@ type ChangedObjects struct {
 	Objects []string
 }
 
-// Tracker ...
-type Tracker interface {
-	Track(isMissing bool, track TrackingTarget, rtype ResourceType, name string)
-	TrackHostname(rtype ResourceType, name, hostname string)
-	TrackBackend(rtype ResourceType, name string, backendID hatypes.BackendID)
-	TrackMissingOnHostname(rtype ResourceType, name, hostname string)
-	TrackStorage(rtype ResourceType, name, storage string)
-	TrackGateway(rtype ResourceType, name string)
-	GetDirtyLinks(oldIngressList, addIngressList, oldIngressClassList, addIngressClassList, oldConfigMapList, addConfigMapList, oldServiceList, addServiceList, oldSecretList, addSecretList, addPodList []string) (dirtyIngs, dirtyHosts []string, dirtyBacks []hatypes.BackendID, dirtyUsers, dirtyStorages []string)
-	GetGatewayChanged(oldSecretList, addSecretList, oldServiceList, addServiceList []string) bool
-	DeleteHostnames(hostnames []string)
-	DeleteBackends(backends []hatypes.BackendID)
-	DeleteUserlists(userlists []string)
-	DeleteStorages(storages []string)
-	DeleteGateway()
+// ResourceType ...
+type ResourceType string
+
+// ...
+const (
+	ResourceIngress      ResourceType = "Ingress"
+	ResourceIngressClass ResourceType = "IngressClass"
+
+	ResourceGateway       ResourceType = "Gateway"
+	ResourceGatewayClass  ResourceType = "GatewayClass"
+	ResourceHTTPRoute     ResourceType = "HTTPRoute"
+	ResourceTLSRoute      ResourceType = "TLSRoute"
+	ResourceTCPRoute      ResourceType = "TCPRoute"
+	ResourceUDPRoute      ResourceType = "UDPRoute"
+	ResourceBackendPolicy ResourceType = "BackendPolicy"
+
+	ResourceConfigMap ResourceType = "ConfigMap"
+	ResourceService   ResourceType = "Service"
+	ResourceSecret    ResourceType = "Secret"
+	ResourcePod       ResourceType = "Pod"
+
+	ResourceHAHostname ResourceType = "HAHostname"
+	ResourceHABackend  ResourceType = "HABackend"
+	ResourceHAUserlist ResourceType = "HAUserlist"
+
+	ResourceAcmeData ResourceType = "AcmeData"
+)
+
+// TrackingRef ...
+type TrackingRef struct {
+	Context    ResourceType
+	UniqueName string
 }
 
-// TrackingTarget ...
-type TrackingTarget struct {
-	Hostname string
-	Backend  hatypes.BackendID
-	Userlist string
-	Gateway  bool
+// TrackingLinks ...
+type TrackingLinks map[ResourceType][]string
+
+// Tracker ...
+type Tracker interface {
+	TrackNames(leftContext ResourceType, leftName string, rightContext ResourceType, rightName string)
+	TrackRefName(left []TrackingRef, rightContext ResourceType, rightName string)
+	TrackRefs(left, right TrackingRef)
+	QueryLinks(input TrackingLinks, removeMatches bool) TrackingLinks
+	ClearLinks()
 }
 
 // AnnotationReader ...
@@ -132,26 +153,3 @@ type CrtFile struct {
 	CommonName string
 	NotAfter   time.Time
 }
-
-// ResourceType ...
-type ResourceType int
-
-const (
-	// IngressType ...
-	IngressType ResourceType = iota
-
-	// IngressClassType ...
-	IngressClassType
-
-	// ConfigMapType ...
-	ConfigMapType
-
-	// ServiceType ...
-	ServiceType
-
-	// SecretType ...
-	SecretType
-
-	// PodType ...
-	PodType
-)

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -112,9 +112,10 @@ const (
 	ResourceSecret    ResourceType = "Secret"
 	ResourcePod       ResourceType = "Pod"
 
-	ResourceHAHostname ResourceType = "HAHostname"
-	ResourceHABackend  ResourceType = "HABackend"
-	ResourceHAUserlist ResourceType = "HAUserlist"
+	RersourceHATCPService ResourceType = "HATCPService"
+	ResourceHAHostname    ResourceType = "HAHostname"
+	ResourceHABackend     ResourceType = "HABackend"
+	ResourceHAUserlist    ResourceType = "HAUserlist"
 
 	ResourceAcmeData ResourceType = "AcmeData"
 )

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -24,8 +24,6 @@ import (
 	"time"
 
 	"github.com/kylelemons/godebug/diff"
-
-	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 )
 
 func TestDynUpdate(t *testing.T) {
@@ -1016,9 +1014,9 @@ INFO-V(2) need to reload due to config changes: [hosts]
 			hostnames = append(hostnames, hostname)
 		}
 		c.config.Hosts().RemoveAll(hostnames)
-		backendIDs := []types.BackendID{}
+		backendIDs := []string{}
 		for _, backend := range c.config.Backends().Items() {
-			backendIDs = append(backendIDs, backend.BackendID())
+			backendIDs = append(backendIDs, backend.ID)
 		}
 		c.config.Backends().RemoveAll(backendIDs)
 		if test.doconfig2 != nil {

--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -265,9 +265,8 @@ func (b *Backends) FindBackendID(backendID BackendID) *Backend {
 }
 
 // RemoveAll ...
-func (b *Backends) RemoveAll(backendID []BackendID) {
-	for _, backend := range backendID {
-		id := backend.String()
+func (b *Backends) RemoveAll(backendID []string) {
+	for _, id := range backendID {
 		if item, found := b.items[id]; found {
 			if len(b.shards) > 0 {
 				delete(b.shards[item.shard], id)

--- a/pkg/haproxy/types/backends_test.go
+++ b/pkg/haproxy/types/backends_test.go
@@ -103,11 +103,11 @@ func TestBackendCrud(t *testing.T) {
 			p := strings.Split(add, "_")
 			backends.AcquireBackend(p[0], p[1], p[2])
 		}
-		var backendIDs []BackendID
+		var backendIDs []string
 		for _, del := range test.del {
 			p := strings.Split(del, "_")
 			if b := backends.FindBackend(p[0], p[1], p[2]); b != nil {
-				backendIDs = append(backendIDs, b.BackendID())
+				backendIDs = append(backendIDs, b.ID)
 			}
 		}
 		backends.RemoveAll(backendIDs)

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -64,11 +64,12 @@ func (f *Frontend) RemoveAuthBackendExcept(used map[string]bool) {
 	f.AuthProxy.BindList = bindList[:i]
 }
 
-func (f *Frontend) RemoveAuthBackendByTarget(backends []BackendID) {
+// RemoveAuthBackendByTarget ...
+func (f *Frontend) RemoveAuthBackendByTarget(backends []string) {
 	bindList := f.AuthProxy.BindList
 	var i int
 	for _, bind := range bindList {
-		if !hasBackend(backends, bind.Backend) {
+		if !hasBackend(backends, bind.Backend.String()) {
 			bindList[i] = bind
 			i++
 		}
@@ -76,7 +77,7 @@ func (f *Frontend) RemoveAuthBackendByTarget(backends []BackendID) {
 	f.AuthProxy.BindList = bindList[:i]
 }
 
-func hasBackend(backends []BackendID, backend BackendID) bool {
+func hasBackend(backends []string, backend string) bool {
 	for _, back := range backends {
 		if back == backend {
 			return true

--- a/pkg/haproxy/types/frontend_test.go
+++ b/pkg/haproxy/types/frontend_test.go
@@ -137,37 +137,37 @@ func TestRemoveAuthBackendByTarget(t *testing.T) {
 	back2 := BackendID{Namespace: "default", Name: "backend2", Port: "8080"}
 	testCases := []struct {
 		input    []BackendID
-		removed  []BackendID
+		removed  []string
 		expected []BackendID
 	}{
 		// 0
 		{
 			input:    []BackendID{back1, back2},
-			removed:  []BackendID{back2},
+			removed:  []string{back2.String()},
 			expected: []BackendID{back1},
 		},
 		// 1
 		{
 			input:    []BackendID{},
-			removed:  []BackendID{back2},
+			removed:  []string{back2.String()},
 			expected: []BackendID{},
 		},
 		// 2
 		{
 			input:    []BackendID{back1, back2},
-			removed:  []BackendID{back1, back2},
+			removed:  []string{back1.String(), back2.String()},
 			expected: []BackendID{},
 		},
 		// 3
 		{
 			input:    []BackendID{back1, back2},
-			removed:  []BackendID{},
+			removed:  []string{},
 			expected: []BackendID{back1, back2},
 		},
 		// 4
 		{
 			input:    []BackendID{back1, back2},
-			removed:  []BackendID{back0, back2},
+			removed:  []string{back0.String(), back2.String()},
 			expected: []BackendID{back1},
 		},
 	}


### PR DESCRIPTION
Tracker is used to link kubernetes resources and haproxy entities each other, allowing to list, remove and rebuild all objects related with a configuration change. This is the base of the partial parsing implementation.

The codebase used in v0.11 (starting implementation) up to v0.13 is a lot bigger than necessary, coupled with k8s and haproxy types , and also tricky to extend and test. This update changes the code base to an abstract implementation that can be expanded without the need to write more code, but instead just declaring a new type to every new k8s or haproxy type that need to be tracked.

Both old and new code base are compatible, they only change in the interface declaration, and the new one doesn't have a special behavior when the target doesn't exist - being missing or not, a resource creation or update will trigger the list+remove+recreate in the same way.

Backlog:

* [x] New tracker implementation
* [x] Move tracking query input generation to a common place
* [x] Decouple resource tracking from the HAProxy's hostname type
* [x] Unit tests covering all possible scenarios
* [x] Exploratory tests