### PR TITLE
Change auth-tls-scrict from false to true

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -851,7 +851,7 @@ See also:
 | `auth-tls-cert-header`   | `Backend` | `false` |        |
 | `auth-tls-error-page`    | `Host`    |         |        |
 | `auth-tls-secret`        | `Host`    |         |        |
-| `auth-tls-strict`        | `Host`    | `false` | v0.8.1 |
+| `auth-tls-strict`        | `Host`    | `true`  | v0.8.1 |
 | `auth-tls-verify-client` | `Host`    |         |        |
 | `ssl-fingerprint-lower`  | `Backend` | `false` | v0.10  |
 | `ssl-headers-prefix`     | `Global`  | `X-SSL` |        |
@@ -872,7 +872,7 @@ The following keys are supported:
 * `auth-tls-cert-header`: If `true` HAProxy will add `X-SSL-Client-Cert` http header with a base64 encoding of the X509 certificate provided by the client. Default is to not provide the client certificate.
 * `auth-tls-error-page`: Optional URL of the page to redirect the user if he doesn't provide a certificate or the certificate is invalid.
 * `auth-tls-secret`: Mandatory secret name with `ca.crt` key providing all certificate authority bundles used to validate client certificates. Since v0.9, an optional `ca.crl` key can also provide a CRL in PEM format for the server to verify against. A filename prefixed with `file://` can be used containing the CA bundle in PEM format, and optionally followed by a comma and the filename with the crl, eg `file:///dir/ca.pem` or `file:///dir/ca.pem,/dir/crl.pem`.
-* `auth-tls-strict`: Defines if a wrong or incomplete configuration, eg missing secret with `ca.crt`, should forbid connection attempts. If `false`, the default value, a wrong or incomplete configuration will ignore the authentication config, allowing anonymous connection. If `true`, a strict configuration is used: all requests will be rejected with HTTP 495 or 496, or redirected to the error page if configured, until a proper `ca.crt` is provided. Strict configuration will only be used if `auth-tls-secret` has a secret name and `auth-tls-verify-client` is missing or is not configured as `off`.
+* `auth-tls-strict`: Defines if a wrong or incomplete configuration, eg missing secret with `ca.crt`, should forbid connection attempts. If `false`, a wrong or incomplete configuration will ignore the authentication config, allowing anonymous connection. If `true`, a strict configuration is used: all requests will be rejected with HTTP 495 or 496, or redirected to the error page if configured, until a proper `ca.crt` is provided. Strict configuration will only be used if `auth-tls-secret` has a secret name and `auth-tls-verify-client` is missing or is not configured as `off`. This options used to have `false` as the default value up to v0.13, changing its default to `true` since v0.14 to improve security.
 * `auth-tls-verify-client`: Optional configuration of Client Verification behavior. Supported values are `off`, `on`, `optional` and `optional_no_ca`. The default value is `on` if a valid secret is provided, `off` otherwise.
 * `ssl-fingerprint-lower`: Defines if the certificate fingerprint should be in lowercase hexadecimal digits. The default value is `false`, which uses uppercase digits.
 * `ssl-headers-prefix`: Configures which prefix should be used on HTTP headers. Since [RFC 6648](https://tools.ietf.org/html/rfc6648) `X-` prefix on unstandardized headers changed from a convention to deprecation. This configuration allows to select which pattern should be used on header names.

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -32,7 +32,7 @@ func createDefaults() map[string]string {
 	return map[string]string{
 		types.TCPTCPServiceLogFormat: "default",
 		//
-		types.HostAuthTLSStrict:     "false",
+		types.HostAuthTLSStrict:     "true",
 		types.HostSSLAlwaysAddHTTPS: "false",
 		types.HostSSLCiphers:        defaultSSLCiphers,
 		types.HostSSLCipherSuites:   defaultSSLCipherSuites,


### PR DESCRIPTION
`auth-tls-scrict` is used to define whether a misconfigured TLS based authentication should always fail, i.e. defines if misconfigured should ignore the configuration or create a fake configuration to protect the backend.

Historically HAProxy Ingress alerts and discards wrong configuration but this could lead to a security issue on configurations that protect applications. Strict option was added in v0.8 as false to preserve backward compatibility, and finally changed its default to true to improve security.