### PR TITLE
Add read and write timeout to the unix socket

### DIFF
--- a/pkg/haproxy/socket/socket_test.go
+++ b/pkg/haproxy/socket/socket_test.go
@@ -388,7 +388,7 @@ func TestHAProxyProcsLoop(t *testing.T) {
 		start := time.Now()
 		_, err := HAProxyProcs(cli)
 		if err != nil {
-			t.Errorf("%d should not return an error: %w", i, err)
+			t.Errorf("%d should not return an error: %v", i, err)
 		}
 		elapsed := time.Now().Sub(start)
 		if elapsed < test.minDelay {


### PR DESCRIPTION
HAProxy's admin socket always respond in a fraction of a millisecond and should only take a bit more time if the proxy is 100% saturated, even so a response should be received within some hundreds of milliseconds. A fix 5s timeout is being added in the socket calls as a protection mechanism to the event loop that parses kubernetes resources - if for any reason, eg a controller bug, makes controller and HAProxy disagree who should be speaking, this timeout will make the controller give up instead of blocking the event loop forever.