### PR TITLE
Add --ingress-class-precedence to allow IngressClass taking precedence over annotation

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -36,6 +36,7 @@ The following command-line options are supported:
 | [`--health-check-path`](#stats)                         | path                       | `/healthz`              |       |
 | [`--healthz-port`](#stats)                              | port number                | `10254`                 |       |
 | [`--ingress-class`](#ingress-class)                     | name                       | `haproxy`               |       |
+| [`--ingress-class-precedence`](#ingress-class)          | [true\|false]              | `false`                 | v0.13.5 |
 | [`--kubeconfig`](#kubeconfig)                           | /path/to/kubeconfig        | in cluster config       |       |
 | [`--master-socket`](#master-socket)                     | socket path                | use embedded haproxy    | v0.12 |
 | [`--max-old-config-files`](#max-old-config-files)       | num of files               | `0`                     |       |
@@ -245,6 +246,8 @@ link to these IngressClasses will be added to the configuration. The `--controll
 command-line option customizes the controller name, allowing to run more than one HAProxy Ingress
 in the same cluster. Configuring `--controller-class=staging` would listen to IngressClasses whose
 controller name is `haproxy-ingress.github.io/controller/staging`.
+* `--ingress-class-precedence`: defines if IngressClass resource should take precedence over
+kubernetes.io/ingress.class annotation if both are defined and conflicting.
 * `--watch-ingress-without-class`: defines if this controller should also listen to ingress resources
 that doesn't declare neither the `kubernetes.io/ingress.class` annotation nor the
 `<ingress>.spec.ingressClassName` field. The default since v0.12 is to ignore ingress without class

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -64,6 +64,7 @@ type Configuration struct {
 
 	DefaultService           string
 	IngressClass             string
+	IngressClassPrecedence   bool
 	ControllerName           string
 	WatchIngressWithoutClass bool
 	WatchGateway             bool

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -54,6 +54,10 @@ default backend.`)
 		ingressClass = flags.String("ingress-class", "haproxy",
 			`Name of the IngressClass to route through this controller.`)
 
+		ingressClassPrecedence = flags.Bool("ingress-class-precedence", false,
+			`Defines if IngressClass resource should take precedence over
+kubernetes.io/ingress.class annotation if both are defined and conflicting.`)
+
 		reloadStrategy = flags.String("reload-strategy", "reusesocket",
 			`Name of the reload strategy. Options are: native or reusesocket`)
 
@@ -464,6 +468,7 @@ tracked.`)
 		WaitBeforeUpdate:         *waitBeforeUpdate,
 		DefaultService:           *defaultSvc,
 		IngressClass:             *ingressClass,
+		IngressClassPrecedence:   *ingressClassPrecedence,
 		ControllerName:           controllerName,
 		WatchIngressWithoutClass: *watchIngressWithoutClass,
 		WatchGateway:             *watchGateway,

--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -706,9 +706,17 @@ func (c *k8scache) IsValidIngress(ing *networking.Ingress) bool {
 		}
 	}
 
-	// annotation has precedence, warn if both class and annotation are configured and they conflict
+	// annotation has precedence by default,
+	// c.cfg.IngressClassPrecedence as `true` gives precedence to IngressClass
+	// if both class and annotation are configured and they conflict
 	if hasAnn {
 		if hasClass && fromAnn != fromClass {
+			if c.cfg.IngressClassPrecedence {
+				c.logger.Warn("ingress %s/%s has conflicting ingress class configuration, "+
+					"using ingress class reference because of --ingress-class-precedence enabled (%t)",
+					ing.Namespace, ing.Name, fromClass)
+				return fromClass
+			}
 			c.logger.Warn("ingress %s/%s has conflicting ingress class configuration, using annotation reference (%t)",
 				ing.Namespace, ing.Name, fromAnn)
 		}


### PR DESCRIPTION
When defined as true, `--controller-class-precedence` with give a precedence to controller class over kubernetes.io/ingress.class annotation. This will be especially useful while migrating from one approach to another having zero downtime in mind. It can be removed once the support of ingress annotation is fully disabled.

I am here referring to situation when both IngressClassName and ingress annotation are defined in Ingress which results in
```W0923 07:50:41.725353       7 cache.go:715] ingress prometheus/prometheus has conflicting ingress class configuration, using annotation reference (false)``` in haproxy ingress controller logs.