### PR TITLE
Add master-worker mode on embedded haproxy

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -40,6 +40,7 @@ The following command-line options are supported:
 | [`--kubeconfig`](#kubeconfig)                           | /path/to/kubeconfig        | in cluster config       |       |
 | [`--local-filesystem-prefix`](#local-filesystem-prefix) | temporary base directory   |                         | v0.14 |
 | [`--master-socket`](#master-socket)                     | socket path                | use embedded haproxy    | v0.12 |
+| [`--master-worker`](#master-worker)                     | [true\|false]              | false                   | v0.14 |
 | [`--max-old-config-files`](#max-old-config-files)       | num of files               | `0`                     |       |
 | [`--profiling`](#stats)                                 | [true\|false]              | `true`                  |       |
 | [`--publish-service`](#publish-service)                 | namespace/servicename      |                         |       |
@@ -303,6 +304,18 @@ See also:
 
 * [example]({{% relref "../examples/external-haproxy" %}}) page.
 * [External]({{% relref "keys#external" %}}) and [Master-worker]({{% relref "keys#master-worker" %}}) configuration keys
+
+---
+
+## --master-worker
+
+Since v0.14
+
+Defines if haproxy should be configured in master-worker mode. If `false`, one single process
+is forked in the background. If `true`, a master process is started in the foreground and can
+be used to manage current and old worker processes. The default value is `false`, which
+preserves historical behavior of HAProxy Ingress. External HAProxy deployment needs
+master-worker mode and will enforce `--master-worker` as `true` if configured.
 
 ---
 

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -1769,8 +1769,9 @@ See also:
 | `master-exit-on-failure` | `Global` | `true`  | v0.12 |
 | `worker-max-reloads`     | `Global` | `0`     | v0.12 |
 
-Configures master-worker related options. These options are only used when an
-external haproxy instance is configured.
+Configures master-worker related options. These options are only used when
+[`--master-worker`]({{% relref "command-line#master-worker" %}})
+command-line option is configured as `true`.
 
 * `master-exit-on-failure`: If `true`, kill all the remaining workers and exit
 from master in the case of an unexpected failure of a worker, eg a segfault.
@@ -1782,10 +1783,10 @@ websockets, and clusters that frequently changes and forces haproxy to reload.
 
 See also:
 
-* [Example]({{% relref "/docs/examples/external-haproxy" %}}) page
+* [External HAProxy example]({{% relref "/docs/examples/external-haproxy" %}}) page
 * https://cbonte.github.io/haproxy-dconv/2.2/configuration.html#3.1-master-worker
 * https://cbonte.github.io/haproxy-dconv/2.2/configuration.html#mworker-max-reloads
-* [master-socket]({{% relref "command-line#master-socket" %}}) command-line option
+* [master-socket]({{% relref "command-line#master-socket" %}}) and [master-worker]({{% relref "command-line#master-worker" %}}) command-line options
 
 ---
 

--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -55,6 +55,7 @@ type GenericController struct {
 // Configuration contains all the settings required by an Ingress controller
 type Configuration struct {
 	Client       types.Client
+	MasterWorker bool
 	MasterSocket string
 
 	RateLimitUpdate  float32

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -118,6 +118,10 @@ func (hc *HAProxyController) configController() {
 	if hc.cfg.ReloadInterval.Seconds() > 0 {
 		hc.reloadQueue = utils.NewRateLimitingQueue(float32(1/hc.cfg.ReloadInterval.Seconds()), hc.reloadHAProxy)
 	}
+	masterSocket := hc.cfg.MasterSocket
+	if masterSocket == "" && hc.cfg.MasterWorker {
+		masterSocket = ingress.DefaultVarRunDirectory + "/master.sock"
+	}
 	var rootFSPrefix string
 	if hc.cfg.LocalFSPrefix != "" {
 		rootFSPrefix = "rootfs"
@@ -127,7 +131,9 @@ func (hc *HAProxyController) configController() {
 		LocalFSPrefix:     hc.cfg.LocalFSPrefix,
 		HAProxyCfgDir:     hc.cfg.LocalFSPrefix + "/etc/haproxy",
 		HAProxyMapsDir:    ingress.DefaultMapsDirectory,
-		MasterSocket:      hc.cfg.MasterSocket,
+		IsMasterWorker:    hc.cfg.MasterWorker,
+		IsExternal:        hc.cfg.MasterSocket != "",
+		MasterSocket:      masterSocket,
 		AdminSocket:       ingress.DefaultVarRunDirectory + "/admin.sock",
 		AcmeSocket:        ingress.DefaultVarRunDirectory + "/acme.sock",
 		BackendShards:     hc.cfg.BackendShards,
@@ -153,6 +159,7 @@ func (hc *HAProxyController) configController() {
 		Tracker:          hc.tracker,
 		DynamicConfig:    hc.dynamicConfig,
 		LocalFSPrefix:    hc.cfg.LocalFSPrefix,
+		IsExternal:       instanceOptions.IsExternal,
 		MasterSocket:     instanceOptions.MasterSocket,
 		AdminSocket:      instanceOptions.AdminSocket,
 		AcmeSocket:       instanceOptions.AcmeSocket,

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -119,7 +119,7 @@ func (c *updater) buildBackendAuthExternal(d *backData) {
 		path.AuthExternal.AlwaysDeny = true
 
 		external := c.haproxy.Global().External
-		if external.IsExternal() && !external.HasLua {
+		if external.IsExternal && !external.HasLua {
 			c.logger.Warn("external authentication on %v needs Lua json module, install lua-json4 and enable 'external-has-lua' global config", url.Source)
 			continue
 		}
@@ -677,7 +677,7 @@ func (c *updater) buildBackendOAuth(d *backData) {
 			continue
 		}
 		external := c.haproxy.Global().External
-		if external.IsExternal() && !external.HasLua {
+		if external.IsExternal && !external.HasLua {
 			c.logger.Warn("oauth2_proxy on %v needs Lua json module, install lua-json4 and enable 'external-has-lua' global config", oauth.Source)
 			continue
 		}

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -467,7 +467,7 @@ func TestAuthExternal(t *testing.T) {
 		c.haproxy.Frontend().AuthProxy.RangeStart = 4001
 		c.haproxy.Frontend().AuthProxy.RangeEnd = 4009
 		if test.isExternal {
-			c.haproxy.Global().External.MasterSocket = "/socket"
+			c.haproxy.Global().External.IsExternal = true
 		}
 		c.haproxy.Global().External.HasLua = test.hasLua
 		// backend is used by svc protocol
@@ -1881,7 +1881,7 @@ WARN oauth2_proxy on ingress 'default/ing1' needs Lua json module, install lua-j
 		c := setup(t)
 		d := c.createBackendMappingData("default/app", source, annDefault, test.ann, []string{})
 		if test.external {
-			c.haproxy.Global().External.MasterSocket = "/tmp/master.sock"
+			c.haproxy.Global().External.IsExternal = true
 		}
 		c.haproxy.Global().External.HasLua = test.haslua
 		if test.backend != "" {

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -151,9 +151,10 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.DrainSupport.Redispatch = mapper.Get(ingtypes.GlobalDrainSupportRedispatch).Bool()
 	d.global.Cookie.Key = mapper.Get(ingtypes.GlobalCookieKey).Value
 	d.global.External.HasLua = mapper.Get(ingtypes.GlobalExternalHasLua).Bool()
-	d.global.External.MasterSocket = c.options.MasterSocket
+	d.global.External.IsExternal = c.options.IsExternal
 	d.global.LoadServerState = mapper.Get(ingtypes.GlobalLoadServerState).Bool()
 	d.global.Master.ExitOnFailure = mapper.Get(ingtypes.GlobalMasterExitOnFailure).Bool()
+	d.global.Master.IsMasterWorker = c.options.MasterSocket != ""
 	d.global.Master.WorkerMaxReloads = mapper.Get(ingtypes.GlobalWorkerMaxReloads).Int()
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()

--- a/pkg/converters/types/options.go
+++ b/pkg/converters/types/options.go
@@ -27,6 +27,7 @@ type ConverterOptions struct {
 	Tracker          Tracker
 	DynamicConfig    *DynamicConfig
 	LocalFSPrefix    string
+	IsExternal       bool
 	MasterSocket     string
 	AdminSocket      string
 	AcmeSocket       string

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1249,7 +1249,10 @@ func TestInstanceEmptyExternal(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()
 
-	c.config.global.External.MasterSocket = "/tmp/master.sock"
+	c.instance.options.IsExternal = true
+	c.instance.options.IsMasterWorker = true
+	c.config.global.External.IsExternal = true
+	c.config.global.Master.IsMasterWorker = true
 	c.config.global.Master.WorkerMaxReloads = 20
 	c.config.global.Security.Username = "external"
 	c.config.global.Security.Groupname = "external"
@@ -4605,7 +4608,7 @@ var endpointS41h = &hatypes.Endpoint{
 
 var defaultLogging = `
 INFO (test) reload was skipped
-INFO haproxy successfully reloaded (embedded)`
+INFO haproxy successfully reloaded (embedded daemon)`
 
 func _yamlMarshal(in interface{}) string {
 	out, _ := yaml.Marshal(in)

--- a/pkg/haproxy/socket/socket_test.go
+++ b/pkg/haproxy/socket/socket_test.go
@@ -214,6 +214,7 @@ func TestHAProxyProcs(t *testing.T) {
 	testCases := []struct {
 		cmdOutput []string
 		cmdError  error
+		hasSock   bool
 		expOutput *ProcTable
 		expError  bool
 	}{
@@ -225,6 +226,7 @@ func TestHAProxyProcs(t *testing.T) {
 		{
 			cmdError: fmt.Errorf("fail"),
 			expError: true,
+			hasSock:  true,
 		},
 		// 2
 		{
@@ -342,6 +344,7 @@ func TestHAProxyProcs(t *testing.T) {
 		cli := &clientMock{
 			cmdOutput: test.cmdOutput,
 			cmdError:  test.cmdError,
+			hasSock:   test.hasSock,
 		}
 		out, err := HAProxyProcs(cli)
 		if !reflect.DeepEqual(out, test.expOutput) {
@@ -418,9 +421,13 @@ type clientMock struct {
 	cmdOutput []string
 	cmdError  error
 	callCnt   int
+	hasSock   bool
 }
 
 func (c *clientMock) Address() string {
+	if c.hasSock {
+		return "/dev/null"
+	}
 	return ""
 }
 

--- a/pkg/haproxy/types/global.go
+++ b/pkg/haproxy/types/global.go
@@ -130,11 +130,6 @@ func (c *AcmeCerts) AssignPreferredChain(preferredChain string) error {
 	return nil
 }
 
-// IsExternal ...
-func (e *ExternalConfig) IsExternal() bool {
-	return e.MasterSocket != ""
-}
-
 func (dns *DNSConfig) String() string {
 	return fmt.Sprintf("%+v", *dns)
 }

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -194,8 +194,8 @@ type DrainConfig struct {
 
 // ExternalConfig ...
 type ExternalConfig struct {
-	HasLua       bool
-	MasterSocket string
+	HasLua     bool
+	IsExternal bool
 }
 
 // HealthzConfig ...
@@ -207,6 +207,7 @@ type HealthzConfig struct {
 // MasterConfig ...
 type MasterConfig struct {
 	ExitOnFailure    bool
+	IsMasterWorker   bool
 	WorkerMaxReloads int
 }
 

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -61,7 +61,7 @@
 {{- define "global" }}
 {{- $global := .p1 }}
 global
-{{- if $global.External.IsExternal }}
+{{- if $global.Master.IsMasterWorker }}
     master-worker{{ if not $global.Master.ExitOnFailure }} no-exit-on-failure{{ end }}
 {{- else }}
     daemon
@@ -97,7 +97,7 @@ global
 {{- if $global.Timeout.Stop }}
     hard-stop-after {{ $global.Timeout.Stop }}
 {{- end }}
-{{- if and $global.External.IsExternal $global.Master.WorkerMaxReloads }}
+{{- if and $global.Master.IsMasterWorker $global.Master.WorkerMaxReloads }}
     mworker-max-reloads {{ $global.Master.WorkerMaxReloads }}
 {{- end }}
 {{- if $global.Syslog.Endpoint }}


### PR DESCRIPTION
Add the ability to run the embedded haproxy in master-worker mode. Master-worker runs in the foreground, allowing to control the lifecycle of the process in a dedicated goroutine, within an event loop that will relaunch the process in the case of an unexpected crash.

Default behavior remains the same, so daemon mode will continue to be used if no configuration option is added, this should probably be changed in a future version.