### PR TITLE
Add disableKeywords only if defined

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strings"
 	"sync"
 	"time"
 
@@ -153,7 +152,7 @@ func (hc *HAProxyController) configController() {
 		DefaultCrtSecret: hc.cfg.DefaultSSLCertificate,
 		FakeCrtFile:      hc.createFakeCrtFile(),
 		FakeCAFile:       hc.createFakeCAFile(),
-		DisableKeywords:  strings.Split(hc.cfg.DisableConfigKeywords, ","),
+		DisableKeywords:  utils.Split(hc.cfg.DisableConfigKeywords, ","),
 		AcmeTrackTLSAnn:  hc.cfg.AcmeTrackTLSAnn,
 		TrackInstances:   hc.cfg.TrackOldInstances,
 		HasGateway:       hc.cache.hasGateway(),

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -532,6 +532,9 @@ func (c *updater) buildBackendCustomConfig(d *backData) {
 		source = config.Source.String()
 	}
 	for _, keyword := range c.options.DisableKeywords {
+		if keyword == "" {
+			continue
+		}
 		if keyword == "*" {
 			c.logger.Warn("skipping configuration snippet on %s: custom configuration is disabled", source)
 			return

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -1379,6 +1379,17 @@ func TestCustomConfig(t *testing.T) {
 			config:   "  http-request set-header x-id 1 if { path / }",
 			expected: []string{"  http-request set-header x-id 1 if { path / }"},
 		},
+		// 7
+		{
+			disabled: []string{"server", ""},
+			config: `
+  acl rootpath path /
+
+  http-request set-header x-id 1 if rootpath
+`,
+			source:   defaultSource,
+			expected: []string{"", "  acl rootpath path /", "", "  http-request set-header x-id 1 if rootpath"},
+		},
 	}
 	for i, test := range testCases {
 		c := setup(t)


### PR DESCRIPTION
`--disable-config-keywords` command-line option allows to define a comma separated list of blacklisted keywords. If not declared, an empty string is used as an input to `Split()`. This empty string is however converted in an array of one element with an empty string, and such empty keyword matches with empty lines, denying configurations with empty lines. This update ignores empty entries when parsing the custom snippet, and also `TrimSpace()` all the options in order to properly match with the custom snippet tokenizer.