### PR TITLE
Fix global config-backend snippet config

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -523,21 +523,22 @@ func (c *updater) buildBackendCors(d *backData) {
 
 func (c *updater) buildBackendCustomConfig(d *backData) {
 	config := d.mapper.Get(ingtypes.BackConfigBackend)
-	if config.Source == nil {
-		return
-	}
 	lines := utils.LineToSlice(config.Value)
 	if len(lines) == 0 {
 		return
 	}
+	source := "global config"
+	if config.Source != nil {
+		source = config.Source.String()
+	}
 	for _, keyword := range c.options.DisableKeywords {
 		if keyword == "*" {
-			c.logger.Warn("skipping configuration snippet on %s: custom configuration is disabled", config.Source)
+			c.logger.Warn("skipping configuration snippet on %s: custom configuration is disabled", source)
 			return
 		}
 		for _, line := range lines {
 			if firstToken(line) == keyword {
-				c.logger.Warn("skipping configuration snippet on %s: keyword '%s' not allowed", config.Source, keyword)
+				c.logger.Warn("skipping configuration snippet on %s: keyword '%s' not allowed", source, keyword)
 				return
 			}
 		}

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -1316,9 +1316,15 @@ func TestCors(t *testing.T) {
 }
 
 func TestCustomConfig(t *testing.T) {
+	defaultSource := &Source{
+		Type:      "Ingress",
+		Namespace: "default",
+		Name:      "app",
+	}
 	testCases := []struct {
 		disabled []string
 		config   string
+		source   *Source
 		expected []string
 		logging  string
 	}{
@@ -1331,13 +1337,14 @@ func TestCustomConfig(t *testing.T) {
 		{
 			disabled: []string{"server"},
 			config:   "  server srv001 127.0.0.1:8080",
+			source:   defaultSource,
 			logging:  `WARN skipping configuration snippet on Ingress 'default/app': keyword 'server' not allowed`,
 		},
 		// 2
 		{
 			disabled: []string{"*"},
 			config:   "  server srv001 127.0.0.1:8080",
-			logging:  `WARN skipping configuration snippet on Ingress 'default/app': custom configuration is disabled`,
+			logging:  `WARN skipping configuration snippet on global config: custom configuration is disabled`,
 		},
 		// 3
 		{
@@ -1363,6 +1370,7 @@ func TestCustomConfig(t *testing.T) {
   acl rootpath path /
   http-request set-header x-id 1 if rootpath
 `,
+			source:  defaultSource,
 			logging: `WARN skipping configuration snippet on Ingress 'default/app': keyword 'acl' not allowed`,
 		},
 		// 6
@@ -1374,15 +1382,10 @@ func TestCustomConfig(t *testing.T) {
 	}
 	for i, test := range testCases {
 		c := setup(t)
-		source := &Source{
-			Type:      "Ingress",
-			Namespace: "default",
-			Name:      "app",
-		}
 		ann := map[string]map[string]string{
 			"/": {ingtypes.BackConfigBackend: test.config},
 		}
-		d := c.createBackendMappingData("default/app", source, map[string]string{}, ann, []string{"/"})
+		d := c.createBackendMappingData("default/app", test.source, map[string]string{}, ann, []string{"/"})
 		updater := c.createUpdater()
 		updater.options.DisableKeywords = test.disabled
 		updater.buildBackendCustomConfig(d)


### PR DESCRIPTION
The mitigation of CVE-2021-25740 added a command-line option to allow a sysadmin to partially or completely remove backend configuration snippet. This option added a new code where there was only a straightforward assignment. This code fails on how to check if a configuration has a source and, instead of adjust the logging message, the whole assignment was being skipped. However a global configuration by definition doesn't have a source, leading to backend configuration snippet being skipped if not configured via ingress or service annotation.

This fix should be merged up to v0.10.