### PR TITLE
Add auth-tls configurations to tcp services

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -2539,7 +2539,9 @@ Due to the limited data that can be inspected on TCP requests, a limited number 
 
 * `Backend` and `Path` scoped configuration keys work, provided that they are not HTTP related - eg [Cors](#cors) and [HSTS](#hsts) are ignored by TCP services, on the other hand [balance algorithm](#balance-algorithm), [Allow list](#allowlist) and [Blue/green](#blue-green) work just like in the HTTP requests counterpart.
 * All `Global` configuration keys related with the whole haproxy process will also be applied to TCP services, like max connections or syslog configurations.
-* All `Host` scoped configuration keys are currently unsupported
+* Regarding `Host` scoped configuration keys:
+  * on v0.13, all `Host` scoped configuration keys are unsupported
+  * on v0.14, [auth-tls](#auth-tls) are supported
 
 Every TCP service port creates a dedicated haproxy frontend that can be [customized](#configuration-snippet) in three distinct ways:
 

--- a/pkg/converters/helper_test/marshal.go
+++ b/pkg/converters/helper_test/marshal.go
@@ -62,6 +62,7 @@ type (
 	}
 	tlsMock struct {
 		TLSFilename string `yaml:",omitempty"`
+		CAFilename  string `yaml:",omitempty"`
 	}
 	// tcp
 	tcpServiceMock struct {
@@ -165,6 +166,7 @@ func MarshalTCPServices(hatcpserviceports ...*hatypes.TCPServicePort) string {
 			ProxyProt:      hasvc.ProxyProt,
 			TLS: tlsMock{
 				TLSFilename: hasvc.TLS.TLSFilename,
+				CAFilename:  hasvc.TLS.CAFilename,
 			},
 		}
 		tcpServices = append(tcpServices, svc)

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -33,7 +33,7 @@ import (
 type Updater interface {
 	UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mapper)
 	UpdateTCPPortConfig(tcp *hatypes.TCPServicePort, mapper *Mapper)
-	UpdateTCPHostConfig(host *hatypes.TCPServiceHost, mapper *Mapper)
+	UpdateTCPHostConfig(tcpPort *hatypes.TCPServicePort, tcpHost *hatypes.TCPServiceHost, mapper *Mapper)
 	UpdateHostConfig(host *hatypes.Host, mapper *Mapper)
 	UpdateBackendConfig(backend *hatypes.Backend, mapper *Mapper)
 }
@@ -64,6 +64,12 @@ type globalData struct {
 	acmeData *hatypes.AcmeData
 	global   *hatypes.Global
 	mapper   *Mapper
+}
+
+type tcpData struct {
+	tcpPort *hatypes.TCPServicePort
+	tcpHost *hatypes.TCPServiceHost
+	mapper  *Mapper
 }
 
 type hostData struct {
@@ -186,7 +192,13 @@ func (c *updater) UpdateTCPPortConfig(tcp *hatypes.TCPServicePort, mapper *Mappe
 	tcp.ProxyProt = mapper.Get(ingtypes.TCPTCPServiceProxyProto).Bool()
 }
 
-func (c *updater) UpdateTCPHostConfig(host *hatypes.TCPServiceHost, mapper *Mapper) {
+func (c *updater) UpdateTCPHostConfig(tcpPort *hatypes.TCPServicePort, tcpHost *hatypes.TCPServiceHost, mapper *Mapper) {
+	data := &tcpData{
+		tcpPort: tcpPort,
+		tcpHost: tcpHost,
+		mapper:  mapper,
+	}
+	c.buildTCPAuthTLS(data)
 }
 
 func (c *updater) UpdateHostConfig(host *hatypes.Host, mapper *Mapper) {


### PR DESCRIPTION
Small refactor in the `buildHostAuthTLS()`, allowing to reuse the same function to populate TLS authentication to both HTTP and TCP frontends.