### PR TITLE
Check by default if gateway api crds are installed

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -607,8 +607,11 @@ changes in one single shot. The default value is `200ms`.
 
 Since v0.13
 
-Enables Gateway API watch and parse. The Gateway API CRDs should be installed before enable
-this option. See also the Gateway API configuration [doc]({{% relref "gateway-api" %}}).
+Enables Gateway API watch and parse. This option is enabled by default since v0.14 and controller
+will start the listener only if the Gateway API CRDs are found. Add `--watch-gateway=false`
+option to instruct the controller to not try to listen to the CRDs. The controller should be
+restarted if the CRDs are installed after starting the controller. See also the Gateway API
+configuration [doc]({{% relref "gateway-api" %}}).
 
 ---
 

--- a/docs/content/en/docs/configuration/gateway-api.md
+++ b/docs/content/en/docs/configuration/gateway-api.md
@@ -14,7 +14,7 @@ The following steps configure the Kubernetes cluster and HAProxy Ingress to read
 
 * Manually install the Gateway API CRDs, see the Gateway API [documentation](https://gateway-api.sigs.k8s.io/v1alpha1/guides/getting-started/#installing-gateway-api-crds-manually)
     * ... or simply `kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v0.3.0" | kubectl apply -f -`
-* Add the controller's [`--watch-gateway`]({{% relref "command-line#watch-gateway" %}}) command-line option
+* Start (or restart) the controller
 
 See below the [getting started steps](#getting-started).
 
@@ -56,15 +56,6 @@ Add the following deployment and service if echoserver isn't running yet:
 ```
 kubectl --namespace default create deployment echoserver --image k8s.gcr.io/echoserver:1.3
 kubectl --namespace default expose deployment echoserver --port=8080
-```
-
-Add the [`--watch-gateway`]({{% relref "command-line#watch-gateway" %}}) command-line option in the `haproxy-ingress-values.yaml` file and [`helm upgrade ...`]({{% relref "/docs/getting-started#installation" %}}) the controller (or simply edit the deployment):
-
-```yaml
-controller:
-  ...
-  extraArgs:
-    watch-gateway: "true"
 ```
 
 A GatewayClass enables Gateways to be read and parsed by HAProxy Ingress. Create a GatewayClass with the following content:

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -89,7 +89,7 @@ new /path, e.g., controller-class=staging will make this controller look for
 declare neither the kubernetes.io/ingress.class annotation nor the
 <ingress>.spec.ingressClassName field. Defaults to false`)
 
-		watchGateway = flags.Bool("watch-gateway", false,
+		watchGateway = flags.Bool("watch-gateway", true,
 			`Watch and parse resources from the Gateway API`)
 
 		masterWorker = flags.Bool("master-worker", false,


### PR DESCRIPTION
Change default value of `--watch-gateway` command-line option to true, so try to listen to gateway API CRDs by default. This new implementation will skip registration of listers and informers if the crds are not installed in the server, contrary to v0.13 which would always try to register them.

There is a backward incompatibility, a v0.13 controller that doesn't declare the command-line option would ignore gateway api resources, while v0.14 would find and configure them by default.