### PR TITLE
Add haproxy 2.5 support for external haproxy

### DIFF
--- a/pkg/haproxy/socket/socket.go
+++ b/pkg/haproxy/socket/socket.go
@@ -233,6 +233,9 @@ type Proc struct {
 	PID     int
 	RPID    int
 	Reloads int
+	Failed  int
+	Uptime  string
+	Version string
 }
 
 // HAProxyProcs reads and converts `show proc` from the master CLI to a ProcTable
@@ -274,8 +277,8 @@ func waitHAProxy(sock HAProxySocket, err error) bool {
 		// connection succeeded, no need to wait (wait = FALSE)
 		return false
 	}
-	if k8snet.IsConnectionRefused(err) {
-		// connection refused, give more time to haproxy (wait = TRUE)
+	if k8snet.IsConnectionRefused(err) || k8snet.IsConnectionReset(err) {
+		// connection refused or connection reset, give more time to haproxy (wait = TRUE)
 		return true
 	}
 	// now check if err (which is not nil) means unix socket not found
@@ -288,6 +291,8 @@ func waitHAProxy(sock HAProxySocket, err error) bool {
 
 // buildProcTable parses `show proc` output and creates a corresponding ProcTable
 //
+//
+// layout 2.2 up to 2.4
 //                   1               3               4               6               8               9
 //   0.......|.......6.......|.......2.......|.......8.......|.......4.......|.......0.......|.......6
 //   #<PID>          <type>          <relative PID>  <reloads>       <uptime>        <version>
@@ -298,7 +303,182 @@ func waitHAProxy(sock HAProxySocket, err error) bool {
 //   2               worker          [was: 1]        1               0d00h00m28s     2.2.3-0e58a34
 //   # programs
 //
+//
+// layout 2.5+
+//                   1               3               4               6               8
+//   0.......|.......6.......|.......2.......|.......8.......|.......4.......|.......0
+//   #<PID>          <type>          <reloads>       <uptime>        <version>
+//   1               master          4200 [failed: 42] 0d00h01m28s     2.5.3-abf078b
+//   # workers
+//   3               worker          0               0d00h00m00s     2.5.3-abf078b
+//   # old workers
+//   2               worker          1               0d00h00m28s     2.5.3-abf078b
+//   # programs
+//
 func buildProcTable(procOutput string) *ProcTable {
+	if strings.Index(procOutput, "relative PID") > 0 {
+		// TODO remove after v0.14
+		return buildProcTable24(procOutput)
+	}
+	procTable := ProcTable{}
+	old := false
+	l := linereader()
+	for _, line := range utils.LineToSlice(procOutput) {
+		if strings.HasPrefix(line, "#<PID>") {
+			l.parseHeader(line)
+		} else if len(line) > 0 && line[0] != '#' {
+			l.feed(line)
+			rpid := l.asInt("<relative_PID>")
+			if rpid == 0 {
+				rpid = l.asInt("<relative_PID>.was")
+			}
+			proc := Proc{
+				PID:     l.asInt("<PID>"),
+				Type:    l.asString("<type>"),
+				RPID:    rpid,
+				Reloads: l.asInt("<reloads>"),
+				Failed:  l.asInt("<reloads>.failed"),
+				Uptime:  l.asString("<uptime>"),
+				Version: l.asString("<version>"),
+			}
+			if proc.Type == "master" {
+				procTable.Master = proc
+			} else if old {
+				procTable.OldWorkers = append(procTable.OldWorkers, proc)
+			} else {
+				procTable.Workers = append(procTable.Workers, proc)
+			}
+		} else if line == "# old workers" {
+			old = true
+		}
+	}
+	return &procTable
+}
+
+type line struct {
+	t       *tokenizer
+	headers []string
+	hwidth  int
+	fields  map[string]string
+}
+
+func linereader() *line {
+	return &line{t: &tokenizer{}, hwidth: 16}
+}
+
+func (l *line) parseHeader(h string) {
+	s := strings.TrimPrefix(h, "#")
+	var inside bool
+	var pos []int
+	for i := range s {
+		switch s[i] {
+		case '<':
+			inside = true
+		case '>':
+			inside = false
+		case ' ':
+			if inside {
+				pos = append(pos, i)
+			}
+		}
+	}
+	for _, i := range pos {
+		s = s[:i] + "_" + s[i+1:]
+	}
+	l.headers = strings.Fields(s)
+	l.fields = nil
+}
+
+func (l *line) feed(line string) {
+	t := l.t
+	t.reset(line)
+	fields := map[string]string{}
+	pos := 0
+	for _, h := range l.headers {
+		t.skipSpaces()
+		for !t.eof() && t.pos-pos < l.hwidth {
+			name, value := t.readField()
+			if name == "" {
+				fields[h] = value
+			} else {
+				fields[h+"."+name] = value
+			}
+			t.skipSpaces()
+		}
+		pos = t.pos
+	}
+	l.fields = fields
+}
+
+func (l *line) asString(h string) string {
+	return l.fields[h]
+}
+
+func (l *line) asInt(h string) int {
+	i, _ := strconv.Atoi(l.asString(h))
+	return i
+}
+
+type tokenizer struct {
+	buf string
+	len int
+	pos int
+}
+
+func (t *tokenizer) reset(buf string) {
+	t.buf = buf
+	t.len = len(buf)
+	t.pos = 0
+}
+
+func (t *tokenizer) eof() bool {
+	return t.pos >= t.len
+}
+
+var isSpace = [256]bool{'\t': true, '\r': true, '\n': true, ' ': true}
+var isSpecial = [256]bool{'[': true, ':': true, ']': true}
+
+func (t *tokenizer) skipSpaces() {
+	for !t.eof() && isSpace[t.buf[t.pos]] {
+		t.pos++
+	}
+}
+
+func (t *tokenizer) readNextToken() string {
+	t.skipSpaces()
+	pos := t.pos
+	if isSpecial[t.buf[pos]] {
+		return string(t.buf[pos])
+	}
+	for pos < t.len && !isSpace[t.buf[pos]] && !isSpecial[t.buf[pos]] {
+		pos++
+	}
+	return t.buf[t.pos:pos]
+}
+
+func (t *tokenizer) readToken() string {
+	token := t.readNextToken()
+	t.pos += len(token)
+	return token
+}
+
+func (t *tokenizer) readField() (string, string) {
+	token := t.readToken()
+	if token != "[" {
+		// e.g. `1` or `worker`
+		return "", token
+	}
+	// e.g. `[failed: 2]` or `[was: 1]`
+	name := t.readToken()
+	_ = t.readToken() // `:`
+	value := t.readToken()
+	for !t.eof() && t.readToken() != "]" {
+		//
+	}
+	return name, value
+}
+
+func buildProcTable24(procOutput string) *ProcTable {
 	atoi := func(s string) int {
 		i, _ := strconv.Atoi(s)
 		return i

--- a/pkg/haproxy/socket/socket_test.go
+++ b/pkg/haproxy/socket/socket_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestSocket(t *testing.T) {
-	// needs a running HAProxy with the conf below
+	// needs a running HAProxy with the conf below:
 	//     global
 	//         stats socket unix@/tmp/h.sock level admin
 	//         stats timeout 1s
@@ -37,7 +37,12 @@ func TestSocket(t *testing.T) {
 	//     listen l1
 	//         bind :8000
 	//         bind :8443 ssl crt /tmp/crt.pem
-	// start with haproxy -f h.cfg -W -S /tmp/m.sock
+	// create a self signed certificate:
+	//     openssl req -x509 -newkey rsa:2048 -subj /CN=localhost -nodes -out crt -keyout key
+	//     cat crt key >/tmp/crt.pem
+	//     rm crt key
+	// start with:
+	//     haproxy -f h.cfg -W -S /tmp/m.sock
 	// TODO create a test and temp server where socket commands can connect to
 	//
 	// testSocket(t, false)
@@ -335,6 +340,66 @@ func TestHAProxyProcs(t *testing.T) {
 				Workers: []Proc{
 					{Type: "worker", PID: 3115, RPID: 1001, Reloads: 11},
 					{Type: "worker", PID: 3116, RPID: 1002, Reloads: 0},
+				},
+			},
+		},
+		// 8
+		{
+			cmdOutput: []string{`#<PID>          <type>          <reloads>       <uptime>        <version>
+94292           master          0 [failed: 0]   0d00h00m04s     2.5.3-abf078b
+# workers
+94293           worker       	   0               0d00h00m04s     2.5.3-abf078b
+# programs
+`},
+			expOutput: &ProcTable{
+				Master: Proc{Type: "master", PID: 94292, Reloads: 0, Failed: 0, Uptime: "0d00h00m04s", Version: "2.5.3-abf078b"},
+				Workers: []Proc{
+					{Type: "worker", PID: 94293, Reloads: 0, Uptime: "0d00h00m04s", Version: "2.5.3-abf078b"},
+				},
+			},
+		},
+		// 9
+		{
+			cmdOutput: []string{`#<PID>          <type>          <reloads>       <uptime>        <version>
+94292           master          1035 [failed: 57] 0d00h09m40s     2.5.3-abf078b
+# workers
+913             worker          57              0d00h04m45s     2.5.3-abf078b
+# programs
+`},
+			expOutput: &ProcTable{
+				Master: Proc{Type: "master", PID: 94292, Reloads: 1035, Failed: 57, Uptime: "0d00h09m40s", Version: "2.5.3-abf078b"},
+				Workers: []Proc{
+					{Type: "worker", PID: 913, Reloads: 57, Uptime: "0d00h04m45s", Version: "2.5.3-abf078b"},
+				},
+			},
+		},
+		// 10
+		{
+			cmdOutput: []string{`#<PID>          <type>          <reloads>       <uptime>        <version>
+2965            master          1420 [failed: 0] 0d00h11m09s     2.5.3-abf078b
+# workers
+10668           worker          0               0d00h00m59s     2.5.3-abf078b
+# old workers
+9529            worker          240             0d00h01m50s     2.5.3-abf078b
+9463            worker          254             0d00h01m53s     2.5.3-abf078b
+9401            worker          268             0d00h01m56s     2.5.3-abf078b
+9335            worker          282             0d00h01m59s     2.5.3-abf078b
+9273            worker          296             0d00h02m02s     2.5.3-abf078b
+9209            worker          310             0d00h02m05s     2.5.3-abf078b
+# programs
+`},
+			expOutput: &ProcTable{
+				Master: Proc{Type: "master", PID: 2965, Reloads: 1420, Failed: 0, Uptime: "0d00h11m09s", Version: "2.5.3-abf078b"},
+				Workers: []Proc{
+					{Type: "worker", PID: 10668, Reloads: 0, Uptime: "0d00h00m59s", Version: "2.5.3-abf078b"},
+				},
+				OldWorkers: []Proc{
+					{Type: "worker", PID: 9529, Reloads: 240, Uptime: "0d00h01m50s", Version: "2.5.3-abf078b"},
+					{Type: "worker", PID: 9463, Reloads: 254, Uptime: "0d00h01m53s", Version: "2.5.3-abf078b"},
+					{Type: "worker", PID: 9401, Reloads: 268, Uptime: "0d00h01m56s", Version: "2.5.3-abf078b"},
+					{Type: "worker", PID: 9335, Reloads: 282, Uptime: "0d00h01m59s", Version: "2.5.3-abf078b"},
+					{Type: "worker", PID: 9273, Reloads: 296, Uptime: "0d00h02m02s", Version: "2.5.3-abf078b"},
+					{Type: "worker", PID: 9209, Reloads: 310, Uptime: "0d00h02m05s", Version: "2.5.3-abf078b"},
 				},
 			},
 		},


### PR DESCRIPTION
Creates a new `show proc` parser compatible with haproxy 2.2 to 2.5. Added in a safe way to allow merging as far as controller v0.12 - version 2.4 and below will continue to use the old parser, minimizing the risk of adding an unknown bug from the new one.

Should be merged as far as v0.12, which is the first version that implements external haproxy and parses `show proc` output.