### PR TITLE
Add match method on all var() sample fetch method

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -123,31 +123,31 @@ func TestBackends(t *testing.T) {
     # path04 = d1.local/sub
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
     http-request set-var(txn.hdr_origin0) req.hdr(Origin)
-    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS { var(txn.pathID) path01 path02 }
-    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) path01 path02 }
+    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS { var(txn.pathID) -m str path01 path02 }
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) -m str path01 path02 }
     http-request set-var(txn.hdr_origin1) req.hdr(Origin)
-    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS { var(txn.pathID) path03 }
-    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) path03 }
-    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS { var(txn.pathID) path04 }
-    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) path04 }
-    acl cors_allow_origin0 var(txn.hdr_origin0) http://d11.local https://d12.local
-    http-response set-header Access-Control-Allow-Origin  "%[var(txn.hdr_origin0)]" if { var(txn.pathID) path01 path02 } cors_allow_origin0
-    http-response set-header Access-Control-Allow-Origin  "http://d11.local" if { var(txn.pathID) path01 path02 } !cors_allow_origin0
-    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) path01 path02 }
-    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if { var(txn.pathID) path01 path02 }
-    http-response set-header Vary %[res.hdr(Vary)],Origin if { res.hdr(Vary) -m found } { var(txn.pathID) path01 path02 }
-    http-response set-header Vary Origin if ! { res.hdr(Vary) -m found } { var(txn.pathID) path01 path02 }
-    acl cors_allow_origin1 var(txn.hdr_origin1) https://d21.local https://d22.local https://d23.local https://d24.local https://d25.local
-    acl cors_allow_origin1 var(txn.hdr_origin1) https://d26.local
-    http-response set-header Access-Control-Allow-Origin  "%[var(txn.hdr_origin1)]" if { var(txn.pathID) path03 } cors_allow_origin1
-    http-response set-header Access-Control-Allow-Origin  "https://d21.local" if { var(txn.pathID) path03 } !cors_allow_origin1
-    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) path03 }
-    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if { var(txn.pathID) path03 }
-    http-response set-header Vary %[res.hdr(Vary)],Origin if { res.hdr(Vary) -m found } { var(txn.pathID) path03 }
-    http-response set-header Vary Origin if ! { res.hdr(Vary) -m found } { var(txn.pathID) path03 }
-    http-response set-header Access-Control-Allow-Origin  "https://d31.local" if { var(txn.pathID) path04 }
-    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) path04 }
-    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if { var(txn.pathID) path04 }`,
+    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS { var(txn.pathID) -m str path03 }
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) -m str path03 }
+    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS { var(txn.pathID) -m str path04 }
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) -m str path04 }
+    acl cors_allow_origin0 var(txn.hdr_origin0) -m str http://d11.local https://d12.local
+    http-response set-header Access-Control-Allow-Origin  "%[var(txn.hdr_origin0)]" if { var(txn.pathID) -m str path01 path02 } cors_allow_origin0
+    http-response set-header Access-Control-Allow-Origin  "http://d11.local" if { var(txn.pathID) -m str path01 path02 } !cors_allow_origin0
+    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) -m str path01 path02 }
+    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if { var(txn.pathID) -m str path01 path02 }
+    http-response set-header Vary %[res.hdr(Vary)],Origin if { res.hdr(Vary) -m found } { var(txn.pathID) -m str path01 path02 }
+    http-response set-header Vary Origin if ! { res.hdr(Vary) -m found } { var(txn.pathID) -m str path01 path02 }
+    acl cors_allow_origin1 var(txn.hdr_origin1) -m str https://d21.local https://d22.local https://d23.local https://d24.local https://d25.local
+    acl cors_allow_origin1 var(txn.hdr_origin1) -m str https://d26.local
+    http-response set-header Access-Control-Allow-Origin  "%[var(txn.hdr_origin1)]" if { var(txn.pathID) -m str path03 } cors_allow_origin1
+    http-response set-header Access-Control-Allow-Origin  "https://d21.local" if { var(txn.pathID) -m str path03 } !cors_allow_origin1
+    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) -m str path03 }
+    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if { var(txn.pathID) -m str path03 }
+    http-response set-header Vary %[res.hdr(Vary)],Origin if { res.hdr(Vary) -m found } { var(txn.pathID) -m str path03 }
+    http-response set-header Vary Origin if ! { res.hdr(Vary) -m found } { var(txn.pathID) -m str path03 }
+    http-response set-header Access-Control-Allow-Origin  "https://d31.local" if { var(txn.pathID) -m str path04 }
+    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) -m str path04 }
+    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if { var(txn.pathID) -m str path04 }`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -165,7 +165,7 @@ func TestBackends(t *testing.T) {
     http-request set-var(txn.hdr_origin0) req.hdr(Origin)
     http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS
     http-request use-service lua.send-cors-preflight if METH_OPTIONS
-    acl cors_allow_origin0 var(txn.hdr_origin0) https://d11.local https://d12.local
+    acl cors_allow_origin0 var(txn.hdr_origin0) -m str https://d11.local https://d12.local
     http-response set-header Access-Control-Allow-Origin  "%[var(txn.hdr_origin0)]" if cors_allow_origin0
     http-response set-header Access-Control-Allow-Origin  "https://d11.local" if !cors_allow_origin0
     http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS"
@@ -243,12 +243,12 @@ func TestBackends(t *testing.T) {
     # path01 = d1.local/
     # path02 = d1.local/sub
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS { var(txn.pathID) path01 }
-    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) path01 }
-    http-response set-header Access-Control-Allow-Origin  "*" if { var(txn.pathID) path01 }
-    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) path01 }
-    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if { var(txn.pathID) path01 }
-    http-response set-header Access-Control-Allow-Credentials "true" if { var(txn.pathID) path01 }`,
+    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS { var(txn.pathID) -m str path01 }
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) -m str path01 }
+    http-response set-header Access-Control-Allow-Origin  "*" if { var(txn.pathID) -m str path01 }
+    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) -m str path01 }
+    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if { var(txn.pathID) -m str path01 }
+    http-response set-header Access-Control-Allow-Credentials "true" if { var(txn.pathID) -m str path01 }`,
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local#/sub path02
@@ -283,8 +283,8 @@ d1.local#/ path01`,
     # path02 = d1.local/path
     # path03 = d1.local/uri
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-response set-header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload" if https-request { var(txn.pathID) path01 }
-    http-response set-header Strict-Transport-Security "max-age=15768000" if https-request { var(txn.pathID) path02 path03 }`,
+    http-response set-header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload" if https-request { var(txn.pathID) -m str path01 }
+    http-response set-header Strict-Transport-Security "max-age=15768000" if https-request { var(txn.pathID) -m str path02 path03 }`,
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local#/uri path03
@@ -339,9 +339,9 @@ d1.local#/ path01`,
     # path02 = d1.local/path2
     # path03 = d1.local/path3
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request replace-path ^/path1(.*)$       /sub1\1     if { var(txn.pathID) path01 }
-    http-request replace-path ^/path2(.*)$       /sub2\1     if { var(txn.pathID) path02 }
-    http-request replace-path ^/path3(.*)$       /sub2\1     if { var(txn.pathID) path03 }`,
+    http-request replace-path ^/path1(.*)$       /sub1\1     if { var(txn.pathID) -m str path01 }
+    http-request replace-path ^/path2(.*)$       /sub2\1     if { var(txn.pathID) -m str path02 }
+    http-request replace-path ^/path3(.*)$       /sub2\1     if { var(txn.pathID) -m str path03 }`,
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local#/path3 path03
@@ -359,7 +359,7 @@ d1.local#/path1 path01`,
     # path01 = d1.local/app
     # path02 = d1.local/path
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request redirect scheme https if !https-request { var(txn.pathID) path01 }`,
+    http-request redirect scheme https if !https-request { var(txn.pathID) -m str path01 }`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -372,7 +372,7 @@ d1.local#/path1 path01`,
     # path01 = d1.local/app
     # path02 = d1.local/path
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request redirect scheme https code 301 if !https-request { var(txn.pathID) path01 }`,
+    http-request redirect scheme https code 301 if !https-request { var(txn.pathID) -m str path01 }`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -388,11 +388,11 @@ d1.local#/path1 path01`,
     # path03 = d1.local/path
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
     acl allow_rule_src0 src 10.0.0.0/8 192.168.0.0/16
-    http-request deny if { var(txn.pathID) path01 path02 } !allow_rule_src0
+    http-request deny if { var(txn.pathID) -m str path01 path02 } !allow_rule_src0
     acl allow_rule_src1 src 192.168.95.0/24
     acl allow_exception_src1 src 192.168.95.11
-    http-request deny if { var(txn.pathID) path03 } allow_exception_src1
-    http-request deny if { var(txn.pathID) path03 } !allow_rule_src1`,
+    http-request deny if { var(txn.pathID) -m str path03 } allow_exception_src1
+    http-request deny if { var(txn.pathID) -m str path03 } !allow_rule_src1`,
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local#/path path03
@@ -421,9 +421,9 @@ d1.local#/api path02`,
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map) if !{ var(txn.pathID) -m found }
     http-request set-var(txn.pathID) var(req.base),map_reg(/etc/haproxy/maps/_back_d1_app_8080_idpath__regex.map) if !{ var(txn.pathID) -m found }
     acl allow_rule_src0 src 172.17.0.0/16
-    http-request deny if { var(txn.pathID) path01 } !allow_rule_src0
+    http-request deny if { var(txn.pathID) -m str path01 } !allow_rule_src0
     acl allow_rule_src1 src 10.0.0.0/8 192.168.0.0/16
-    http-request deny if { var(txn.pathID) path02 path03 path04 path05 } !allow_rule_src1`,
+    http-request deny if { var(txn.pathID) -m str path02 path03 path04 path05 } !allow_rule_src1`,
 			expFronts: "<<frontends-default-match-4>>",
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__exact.map": `
@@ -452,11 +452,11 @@ d1.local#/ path01`,
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
     acl allow_rule_src0 src 10.0.0.0/8
     acl allow_exception_src0 src 10.0.110.0/24
-    http-request deny if { var(txn.pathID) path01 } allow_exception_src0
-    http-request deny if { var(txn.pathID) path01 } !allow_rule_src0
+    http-request deny if { var(txn.pathID) -m str path01 } allow_exception_src0
+    http-request deny if { var(txn.pathID) -m str path01 } !allow_rule_src0
     acl deny_rule_src1 src 192.168.95.0/24
     acl deny_exception_src1 src 192.168.95.128/28
-    http-request deny if { var(txn.pathID) path02 } deny_rule_src1 !deny_exception_src1`,
+    http-request deny if { var(txn.pathID) -m str path02 } deny_rule_src1 !deny_exception_src1`,
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local#/app3 path03
@@ -479,13 +479,13 @@ d1.local#/app1 path01`,
     # path04 = d1.local/app4
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
     acl allow_rule_src0 src 10.0.0.0/8
-    http-request deny if { var(txn.pathID) path01 } !allow_rule_src0
+    http-request deny if { var(txn.pathID) -m str path01 } !allow_rule_src0
     acl allow_exception_src1 src 10.0.110.0/24
-    http-request deny if { var(txn.pathID) path02 } allow_exception_src1
+    http-request deny if { var(txn.pathID) -m str path02 } allow_exception_src1
     acl deny_rule_src1 src 192.168.95.0/24
-    http-request deny if { var(txn.pathID) path03 } deny_rule_src1
+    http-request deny if { var(txn.pathID) -m str path03 } deny_rule_src1
     acl deny_exception_src2 src 192.168.95.128/28
-    http-request deny if { var(txn.pathID) path04 } !deny_exception_src2`,
+    http-request deny if { var(txn.pathID) -m str path04 } !deny_exception_src2`,
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local#/app4 path04
@@ -510,7 +510,7 @@ d1.local#/app1 path01`,
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
     acl allow_rule_src1 src 1.1.1.1 1.1.1.2 1.1.1.3 1.1.1.4 1.1.1.5 1.1.1.6 1.1.1.7 1.1.1.8 1.1.1.9 1.1.1.10
     acl allow_rule_src1 src 1.1.1.11
-    http-request deny if { var(txn.pathID) path03 } !allow_rule_src1`,
+    http-request deny if { var(txn.pathID) -m str path03 } !allow_rule_src1`,
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local#/path path03
@@ -568,7 +568,7 @@ d1.local#/api path02`,
     # path01 = d1.local/
     # path02 = d1.local/app
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request use-service lua.send-413 if { var(txn.pathID) path02 } { req.body_size,sub(2048) gt 0 }`,
+    http-request use-service lua.send-413 if { var(txn.pathID) -m str path02 } { req.body_size,sub(2048) gt 0 }`,
 			expCheck: map[string]string{
 				"_back_d1_app_8080_idpath__begin.map": `
 d1.local#/app path02
@@ -610,9 +610,9 @@ d1.local#/ path01`,
     # path01 = d1.local/app1
     # path02 = d1.local/app2
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request set-header X-Real-IP %[src] if { var(txn.pathID) path01 }
-    http-request lua.auth-intercept _auth_4001 /oauth2/auth GET '*' '*' '*' if { var(txn.pathID) path01 }
-    http-request deny if !{ var(txn.auth_response_successful) -m bool } { var(txn.pathID) path01 }`,
+    http-request set-header X-Real-IP %[src] if { var(txn.pathID) -m str path01 }
+    http-request lua.auth-intercept _auth_4001 /oauth2/auth GET '*' '*' '*' if { var(txn.pathID) -m str path01 }
+    http-request deny if !{ var(txn.auth_response_successful) -m bool } { var(txn.pathID) -m str path01 }`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -630,9 +630,9 @@ d1.local#/ path01`,
     # path01 = d1.local/app1
     # path02 = d1.local/app2
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request set-header X-Real-IP %[src] if { var(txn.pathID) path01 }
-    http-request lua.auth-intercept _auth_4001 /oauth2/auth GET 'X-UserID1,X-Token1' 'X-UserID2,X-Token2' 'X-UserID3,X-Token3' if { var(txn.pathID) path01 }
-    http-request redirect location http://auth.local/auth1 if !{ var(txn.auth_response_successful) -m bool } { var(txn.pathID) path01 }`,
+    http-request set-header X-Real-IP %[src] if { var(txn.pathID) -m str path01 }
+    http-request lua.auth-intercept _auth_4001 /oauth2/auth GET 'X-UserID1,X-Token1' 'X-UserID2,X-Token2' 'X-UserID3,X-Token3' if { var(txn.pathID) -m str path01 }
+    http-request redirect location http://auth.local/auth1 if !{ var(txn.auth_response_successful) -m bool } { var(txn.pathID) -m str path01 }`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -651,10 +651,10 @@ d1.local#/ path01`,
     # path01 = d1.local/app1
     # path02 = d1.local/app2
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request set-header X-Real-IP %[src] if { var(txn.pathID) path01 }
-    http-request lua.auth-intercept _auth_4001 /oauth2/auth HEAD '*' '-' '-' if { var(txn.pathID) path01 }
-    http-request redirect location http://auth.local/login if !{ var(txn.auth_response_successful) -m bool } { var(txn.pathID) path01 }
-    http-request set-header X-Auth-Request-Email %[var(req.auth_response_header.x_auth_request_email)] if { var(req.auth_response_header.x_auth_request_email) -m found } { var(txn.pathID) path01 }`,
+    http-request set-header X-Real-IP %[src] if { var(txn.pathID) -m str path01 }
+    http-request lua.auth-intercept _auth_4001 /oauth2/auth HEAD '*' '-' '-' if { var(txn.pathID) -m str path01 }
+    http-request redirect location http://auth.local/login if !{ var(txn.auth_response_successful) -m bool } { var(txn.pathID) -m str path01 }
+    http-request set-header X-Auth-Request-Email %[var(req.auth_response_header.x_auth_request_email)] if { var(req.auth_response_header.x_auth_request_email) -m found } { var(txn.pathID) -m str path01 }`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -666,7 +666,7 @@ d1.local#/ path01`,
     # path01 = d1.local/app1
     # path02 = d1.local/app2
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request deny if { var(txn.pathID) path01 }`,
+    http-request deny if { var(txn.pathID) -m str path01 }`,
 		},
 		{
 			doconfig: func(g *hatypes.Global, h *hatypes.Host, b *hatypes.Backend) {
@@ -1356,18 +1356,18 @@ backend d1_app_8080
     http-request redirect scheme https if !https-request
     acl allow_rule_src0 src 10.0.0.0/8
     http-request deny if !allow_rule_src0
-    http-request set-var(txn.cors_max_age) str(0) if METH_OPTIONS { var(txn.pathID) ` + pathIDs01_30 + ` }
-    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) ` + pathIDs01_30 + ` }
-    http-request set-var(txn.cors_max_age) str(0) if METH_OPTIONS { var(txn.pathID) path31 }
-    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) path31 }
-    http-response set-header Strict-Transport-Security "max-age=0" if { var(txn.pathID) ` + pathIDs01_30 + ` }
-    http-response set-header Strict-Transport-Security "max-age=0" if { var(txn.pathID) path31 }
-    http-response set-header Access-Control-Allow-Origin  "*" if { var(txn.pathID) ` + pathIDs01_30 + ` }
-    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) ` + pathIDs01_30 + ` }
-    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent" if { var(txn.pathID) ` + pathIDs01_30 + ` }
-    http-response set-header Access-Control-Allow-Origin  "*" if { var(txn.pathID) path31 }
-    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) path31 }
-    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent" if { var(txn.pathID) path31 }
+    http-request set-var(txn.cors_max_age) str(0) if METH_OPTIONS { var(txn.pathID) -m str ` + pathIDs01_30 + ` }
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) -m str ` + pathIDs01_30 + ` }
+    http-request set-var(txn.cors_max_age) str(0) if METH_OPTIONS { var(txn.pathID) -m str path31 }
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS { var(txn.pathID) -m str path31 }
+    http-response set-header Strict-Transport-Security "max-age=0" if { var(txn.pathID) -m str ` + pathIDs01_30 + ` }
+    http-response set-header Strict-Transport-Security "max-age=0" if { var(txn.pathID) -m str path31 }
+    http-response set-header Access-Control-Allow-Origin  "*" if { var(txn.pathID) -m str ` + pathIDs01_30 + ` }
+    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) -m str ` + pathIDs01_30 + ` }
+    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent" if { var(txn.pathID) -m str ` + pathIDs01_30 + ` }
+    http-response set-header Access-Control-Allow-Origin  "*" if { var(txn.pathID) -m str path31 }
+    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if { var(txn.pathID) -m str path31 }
+    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent" if { var(txn.pathID) -m str path31 }
     server s1 172.17.0.11:8080 weight 100
 <<backends-default>>
 <<frontends-default>>
@@ -1494,11 +1494,11 @@ func TestInstanceFrontingProxy(t *testing.T) {
 		aclBackWithSockID = `
     acl fronting-proxy so_id 11
     acl https-request ssl_fc
-    acl https-request var(txn.proto) https`
+    acl https-request var(txn.proto) -m str https`
 		aclBackWithHdr = `
     acl fronting-proxy hdr(X-Forwarded-Proto) -m found
     acl https-request ssl_fc
-    acl https-request var(txn.proto) https`
+    acl https-request var(txn.proto) -m str https`
 		setHeaderWithACL = `
     http-request set-header X-SSL-Client-CN   %{+Q}[ssl_c_s_dn(cn)]   if local-offload
     http-request set-header X-SSL-Client-DN   %{+Q}[ssl_c_s_dn]       if local-offload
@@ -1779,9 +1779,9 @@ frontend _front_https
     http-request del-header X-SSL-Client-SHA1
     http-request del-header X-SSL-Client-Cert` + test.expectedACLFront + test.expectedSetvar + `
     http-request use-service lua.send-421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
-    http-request use-service lua.send-496 if { var(req.tls_nocrt_redir) _internal }
+    http-request use-service lua.send-496 if { var(req.tls_nocrt_redir) -m str _internal }
     http-request use-service lua.send-421 if !tls-has-crt tls-host-need-crt
-    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) _internal }
+    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) -m str _internal }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.snibackend)] if { var(req.snibackend) -m found }
     default_backend _error404
@@ -2204,9 +2204,9 @@ backend d1_app_8080
     http-request set-var(txn.pathID) var(req.path),map_str(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__exact.map)
     http-request set-var(txn.pathID) var(req.path),map_dir(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__prefix_02.map) if !{ var(txn.pathID) -m found }
     http-request set-var(txn.pathID) var(req.path),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__begin.map) if !{ var(txn.pathID) -m found }
-    http-request redirect scheme https if !https-request { var(txn.pathID) path01 }
-    http-request use-service lua.send-413 if { var(txn.pathID) path03 } { req.body_size,sub(32768) gt 0 }
-    http-request replace-path ^/app1/?(.*)$     /\1     if { var(txn.pathID) path02 }
+    http-request redirect scheme https if !https-request { var(txn.pathID) -m str path01 }
+    http-request use-service lua.send-413 if { var(txn.pathID) -m str path03 } { req.body_size,sub(32768) gt 0 }
+    http-request replace-path ^/app1/?(.*)$     /\1     if { var(txn.pathID) -m str path02 }
     server s1 172.17.0.11:8080 weight 100
 backend d2_app_8080
     mode http
@@ -2217,9 +2217,9 @@ backend d2_app_8080
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d2_app_8080_idpath__begin.map)
     http-request set-var(txn.pathID) var(req.path),map_str(/etc/haproxy/maps/_back_d2_app_8080_idpathdef__exact.map) if !{ var(txn.pathID) -m found }
     http-request set-var(txn.pathID) var(req.path),map_dir(/etc/haproxy/maps/_back_d2_app_8080_idpathdef__prefix.map) if !{ var(txn.pathID) -m found }
-    http-request redirect scheme https if !https-request { var(txn.pathID) path01 }
-    http-request use-service lua.send-413 if { var(txn.pathID) path03 } { req.body_size,sub(65536) gt 0 }
-    http-request replace-path ^/app12/?(.*)$     /\1     if { var(txn.pathID) path02 }
+    http-request redirect scheme https if !https-request { var(txn.pathID) -m str path01 }
+    http-request use-service lua.send-413 if { var(txn.pathID) -m str path03 } { req.body_size,sub(65536) gt 0 }
+    http-request replace-path ^/app12/?(.*)$     /\1     if { var(txn.pathID) -m str path02 }
     server s1 172.17.0.11:8080 weight 100
 backend default_default-backend_8080
     mode http
@@ -2640,15 +2640,15 @@ frontend _front_https
     http-request set-var(req.snibackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_sni__begin.map) if !{ var(req.snibackend) -m found } !tls-has-crt !tls-host-need-crt
     http-request set-var(req.snibackend) var(req.base),map_reg(/etc/haproxy/maps/_front_https_sni__regex.map) if !{ var(req.snibackend) -m found } !tls-has-crt !tls-host-need-crt
     http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower,map_str(/etc/haproxy/maps/_front_tls_missingcrt_pages__exact.map,_internal) if !tls-has-crt tls-need-crt
-    http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower,map_reg(/etc/haproxy/maps/_front_tls_missingcrt_pages__regex.map,_internal) if { var(req.tls_nocrt_redir) _internal }
+    http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower,map_reg(/etc/haproxy/maps/_front_tls_missingcrt_pages__regex.map,_internal) if { var(req.tls_nocrt_redir) -m str _internal }
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map_str(/etc/haproxy/maps/_front_tls_invalidcrt_pages__exact.map,_internal) if tls-has-invalid-crt tls-check-crt
-    http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map_reg(/etc/haproxy/maps/_front_tls_invalidcrt_pages__regex.map,_internal) if { var(req.tls_invalidcrt_redir) _internal }
-    http-request redirect location %[var(req.tls_nocrt_redir)] code 303 if { var(req.tls_nocrt_redir) -m found } !{ var(req.tls_nocrt_redir) _internal }
-    http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303 if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
+    http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map_reg(/etc/haproxy/maps/_front_tls_invalidcrt_pages__regex.map,_internal) if { var(req.tls_invalidcrt_redir) -m str _internal }
+    http-request redirect location %[var(req.tls_nocrt_redir)] code 303 if { var(req.tls_nocrt_redir) -m found } !{ var(req.tls_nocrt_redir) -m str _internal }
+    http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303 if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) -m str _internal }
     http-request use-service lua.send-421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
-    http-request use-service lua.send-496 if { var(req.tls_nocrt_redir) _internal }
+    http-request use-service lua.send-496 if { var(req.tls_nocrt_redir) -m str _internal }
     http-request use-service lua.send-421 if !tls-has-crt tls-host-need-crt
-    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) _internal }
+    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) -m str _internal }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.snibackend)] if { var(req.snibackend) -m found }
     default_backend default_default-backend_8080
@@ -3947,7 +3947,7 @@ backend d1_app_8080
     # path01 = d1.local/
     # path02 = d1.local/admin
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
-    http-request auth` + realm + ` if { var(txn.pathID) path02 } !{ http_auth(` + test.listname + `) }
+    http-request auth` + realm + ` if { var(txn.pathID) -m str path02 } !{ http_auth(` + test.listname + `) }
     server s1 172.17.0.11:8080 weight 100
 <<backends-default>>
 <<frontends-default>>
@@ -4204,7 +4204,7 @@ func TestModSecurity(t *testing.T) {
     # path01 = d1.local/sub
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
-    http-request deny if { var(txn.modsec.code) -m int gt 0 } { var(txn.pathID) path01 }`,
+    http-request deny if { var(txn.modsec.code) -m int gt 0 } { var(txn.pathID) -m str path01 }`,
 			modsecExp: `
     timeout connect 1s
     timeout server  2s
@@ -4336,9 +4336,9 @@ frontend _front_https
     http-request set-var(req.snibackend) var(req.snibase),map_reg(/etc/haproxy/maps/_front_https_sni__regex.map)
     http-request set-var(req.snibackend) var(req.base),map_reg(/etc/haproxy/maps/_front_https_sni__regex.map) if !{ var(req.snibackend) -m found } !tls-has-crt
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower,map_reg(/etc/haproxy/maps/_front_tls_invalidcrt_pages__regex.map,_internal) if tls-has-invalid-crt tls-check-crt
-    http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303 if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
+    http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303 if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) -m str _internal }
     http-request use-service lua.send-421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
-    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) _internal }
+    http-request use-service lua.send-495 if { var(req.tls_invalidcrt_redir) -m str _internal }
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.snibackend)] if { var(req.snibackend) -m found }
     default_backend _error404

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -415,7 +415,7 @@ backend {{ $backend.ID }}
 {{- if and (not $frontingIgnoreProto) (or $backend.HasHSTS $backend.HasSSLRedirect) }}
     acl https-request ssl_fc
 {{- if $frontingUseProto }}
-    acl https-request var(txn.proto) https
+    acl https-request var(txn.proto) -m str https
 {{- end }}
 {{- end }}
 {{- if $backend.TLS.HasTLSAuth }}
@@ -453,7 +453,7 @@ backend {{ $backend.ID }}
 {{- range $i, $attr := $attrCfg.Items }}
 {{- range $pathIDs := $attrCfg.PathIDs $i }}
     some haproxy keyword {{ $attr }}
-        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} if { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -476,7 +476,7 @@ backend {{ $backend.ID }}
     http-request redirect scheme https
         {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
         {{- "" }} if{{ if $hasFrontingProxy }} !fronting-proxy{{ end }} !https-request
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -518,12 +518,12 @@ backend {{ $backend.ID }}
 {{- range $pathIDs := $allowCfg.PathIDs $i }}
 {{- if $allow.Exception }}
     http-request deny if
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
         {{- "" }} allow_exception_src{{ $i }}
 {{- end }}
 {{- if $allow.Rule }}
     http-request deny if
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
         {{- "" }} !allow_rule_src{{ $i }}
 {{- end }}
 {{- end }}
@@ -538,7 +538,7 @@ backend {{ $backend.ID }}
 {{- end }}
 {{- range $pathIDs := $denyCfg.PathIDs $i }}
     http-request deny if
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
         {{- if $deny.Rule }} deny_rule_src{{ $i }}{{ end }}
         {{- if $deny.Exception }} !deny_exception_src{{ $i }}{{ end }}
 {{- end }}
@@ -553,7 +553,7 @@ backend {{ $backend.ID }}
     http-request auth
         {{- if $authHTTP.Realm }} realm "{{ $authHTTP.Realm }}"{{ end }}
         {{- "" }} if{{ if and $backend.HasCorsEnabled }} !METH_OPTIONS{{ end }}
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
         {{- "" }} !{ http_auth({{ $authHTTP.UserlistName }}) }
 {{- end }}
 {{- end }}
@@ -565,7 +565,7 @@ backend {{ $backend.ID }}
 {{- if $maxbody }}
 {{- range $pathIDs := $maxbodyCfg.PathIDs $i }}
     http-request use-service lua.send-413 if
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
         {{- "" }} { req.body_size,sub({{ $maxbody }}) gt 0 }
 {{- end }}
 {{- end }}
@@ -579,7 +579,7 @@ backend {{ $backend.ID }}
 {{- if eq $waf.Mode "deny" }}
 {{- range $pathIDs := $wafCfg.PathIDs $i }}
     http-request deny if { var(txn.modsec.code) -m int gt 0 }
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -613,9 +613,9 @@ backend {{ $backend.ID }}
 {{- end }}
 {{- range $pathIDs := $corsCfg.PathIDs $i }}
     http-request set-var(txn.cors_max_age) str({{ $cors.MaxAge }}) if METH_OPTIONS
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
     http-request use-service lua.send-cors-preflight if METH_OPTIONS
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -637,16 +637,16 @@ backend {{ $backend.ID }}
 {{- range $pathIDs := $authCfg.PathIDs $i }}
 {{- if $auth.AlwaysDeny }}
     http-request deny
-        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} if { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- else }}
 {{- if $auth.AuthBackendName }}
     http-request set-header X-Real-IP %[src]
-        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} if { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
     http-request lua.auth-intercept {{ $auth.AuthBackendName }} {{ $auth.AuthPath }} {{ $auth.Method }}
         {{- printf " '%s' '%s' '%s'" ($auth.HeadersRequest | join ",") ($auth.HeadersSucceed | join ",") ($auth.HeadersFail | join ",") }}
         {{- if or $auth.AllowedPath $pathIDs }} if{{ end }}
         {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- if $auth.RedirectOnFail }}
     http-request redirect location {{ $auth.RedirectOnFail }}
 {{- else }}
@@ -654,11 +654,11 @@ backend {{ $backend.ID }}
 {{- end }}
         {{- "" }} if !{ var(txn.auth_response_successful) -m bool }
         {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- range $header, $attr := $auth.HeadersVars }}
     http-request set-header {{ $header }} %[var({{ $attr }})] if { var({{ $attr }}) -m found }
         {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -697,10 +697,10 @@ backend {{ $backend.ID }}
 {{- range $path := ($rewriteCfg.Paths $i) }}
 {{- if eq $rewrite "/" }}
     http-request replace-path ^{{ $path.Path }}/?(.*)$     {{ $rewrite }}\1
-        {{- if $needACL }}     if { var(txn.pathID) {{ $path.ID }} }{{ end }}
+        {{- if $needACL }}     if { var(txn.pathID) -m str {{ $path.ID }} }{{ end }}
 {{- else }}
     http-request replace-path ^{{ $path.Path }}(.*)$       {{ $rewrite }}{{ if hasSuffix $path.Path "/" }}/{{ end }}\1
-        {{- if $needACL }}     if { var(txn.pathID) {{ $path.ID }} }{{ end }}
+        {{- if $needACL }}     if { var(txn.pathID) -m str {{ $path.ID }} }{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -718,7 +718,7 @@ backend {{ $backend.ID }}
         {{- if $hsts.Preload }}; preload{{ end }}"
         {{- if or $needSSLACL $pathIDs }} if
             {{- if $needSSLACL }} https-request{{ end }}
-            {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+            {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
         {{- end }}
 {{- end }}
 {{- end }}
@@ -730,40 +730,40 @@ backend {{ $backend.ID }}
 {{- $dynamicOrigin := gt (len $cors.AllowOrigin) 1 }}
 {{- if $dynamicOrigin }}
 {{- range $a1 := short 5 $cors.AllowOrigin }}
-    acl cors_allow_origin{{ $i }} var(txn.hdr_origin{{ $i }}){{ range $a := $a1 }} {{ $a }}{{ end }}
+    acl cors_allow_origin{{ $i }} var(txn.hdr_origin{{ $i }}) -m str{{ range $a := $a1 }} {{ $a }}{{ end }}
 {{- end }}
 {{- end }}
 {{- range $pathIDs := $corsCfg.PathIDs $i }}
     http-response set-header Access-Control-Allow-Origin
         {{- if $dynamicOrigin }}  "%[var(txn.hdr_origin{{ $i }})]"{{ else }}  "{{ index $cors.AllowOrigin 0 }}"{{ end }}
         {{- if or $dynamicOrigin $pathIDs }} if
-            {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+            {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
             {{- if $dynamicOrigin }} cors_allow_origin{{ $i }}{{ end }}
         {{- end }}
 {{- if $dynamicOrigin }}
     http-response set-header Access-Control-Allow-Origin  "{{ index $cors.AllowOrigin 0 }}"
-        {{- "" }} if{{ if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- "" }} if{{ if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
         {{- "" }} !cors_allow_origin{{ $i }}
 {{- end }}
     http-response set-header Access-Control-Allow-Methods "{{ $cors.AllowMethods }}"
-        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} if { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
     http-response set-header Access-Control-Allow-Headers "{{ $cors.AllowHeaders }}"
-        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} if { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- if $cors.AllowCredentials }}
     http-response set-header Access-Control-Allow-Credentials "{{ $cors.AllowCredentials }}"
-        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} if { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- if $cors.ExposeHeaders }}
     http-response set-header Access-Control-Expose-Headers "{{ $cors.ExposeHeaders }}"
-        {{- if $pathIDs }} if { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} if { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- if $dynamicOrigin }}
     http-response set-header Vary %[res.hdr(Vary)],Origin
         {{- "" }} if { res.hdr(Vary) -m found }
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
     http-response set-header Vary Origin
         {{- "" }} if ! { res.hdr(Vary) -m found }
-        {{- if $pathIDs }} { var(txn.pathID) {{ $pathIDs }} }{{ end }}
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -1355,7 +1355,7 @@ frontend {{ $proxy__front_https }}
     http-request set-var(req.tls_nocrt_redir) ssl_fc_sni,lower
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }},_internal) if
         {{- if $match.First }} !tls-has-crt tls-need-crt
-        {{- else }} { var(req.tls_nocrt_redir) _internal }{{ end }}
+        {{- else }} { var(req.tls_nocrt_redir) -m str _internal }{{ end }}
 {{- end }}
 {{- end }}
 
@@ -1366,15 +1366,15 @@ frontend {{ $proxy__front_https }}
     http-request set-var(req.tls_invalidcrt_redir) ssl_fc_sni,lower
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }},_internal) if
         {{- if $match.First }} tls-has-invalid-crt tls-check-crt
-        {{- else }} { var(req.tls_invalidcrt_redir) _internal }{{ end }}
+        {{- else }} { var(req.tls_invalidcrt_redir) -m str _internal }{{ end }}
 {{- end }}
 {{- if and $mandatory $fmaps.TLSMissingCrtPagesMap.HasHost }}
     http-request redirect location %[var(req.tls_nocrt_redir)] code 303
-        {{- "" }} if { var(req.tls_nocrt_redir) -m found } !{ var(req.tls_nocrt_redir) _internal }
+        {{- "" }} if { var(req.tls_nocrt_redir) -m found } !{ var(req.tls_nocrt_redir) -m str _internal }
 {{- end }}
 {{- if $fmaps.TLSInvalidCrtPagesMap.HasHost }}
     http-request redirect location %[var(req.tls_invalidcrt_redir)] code 303
-        {{- "" }} if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) _internal }
+        {{- "" }} if { var(req.tls_invalidcrt_redir) -m found } !{ var(req.tls_invalidcrt_redir) -m str _internal }
 {{- end }}
 
 {{- end }}{{/* if $fmaps.TLSAuthList.HasHost */}}
@@ -1393,14 +1393,14 @@ frontend {{ $proxy__front_https }}
         {{- "" }} tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
 {{- if $fmaps.TLSNeedCrtList.HasHost }}
     http-request use-service lua.send-496 if
-        {{- "" }} { var(req.tls_nocrt_redir) _internal }
+        {{- "" }} { var(req.tls_nocrt_redir) -m str _internal }
 {{- /* HTTP 421 instead of 404 if missing sni or the provided one doesn't read client crt. */}}
 {{- /* Waiting move the tls-auth stuff to the backend to implement a proper config. */}}
     http-request use-service lua.send-421 if
         {{- "" }} !tls-has-crt tls-host-need-crt
 {{- end }}
     http-request use-service lua.send-495 if
-        {{- "" }} { var(req.tls_invalidcrt_redir) _internal }
+        {{- "" }} { var(req.tls_invalidcrt_redir) -m str _internal }
 {{- end }}
 
 {{- /*------------------------------------*/}}


### PR DESCRIPTION
Historically var() sample fetch used to return string so a match method was optional. Currently var() returns undefined, and since 2.5 the match method is mandatory. This helps to not make bogus configuration, when e.g. an int type is expected but it's in fact matched as string. See https://www.mail-archive.com/haproxy@formilux.org/msg41341.html

This update should be merged as far as v0.12, which is the first controller version that supports external haproxy.