### PR TITLE
Fix sni sample fetch on ssl decyphered tcp conns

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1919,14 +1919,22 @@ func TestInstanceTCPServices(t *testing.T) {
 			backend:  b3.BackendID(),
 		},
 		{
-			port:    7012,
-			backend: b.BackendID(),
-			custom:  []string{"## custom for TCP 7012"},
+			port:     7012,
+			hostname: "local1",
+			backend:  b.BackendID(),
+			tls: hatypes.TLSConfig{
+				TLSFilename: "/ssl/7012.pem",
+			},
 		},
 		{
 			port:    7013,
 			backend: b.BackendID(),
-			custom:  []string{"## custom for TCP 7013", "## multi line"},
+			custom:  []string{"## custom for TCP 7013"},
+		},
+		{
+			port:    7014,
+			backend: b.BackendID(),
+			custom:  []string{"## custom for TCP 7014", "## multi line"},
 		},
 	}
 
@@ -2011,14 +2019,21 @@ frontend _front_tcp_7011
     use_backend %[var(req.tcpback)] if { var(req.tcpback) -m found }
     default_backend d1_app_8080
 frontend _front_tcp_7012
-    bind :7012
+    bind :7012 ssl crt /ssl/7012.pem
     mode tcp
-    ## custom for TCP 7012
-    default_backend d1_app_8080
+    tcp-request inspect-delay 5s
+    tcp-request content set-var(req.tcpback) ssl_fc_sni,lower,map_str(/etc/haproxy/maps/_tcp_sni_7012__exact.map)
+    tcp-request content accept if { req.ssl_hello_type 1 }
+    use_backend %[var(req.tcpback)] if { var(req.tcpback) -m found }
 frontend _front_tcp_7013
     bind :7013
     mode tcp
     ## custom for TCP 7013
+    default_backend d1_app_8080
+frontend _front_tcp_7014
+    bind :7014
+    mode tcp
+    ## custom for TCP 7014
     ## multi line
     default_backend d1_app_8080
 <<frontends-default>>
@@ -2029,6 +2044,8 @@ local2 d2_app_8080
 local3 d3_app_8080`)
 	c.checkMap("_tcp_sni_7011__regex.map", `
 ^[^.]+\.local4$ d3_app_8080`)
+	c.checkMap("_tcp_sni_7012__exact.map", `
+local1 d1_app_8080`)
 	c.logger.CompareLogging(defaultLogging)
 }
 

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1804,13 +1804,16 @@ func TestInstanceTCPServices(t *testing.T) {
 
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
+	b.ModeTCP = true
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 	h = c.config.Hosts().AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	b2 := c.config.Backends().AcquireBackend("d2", "app", "8080")
+	b2.ModeTCP = true
 	b2.Endpoints = []*hatypes.Endpoint{endpointS21, endpointS22}
 	b3 := c.config.Backends().AcquireBackend("d3", "app", "8080")
+	b3.ModeTCP = true
 	b3.Endpoints = []*hatypes.Endpoint{endpointS31, endpointS32}
 
 	services := []struct {
@@ -1955,14 +1958,14 @@ func TestInstanceTCPServices(t *testing.T) {
 <<global>>
 <<defaults>>
 backend d1_app_8080
-    mode http
+    mode tcp
     server s1 172.17.0.11:8080 weight 100
 backend d2_app_8080
-    mode http
+    mode tcp
     server s21 172.17.0.121:8080 weight 100
     server s22 172.17.0.122:8080 weight 100
 backend d3_app_8080
-    mode http
+    mode tcp
     server s31 172.17.0.131:8080 weight 100
     server s32 172.17.0.132:8080 weight 100
 <<backends-default>>

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1011,7 +1011,7 @@ frontend {{ $proxy_name }}
 {{- if $tcpport.SNIMap.HasHost }}
     tcp-request inspect-delay 5s
 {{- range $match := $tcpport.SNIMap.MatchFiles }}
-    tcp-request content set-var(req.tcpback) req.ssl_sni,lower
+    tcp-request content set-var(req.tcpback) {{ if $tls.TLSFilename }}ssl_fc_sni{{ else }}req.ssl_sni{{ end }},lower
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if not $match.First }} if !{ var(req.tcpback) -m found }{{ end }}
 {{- end }}


### PR DESCRIPTION
Annotation based TCP Services has the ability to choose a TCP backend based on the TLS SNI extension sent by the client. HAProxy however has two distinct samples fetches for read the SNI extension, one used in pure TCP connections and the help of the inspect-delay, another one used on requests decyphered by haproxy. This distinction wasn't being made by the controller.

Should be merged to v0.13.