### PR TITLE
Allow setting HTTP2 Initial Window Size and set larger default

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -496,6 +496,7 @@ The table below describes all supported configuration keys.
 | [`waf-mode`](#waf)                                   | [deny\|detect]                          | Path    | `deny` (if waf is set) |
 | [`whitelist-source-range`](#allowlist)               | Comma-separated IPs or CIDRs            | Path    |                    |
 | [`worker-max-reloads`](#master-worker)               | number of reloads                       | Global  | `0`                |
+| ['http2-initial-window-size']                        | HTTP2 initial window size (bytes)       | Global  | `268435456`        |
 
 ---
 
@@ -2668,3 +2669,21 @@ The default behavior here is `deny` if `waf` is set to `modsecurity`.
 See also:
 
 * [Modsecurity](#modsecurity) configuration keys.
+
+## HTTP2 initial window size
+
+| Configuration key             | Scope    | Default     | Since  |
+|-------------------------------|----------|-------------|--------|
+| `http2-initial-window-size`   | `Global` | `268435456` | v0.13.6|
+
+This setting affects upload speeds over haproxy-ingress. Without a sufficiently large initial window size,
+uploads may appear slow if latency is high enough.
+For example, to sustain a 200Mbit connection using the default haproxy intial window size of `65535`,
+RTT cannot be higher than 2.6ms:
+`65535 / 25000000 = 0.0026214`
+
+Therefore, haproxy-ingress will apply a larger size by default. 
+
+See also:
+
+* https://cbonte.github.io/haproxy-dconv/2.2/configuration.html#tune.h2.initial-window-size

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -156,6 +156,7 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.Master.WorkerMaxReloads = mapper.Get(ingtypes.GlobalWorkerMaxReloads).Int()
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()
+	d.global.HTTP2InitialWindowSize = mapper.Get(ingtypes.GlobalHTTP2InitialWindowSize).Int()
 	//
 	c.haproxy.Frontend().RedirectFromCode = mapper.Get(ingtypes.GlobalRedirectFromCode).Int()
 	c.haproxy.Frontend().RedirectToCode = mapper.Get(ingtypes.GlobalRedirectToCode).Int()

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -114,5 +114,6 @@ func createDefaults() map[string]string {
 		types.GlobalUseForwardedProto:            "true",
 		types.GlobalUseHTX:                       "true",
 		types.GlobalDefaultBackendRedirectCode:   "302",
+		types.GlobalHTTP2InitialWindowSize:       "268435456",
 	}
 }

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -111,4 +111,5 @@ const (
 	GlobalUseHTX                       = "use-htx"
 	GlobalUseProxyProtocol             = "use-proxy-protocol"
 	GlobalWorkerMaxReloads             = "worker-max-reloads"
+	GlobalHTTP2InitialWindowSize       = "http2-initial-window-size"
 )

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1155,6 +1155,7 @@ global
     ssl-default-bind-options no-sslv3
     ssl-default-server-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256
+    tune.h2.initial-window-size 536870912
 defaults
     log global
     maxconn 2000
@@ -1213,6 +1214,7 @@ global
     ssl-default-bind-options no-sslv3
     ssl-default-server-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256
+    tune.h2.initial-window-size 536870912
 defaults
     log global
     maxconn 2000
@@ -1274,6 +1276,7 @@ global
     ssl-default-bind-options no-sslv3
     ssl-default-server-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256
+    tune.h2.initial-window-size 536870912
 <<defaults>>
 backend default_empty_8080
     mode http
@@ -1405,6 +1408,7 @@ global
     ssl-default-bind-options no-sslv3
     ssl-default-server-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256
+    tune.h2.initial-window-size 536870912
 <<defaults>>
 backend default_empty_8080
     mode http
@@ -3730,6 +3734,7 @@ global
     ssl-default-bind-options no-sslv3
     ssl-default-server-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256
+    tune.h2.initial-window-size 536870912
 <<defaults>>
 backend d1_app_8080
     mode http
@@ -4537,6 +4542,7 @@ func (c *testConfig) configGlobal(global *hatypes.Global) {
 	global.Timeout.Stop = "15m"
 	global.Timeout.Tunnel = "1h"
 	global.UseHTX = true
+	global.HTTP2InitialWindowSize = 268435456 * 2
 }
 
 var endpointS0 = &hatypes.Endpoint{
@@ -4638,7 +4644,8 @@ func (c *testConfig) checkConfigFile(expected, fileName string) {
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256
     ssl-default-bind-options no-sslv3
     ssl-default-server-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
-    ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256`,
+    ssl-default-server-ciphersuites TLS_AES_128_GCM_SHA256
+    tune.h2.initial-window-size 536870912`,
 		"<<defaults>>": `defaults
     log global
     maxconn 2000

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -85,6 +85,7 @@ type Global struct {
 	CustomProxy             map[string][]string
 	CustomSections          []string
 	CustomTCP               []string
+	HTTP2InitialWindowSize  int
 }
 
 // GlobalBindConfig ...

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -135,6 +135,9 @@ global
 {{- if $global.SSL.BackendCipherSuites }}
     ssl-default-server-ciphersuites {{ $global.SSL.BackendCipherSuites }}
 {{- end }}
+{{- if $global.HTTP2InitialWindowSize }}
+    tune.h2.initial-window-size {{ $global.HTTP2InitialWindowSize }}
+{{- end }}
 {{- range $snippet := $global.CustomConfig }}
     {{ $snippet }}
 {{- end }}


### PR DESCRIPTION
Uploads using haproxy-ingress to backend servers in k8s were weirdly slow, while uploads to other endpoints to services on the same server could utilize my full upload speed.

While trying to find the root cause for this, I noticed that latency had a huge impact on the transfer speed.

Then I found this haproxy issue: https://github.com/haproxy/haproxy/issues/293

Adding the described option to the global section of haproxy-ingress fixed my upload bandwidth issues.

I think increasing the initial window size by default should be beneficial to most haproxy-ingress use cases, therefore I created this PR.

The default value will at most allow for 25Mbit/s uploads at 25ms RTT (which is what I experienced):
```
>>> 65535 (bytes) / 0.025 (s)
2621400.0
>>> 2621400.0 (bytes) / 1024
2559.9609375
```

The new default of `268435456` bytes is also used by envoy: https://github.com/envoyproxy/envoy/blame/main/api/envoy/api/v2/core/protocol.proto#L179
nginx seems to just set the maximum window size once a transfer starts: https://github.com/nginx/nginx/blob/master/src/http/v2/ngx_http_v2.c#L309

Using `268435456` bytes should fix this issue for most if not all use-cases, theoretically allowing a 10Gbit Link to be saturated at up to ~214ms RTT:
```
>>> 268435456 (bytes) / 1250000000 (bytes/s)
0.2147483648
```