### PR TITLE
Fix match of prefix pathtype if using default host

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -197,7 +197,8 @@ func (c *config) WriteFrontendMaps() error {
 	defaultHost := c.hosts.DefaultHost()
 	if defaultHost != nil && !defaultHost.SSLPassthrough() {
 		for _, path := range defaultHost.Paths {
-			fmaps.DefaultHostMap.AddHostnamePathMapping("", path, path.Backend.ID)
+			// using DefaultHost ID as hostname, see types.maps.go/buildMapKey()
+			fmaps.DefaultHostMap.AddHostnamePathMapping(hatypes.DefaultHost, path, path.Backend.ID)
 		}
 	}
 	for _, host := range c.hosts.BuildSortedItems() {
@@ -354,7 +355,8 @@ func (c *config) WriteBackendMaps() error {
 					continue
 				}
 				if path.IsDefaultHost() {
-					pathsDefaultHostMap.AddHostnamePathMapping("", p[0], path.ID)
+					// using DefaultHost ID as hostname, see types.maps.go/buildMapKey()
+					pathsDefaultHostMap.AddHostnamePathMapping(hatypes.DefaultHost, p[0], path.ID)
 				} else {
 					pathsMap.AddHostnamePathMapping(path.Hostname(), p[0], path.ID)
 				}

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2234,9 +2234,9 @@ backend d1_app_8080
     # path01 = <default>/
     # path02 = <default>/app1
     # path03 = <default>/app2
-    http-request set-var(txn.pathID) var(req.path),map_str(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__exact.map)
-    http-request set-var(txn.pathID) var(req.path),map_dir(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__prefix_02.map) if !{ var(txn.pathID) -m found }
-    http-request set-var(txn.pathID) var(req.path),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__begin.map) if !{ var(txn.pathID) -m found }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_str(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__exact.map)
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__prefix_02.map) if !{ var(txn.pathID) -m found }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpathdef__begin.map) if !{ var(txn.pathID) -m found }
     http-request redirect scheme https if !https-request { var(txn.pathID) -m str path01 }
     http-request use-service lua.send-413 if { var(txn.pathID) -m str path03 } { req.body_size,sub(32768) gt 0 }
     http-request replace-path ^/app1/?(.*)$     /\1     if { var(txn.pathID) -m str path02 }
@@ -2248,8 +2248,8 @@ backend d2_app_8080
     # path03 = <default>/app13
     # path01 = d2.local/app11
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d2_app_8080_idpath__begin.map)
-    http-request set-var(txn.pathID) var(req.path),map_str(/etc/haproxy/maps/_back_d2_app_8080_idpathdef__exact.map) if !{ var(txn.pathID) -m found }
-    http-request set-var(txn.pathID) var(req.path),map_dir(/etc/haproxy/maps/_back_d2_app_8080_idpathdef__prefix.map) if !{ var(txn.pathID) -m found }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_str(/etc/haproxy/maps/_back_d2_app_8080_idpathdef__exact.map) if !{ var(txn.pathID) -m found }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_d2_app_8080_idpathdef__prefix.map) if !{ var(txn.pathID) -m found }
     http-request redirect scheme https if !https-request { var(txn.pathID) -m str path01 }
     http-request use-service lua.send-413 if { var(txn.pathID) -m str path03 } { req.body_size,sub(65536) gt 0 }
     http-request replace-path ^/app12/?(.*)$     /\1     if { var(txn.pathID) -m str path02 }
@@ -2265,9 +2265,9 @@ frontend _front_http
     http-request set-var(txn.namespace) str(-) if !{ var(txn.namespace) -m found }
     <<http-headers>>
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
-    http-request set-var(req.defaultbackend) var(req.path),map_str(/etc/haproxy/maps/_front_defaulthost__exact.map) if !{ var(req.backend) -m found }
-    http-request set-var(req.defaultbackend) var(req.path),map_dir(/etc/haproxy/maps/_front_defaulthost__prefix_02.map) if !{ var(req.backend) -m found } !{ var(req.defaultbackend) -m found }
-    http-request set-var(req.defaultbackend) var(req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.backend) -m found } !{ var(req.defaultbackend) -m found }
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path),map_str(/etc/haproxy/maps/_front_defaulthost__exact.map) if !{ var(req.backend) -m found }
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_front_defaulthost__prefix_02.map) if !{ var(req.backend) -m found } !{ var(req.defaultbackend) -m found }
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.backend) -m found } !{ var(req.defaultbackend) -m found }
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
     use_backend %[var(req.defaultbackend)]
     default_backend default_default-backend_8080
@@ -2276,9 +2276,9 @@ frontend _front_https
     bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_bind_crt.list ca-ignore-err all crt-ignore-err all
     <<set-req-base>>
     http-request set-var(req.hostbackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_host__begin.map)
-    http-request set-var(req.defaultbackend) var(req.path),map_str(/etc/haproxy/maps/_front_defaulthost__exact.map) if !{ var(req.hostbackend) -m found }
-    http-request set-var(req.defaultbackend) var(req.path),map_dir(/etc/haproxy/maps/_front_defaulthost__prefix_02.map) if !{ var(req.hostbackend) -m found } !{ var(req.defaultbackend) -m found }
-    http-request set-var(req.defaultbackend) var(req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.hostbackend) -m found } !{ var(req.defaultbackend) -m found }
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path),map_str(/etc/haproxy/maps/_front_defaulthost__exact.map) if !{ var(req.hostbackend) -m found }
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_front_defaulthost__prefix_02.map) if !{ var(req.hostbackend) -m found } !{ var(req.defaultbackend) -m found }
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.hostbackend) -m found } !{ var(req.defaultbackend) -m found }
     http-request set-var(txn.namespace) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_namespace__begin.map)
     http-request set-var(txn.namespace) str(-) if !{ var(txn.namespace) -m found }
     <<https-headers>>
@@ -2301,23 +2301,23 @@ d2.local#/app11 d2
 d2.local#/app11 d2_app_8080
 `)
 	c.checkMap("_front_defaulthost__prefix_02.map", `
-/app2 d1_app_8080
-/app13 d2_app_8080`)
+<default>#/app2 d1_app_8080
+<default>#/app13 d2_app_8080`)
 	c.checkMap("_front_defaulthost__exact.map", `
-/app1 d1_app_8080
-/app12 d2_app_8080`)
+<default>#/app1 d1_app_8080
+<default>#/app12 d2_app_8080`)
 	c.checkMap("_front_defaulthost__begin.map", `
-/ d1_app_8080`)
+<default>#/ d1_app_8080`)
 	c.checkMap("_back_d1_app_8080_idpathdef__exact.map", `
-/app1 path02`)
+<default>#/app1 path02`)
 	c.checkMap("_back_d1_app_8080_idpathdef__prefix_02.map", `
-/app2 path03`)
+<default>#/app2 path03`)
 	c.checkMap("_back_d1_app_8080_idpathdef__begin.map", `
-/ path01`)
+<default>#/ path01`)
 	c.checkMap("_back_d2_app_8080_idpathdef__exact.map", `
-/app12 path02`)
+<default>#/app12 path02`)
 	c.checkMap("_back_d2_app_8080_idpathdef__prefix.map", `
-/app13 path03`)
+<default>#/app13 path03`)
 	c.checkMap("_back_d2_app_8080_idpath__begin.map", `
 d2.local#/app11 path01`)
 
@@ -2437,7 +2437,7 @@ frontend _front_http
     http-request set-var(req.base) var(req.host),concat(\#,req.path)
     <<http-headers>>
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
-    http-request set-var(req.defaultbackend) var(req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.backend) -m found }
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.backend) -m found }
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
     use_backend %[var(req.defaultbackend)]
     default_backend _error404
@@ -2448,7 +2448,7 @@ frontend _front_https
     http-request set-var(req.host) hdr(host),field(1,:),lower
     http-request set-var(req.base) var(req.host),concat(\#,req.path)
     http-request set-var(req.hostbackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_host__begin.map)
-    http-request set-var(req.defaultbackend) var(req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.hostbackend) -m found }
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path),lower,map_beg(/etc/haproxy/maps/_front_defaulthost__begin.map) if !{ var(req.hostbackend) -m found }
     <<https-headers>>
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     use_backend %[var(req.defaultbackend)]
@@ -2464,7 +2464,7 @@ d1.local#/path d1_app_8080
 d1.local#/ d2_app_8080
 `)
 	c.checkMap("_front_defaulthost__begin.map", `
-/ d2_app_8080`)
+<default>#/ d2_app_8080`)
 	c.logger.CompareLogging(defaultLogging)
 }
 

--- a/pkg/haproxy/types/maps.go
+++ b/pkg/haproxy/types/maps.go
@@ -171,6 +171,16 @@ func buildMapKey(match MatchType, hostname, path string) string {
 		//
 		// backend2 would be chosen on beg and reg match types, but backend1
 		// would be chosen if dir was used.
+		//
+		// The default hostname adds a hostname as well due to how map_dir()
+		// converter behaves in HAProxy:
+		//
+		//   /
+		//   <default>#/
+		//
+		// the former pattern doesn't match `/app` but it should, so the
+		// hostname part is added which will make the later pattern match
+		// with `<default>#/app`
 		return hostname + "#" + path
 	}
 	return hostname + path

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -440,7 +440,7 @@ backend {{ $backend.ID }}
 {{- end }}
 {{- $pathsHasHost := $backend.PathsMap.HasHost }}
 {{- range $match := $backend.PathsDefaultHostMap.MatchFiles }}
-    http-request set-var(txn.pathID) var(req.path)
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
         {{- if or $pathsHasHost (not $match.First) }} if !{ var(txn.pathID) -m found }{{ end }}
@@ -1198,10 +1198,11 @@ frontend {{ $proxy__front_http }}
         {{- if not $match.First }} if !{ var(req.backend) -m found }{{ end }}
 {{- end }}
 {{- range $match := $fmaps.DefaultHostMap.MatchFiles }}
-    http-request set-var(req.defaultbackend) var(req.path)
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
-        {{- "" }} if !{ var(req.backend) -m found }{{- if not $match.First }} !{ var(req.defaultbackend) -m found }{{ end }}
+        {{- "" }} if !{ var(req.backend) -m found }
+        {{- if not $match.First }} !{ var(req.defaultbackend) -m found }{{ end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -1274,10 +1275,11 @@ frontend {{ $proxy__front_https }}
         {{- if not $match.First }} if !{ var(req.hostbackend) -m found }{{ end }}
 {{- end }}
 {{- range $match := $fmaps.DefaultHostMap.MatchFiles }}
-    http-request set-var(req.defaultbackend) var(req.path)
+    http-request set-var(req.defaultbackend) str(<default>\#),concat(,req.path)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
-        {{- "" }} if !{ var(req.hostbackend) -m found }{{- if not $match.First }} !{ var(req.defaultbackend) -m found }{{ end }}
+        {{- "" }} if !{ var(req.hostbackend) -m found }
+        {{- if not $match.First }} !{ var(req.defaultbackend) -m found }{{ end }}
 {{- end }}
 
 {{- /*------------------------------------*/}}


### PR DESCRIPTION
HAProxy's subdir match type is used to implement the `Prefix` pathType. This match type however doesn't implement exactly what is expected from the `Prefix` type if a single slash is used as the pattern - ingress expects that `/bar` would match, but it doesn't, matching only `/bar/` instead. This works well with declared hostnames because HAProxy Ingress builds the pattern concatenating hostname and path, but this doesn't happen with the default hostname where the path is configured alone.

This update adds a prefix in the default hostname patterns, just like it's already happening with declared hostnames, in order to them to behave in the same way.