### PR TITLE
add acme-preferred-chain config key

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -293,6 +293,7 @@ The table below describes all supported configuration keys.
 | [`acme-emails`](#acme)                               | email1,email2,...                       | Global  |                    |
 | [`acme-endpoint`](#acme)                             | [`v2-staging`\|`v2`\|`endpoint`]        | Global  |                    |
 | [`acme-expiring`](#acme)                             | number of days                          | Global  | `30`               |
+| [`acme-preferred-chain`](#acme)                      | CN (Common Name) of the issuer          | Host    |                    |
 | [`acme-shared`](#acme)                               | [true\|false]                           | Global  | `false`            |
 | [`acme-terms-agreed`](#acme)                         | [true\|false]                           | Global  | `false`            |
 | [`affinity`](#affinity)                              | affinity type                           | Backend |                    |
@@ -500,14 +501,15 @@ The table below describes all supported configuration keys.
 
 ## Acme
 
-| Configuration key   | Scope    | Default | Since |
-|---------------------|----------|---------|-------|
-| `acme-emails`       | `Global` |         | v0.9  |
-| `acme-endpoint`     | `Global` |         | v0.9  |
-| `acme-expiring`     | `Global` | `30`    | v0.9  |
-| `acme-shared`       | `Global` | `false` | v0.9  |
-| `acme-terms-agreed` | `Global` | `false` | v0.9  |
-| `cert-signer`       | `Host`   |         | v0.9  |
+| Configuration key      | Scope    | Default | Since   |
+|------------------------|----------|---------|---------|
+| `acme-emails`          | `Global` |         | v0.9    |
+| `acme-endpoint`        | `Global` |         | v0.9    |
+| `acme-expiring`        | `Global` | `30`    | v0.9    |
+| `acme-preferred-chain` | `Host`   |         | v0.13.5 |
+| `acme-shared`          | `Global` | `false` | v0.9    |
+| `acme-terms-agreed`    | `Global` | `false` | v0.9    |
+| `cert-signer`          | `Host`   |         | v0.9    |
 
 Configures dynamic options used to authorize and sign certificates against a server
 which implements the acme protocol, version 2.
@@ -520,6 +522,7 @@ Supported acme configuration keys:
 * `acme-emails`: mandatory, a comma-separated list of emails used to configure the client account. The account will be updated if this option is changed.
 * `acme-endpoint`: mandatory, endpoint of the acme environment. `v2-staging` and `v02-staging` are alias to `https://acme-staging-v02.api.letsencrypt.org`, while `v2` and `v02` are alias to `https://acme-v02.api.letsencrypt.org`.
 * `acme-expiring`: how many days before expiring a certificate should be considered old and should be updated. Defaults to `30` days.
+* `acme-preferred-chain`: optional, defines the Issuer's CN (Common Name) of the topmost certificate in the chain, if the acme server offers multiple certificate chains. The default certificate chain will be used if empty or no match is found. Note that changing this option will not force a new certificate to be issued if a valid one is already in place and actual and preferred chains differ. A new certificate can be emitted by changing the secret name in the ingress resource, or removing the secret being referenced.
 * `acme-shared`: defines if another certificate signer is running in the cluster. If `false`, the default value, any request to `/.well-known/acme-challenge/` is sent to the local acme server despite any ingress object configuration. Otherwise, if `true`, a configured ingress object would take precedence.
 * `acme-terms-agreed`: mandatory, it should be defined as `true`, otherwise certificates won't be issued.
 * `cert-signer`: defines the certificate signer that should be used to authorize and sign new certificates. The only supported value is `"acme"`. Add this config as an annotation in the ingress object that should have its certificate managed by haproxy-ingress and signed by the configured acme environment. The annotation `kubernetes.io/tls-acme: "true"` is also supported if the command-line option `--acme-track-tls-annotation` is used.

--- a/pkg/acme/signer_test.go
+++ b/pkg/acme/signer_test.go
@@ -34,58 +34,58 @@ func TestNotifyVerify(t *testing.T) {
 	testCases := []struct {
 		input     string
 		expiresIn time.Duration
-		cert string
+		cert      string
 		logging   string
 	}{
 		// 0
 		{
-			input:     "s1,d1.local",
+			input:     "s1,,d1.local",
 			expiresIn: 10 * 24 * time.Hour,
-			cert: dumbcrt,
+			cert:      dumbcrt,
 			logging: `
 INFO-V(2) acme: skipping sign, certificate is updated: secret=s1 domain(s)=d1.local`,
 		},
 		// 1
 		{
-			input:     "s1,d2.local",
+			input:     "s1,,d2.local",
 			expiresIn: -10 * 24 * time.Hour,
-			cert: dumbcrt,
+			cert:      dumbcrt,
 			logging: `
 INFO acme: authorizing: id=1 secret=s1 domain(s)=d2.local endpoint=https://acme-v2.local reason='certificate expires in 2020-12-01 16:33:14 +0000 UTC'
-INFO acme: new certificate issued: id=1 secret=s1 domain(s)=d2.local`,
+INFO acme: new certificate issued: id=1 secret=s1 domain(s)=d2.local preferred-chain=`,
 		},
 		// 2
 		{
-			input:     "s1,d3.local",
+			input:     "s1,,d3.local",
 			expiresIn: 10 * 24 * time.Hour,
-			cert: dumbcrt,
+			cert:      dumbcrt,
 			logging: `
 INFO acme: authorizing: id=1 secret=s1 domain(s)=d3.local endpoint=https://acme-v2.local reason='added one or more domains to an existing certificate'
-INFO acme: new certificate issued: id=1 secret=s1 domain(s)=d3.local`,
+INFO acme: new certificate issued: id=1 secret=s1 domain(s)=d3.local preferred-chain=`,
 		},
 		// 3
 		{
-			input:     "s2,d1.local",
+			input:     "s2,,d1.local",
 			expiresIn: 10 * 24 * time.Hour,
-			cert: dumbcrt,
+			cert:      dumbcrt,
 			logging: `
 INFO acme: authorizing: id=1 secret=s2 domain(s)=d1.local endpoint=https://acme-v2.local reason='certificate does not exist (secret not found: s2)'
-INFO acme: new certificate issued: id=1 secret=s2 domain(s)=d1.local`,
+INFO acme: new certificate issued: id=1 secret=s2 domain(s)=d1.local preferred-chain=`,
 		},
 		{
-			input:     "s1,s3.dev.local",
+			input:     "s1,,s3.dev.local",
 			expiresIn: 10 * 24 * time.Hour,
-			cert: dumbwildcardcrt,
+			cert:      dumbwildcardcrt,
 			logging: `
 INFO-V(2) acme: skipping sign, certificate is updated: secret=s1 domain(s)=s3.dev.local`,
 		},
 		{
-			input:     "s1,other.s3.dev.local",
+			input:     "s1,,other.s3.dev.local",
 			expiresIn: 10 * 24 * time.Hour,
-			cert: dumbwildcardcrt,
+			cert:      dumbwildcardcrt,
 			logging: `
 INFO acme: authorizing: id=1 secret=s1 domain(s)=other.s3.dev.local endpoint=https://acme-v2.local reason='added one or more domains to an existing certificate'
-INFO acme: new certificate issued: id=1 secret=s1 domain(s)=other.s3.dev.local`,
+INFO acme: new certificate issued: id=1 secret=s1 domain(s)=other.s3.dev.local preferred-chain=`,
 		},
 	}
 	c := setup(t)
@@ -132,8 +132,8 @@ func (c *config) newSigner() *signer {
 
 type clientMock struct{}
 
-func (c *clientMock) Sign(domains []string) (crt, key []byte, err error) {
-	return nil, nil, nil
+func (c *clientMock) Sign(domains []string, preferredChain string) (crt, key []byte, err error) {
+	return []byte("fake-crt"), []byte("fake-key"), nil
 }
 
 type cache struct {

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -475,7 +475,13 @@ func (c *converter) syncIngressHTTP(source *annotations.Source, ing *networking.
 			if tls.SecretName != "" {
 				secretName := ing.Namespace + "/" + tls.SecretName
 				ingName := ing.Namespace + "/" + ing.Name
-				c.haproxy.AcmeData().Storages().Acquire(secretName).AddDomains(tls.Hosts)
+				acmeStorage := c.haproxy.AcmeData().Storages().Acquire(secretName)
+				acmeStorage.AddDomains(tls.Hosts)
+				if preferredChain := annHost[ingtypes.HostAcmePreferredChain]; preferredChain != "" {
+					if err := acmeStorage.AssignPreferredChain(preferredChain); err != nil {
+						c.logger.Warn("preferred chain ignored on %v due to an error: %v", source, err)
+					}
+				}
 				c.tracker.TrackNames(convtypes.ResourceIngress, ingName, convtypes.ResourceAcmeData, secretName)
 			} else {
 				c.logger.Warn("skipping cert signer of %v: missing secret name", source)

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -36,6 +36,7 @@ var (
 
 // Host Annotations
 const (
+	HostAcmePreferredChain     = "acme-preferred-chain"
 	HostAppRoot                = "app-root"
 	HostAuthTLSErrorPage       = "auth-tls-error-page"
 	HostAuthTLSSecret          = "auth-tls-secret"
@@ -59,6 +60,7 @@ const (
 var (
 	// AnnHost ...
 	AnnHost = map[string]struct{}{
+		HostAcmePreferredChain:     {},
 		HostAppRoot:                {},
 		HostAuthTLSErrorPage:       {},
 		HostAuthTLSSecret:          {},

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -132,10 +132,13 @@ func (i *instance) acmeEnsureConfig(acmeConfig *hatypes.AcmeData) bool {
 
 func (i *instance) acmeAddStorage(storage string) {
 	// TODO change to a proper entity
-	index := strings.Index(storage, ",")
-	name := storage[:index]
-	domains := storage[index+1:]
-	i.logger.InfoV(3, "enqueue certificate for processing: storage=%s domain(s)=%s", name, domains)
+	items := strings.Split(storage, ",")
+	if len(items) >= 2 {
+		name := items[0]
+		prefChain := items[1]
+		domains := strings.Join(items[2:], ",")
+		i.logger.InfoV(3, "enqueue certificate for processing: storage=%s domain(s)=%s preferred-chain=%s", name, domains, prefChain)
+	}
 	i.options.AcmeQueue.Add(storage)
 }
 

--- a/pkg/haproxy/types/global.go
+++ b/pkg/haproxy/types/global.go
@@ -83,7 +83,7 @@ func buildAcmeStorages(items map[string]*AcmeCerts) []string {
 			j++
 		}
 		sort.Strings(certs)
-		storages[i] = name + "," + strings.Join(certs, ",")
+		storages[i] = name + "," + item.preferredChain + "," + strings.Join(certs, ",")
 		i++
 	}
 	return storages
@@ -119,6 +119,15 @@ func (c *AcmeCerts) AddDomains(domains []string) {
 	for _, domain := range domains {
 		c.certs[domain] = struct{}{}
 	}
+}
+
+// AssignPreferredChain ...
+func (c *AcmeCerts) AssignPreferredChain(preferredChain string) error {
+	if c.preferredChain != "" && c.preferredChain != preferredChain {
+		return fmt.Errorf("preferred chain already assigned to '%s'", c.preferredChain)
+	}
+	c.preferredChain = preferredChain
+	return nil
 }
 
 // IsExternal ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -38,7 +38,8 @@ type AcmeStorages struct {
 
 // AcmeCerts ...
 type AcmeCerts struct {
-	certs map[string]struct{}
+	certs          map[string]struct{}
+	preferredChain string
 }
 
 // Acme ...


### PR DESCRIPTION
Since the deprecation of DST X3 root CA, which used to sign Let's Encrypt root CA, a few issues raised and can be summarized as:

* If the topmost certificate of the provided chain is issued by `DST X3`, clients that has `DST X3` on their trusted CAs bundle, care about the expiration of their CAs, and a somewhat old openssl, will fail to trust in the Let's Encrypt chain even if they trust in the Let's Encrypt's `ISRG Root X1`. Clients should update openssl or remove `DST X3` from their trusted CAs. This is the default chain provided by Let's Encrypt;
* If the topmost certificate is issed by `ISRG Root X1`, which is Let's Encrypt's root CA, old clients will fail to trust Let's Encrypt certificate, mostly Android older than 7.1.1.

Let's Encrypt production API adds alternative chains that can be chosen by the Common Name of its topmost certificate. This is the purpose of this configuration key, so sys admins can choose the chain that will have the lesser impact on their users.

Acme client was updated in a way that a mistyped preferred chain doesn't fail the emission of the certificate, which avoids to being blocked by the acme server due to the amount of new orders.

As a first implementation that's being planned to be merged to v0.13, it wasn't added the ability to identify that a preferred chain was changed. Such change would need to change even more code, making this even less secure to be merged to a stable version.

Should be merged to v0.13 so users can benefit from this alternative as soon as possible.