### PR TITLE
Add ssl-fingerprint-sha2-bits configuration key

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -451,6 +451,7 @@ The table below describes all supported configuration keys.
 | [`ssl-dh-param`](#ssl-dh)                            | namespace/secret name                   | Global  | no custom DH param |
 | [`ssl-engine`](#ssl-engine)                          | OpenSSL engine name and parameters      | Global  | no engine set      |
 | [`ssl-fingerprint-lower`](#auth-tls)                 | [true\|false]                           | Backend | `false`            |
+| [`ssl-fingerprint-sha2-bits`](#auth-tls)             | Bits of the SHA-2 fingerprint           | Backend |                    |
 | [`ssl-headers-prefix`](#auth-tls)                    | prefix                                  | Global  | `X-SSL`            |
 | [`ssl-mode-async`](#ssl-engine)                      | [true\|false]                           | Global  | `false`            |
 | [`ssl-options`](#ssl-options)                        | space-separated list                    | Global  | [see description](#ssl-options) |
@@ -848,15 +849,16 @@ See also:
 
 ## Auth TLS
 
-| Configuration key        | Scope     | Default | Since  |
-|--------------------------|-----------|---------|--------|
-| `auth-tls-cert-header`   | `Backend` | `false` |        |
-| `auth-tls-error-page`    | `Host`    |         |        |
-| `auth-tls-secret`        | `Host`    |         |        |
-| `auth-tls-strict`        | `Host`    | `true`  | v0.8.1 |
-| `auth-tls-verify-client` | `Host`    |         |        |
-| `ssl-fingerprint-lower`  | `Backend` | `false` | v0.10  |
-| `ssl-headers-prefix`     | `Global`  | `X-SSL` |        |
+| Configuration key           | Scope     | Default | Since  |
+|-----------------------------|-----------|---------|--------|
+| `auth-tls-cert-header`      | `Backend` | `false` |        |
+| `auth-tls-error-page`       | `Host`    |         |        |
+| `auth-tls-secret`           | `Host`    |         |        |
+| `auth-tls-strict`           | `Host`    | `true`  | v0.8.1 |
+| `auth-tls-verify-client`    | `Host`    |         |        |
+| `ssl-fingerprint-lower`     | `Backend` | `false` | v0.10  |
+| `ssl-fingerprint-sha2-bits` | `Backend` |         | v0.14  |
+| `ssl-headers-prefix`        | `Global`  | `X-SSL` |        |
 
 Configure client authentication with X509 certificate. The following headers are
 added to the request:
@@ -864,6 +866,11 @@ added to the request:
 * `X-SSL-Client-SHA1`: Hex encoding of the SHA-1 fingerprint of the X509 certificate. The default output uses uppercase hexadecimal digits, configure `ssl-fingerprint-lower` to `true` to use lowercase digits instead.
 * `X-SSL-Client-DN`: Distinguished name of the certificate
 * `X-SSL-Client-CN`: Common name of the certificate
+
+These headers can also be added depending on the configuration:
+
+* `X-SSL-Client-SHA2`: Only if `ssl-fingerprint-sha2-bits` is declared. Hex encoding of the SHA-2 fingerprint of the X509 certificate. Valid `ssl-fingerprint-sha2-bits` values are `224`, `256`, `384` or `512`. The default output uses uppercase hexadecimal digits, configure `ssl-fingerprint-lower` to `true` to use lowercase digits instead.
+* `X-SSL-Client-Cert`: Only if `auth-tls-cert-header` is `true`. Base64 encoding of the X509 certificate in DER format.
 
 The prefix of the header names can be configured with `ssl-headers-prefix` key.
 The default value is to `X-SSL`, which will create a `X-SSL-Client-DN` header with
@@ -877,6 +884,7 @@ The following keys are supported:
 * `auth-tls-strict`: Defines if a wrong or incomplete configuration, eg missing secret with `ca.crt`, should forbid connection attempts. If `false`, a wrong or incomplete configuration will ignore the authentication config, allowing anonymous connection. If `true`, a strict configuration is used: all requests will be rejected with HTTP 495 or 496, or redirected to the error page if configured, until a proper `ca.crt` is provided. Strict configuration will only be used if `auth-tls-secret` has a secret name and `auth-tls-verify-client` is missing or is not configured as `off`. This options used to have `false` as the default value up to v0.13, changing its default to `true` since v0.14 to improve security.
 * `auth-tls-verify-client`: Optional configuration of Client Verification behavior. Supported values are `off`, `on`, `optional` and `optional_no_ca`. The default value is `on` if a valid secret is provided, `off` otherwise.
 * `ssl-fingerprint-lower`: Defines if the certificate fingerprint should be in lowercase hexadecimal digits. The default value is `false`, which uses uppercase digits.
+* `ssl-fingerprint-sha2-bits`: Defines the number of bits of the SHA-2 fingerprint of the client certificate. Valid values are `224`, `256`, `384` or `512`. The header `X-SSL-Client-SHA2` will only be added if this option is declared.
 * `ssl-headers-prefix`: Configures which prefix should be used on HTTP headers. Since [RFC 6648](https://tools.ietf.org/html/rfc6648) `X-` prefix on unstandardized headers changed from a convention to deprecation. This configuration allows to select which pattern should be used on header names.
 
 See also:

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -920,6 +920,13 @@ func (c *updater) buildBackendSourceAddressIntf(d *backData) {
 func (c *updater) buildBackendSSL(d *backData) {
 	d.backend.TLS.AddCertHeader = d.mapper.Get(ingtypes.BackAuthTLSCertHeader).Bool()
 	d.backend.TLS.FingerprintLower = d.mapper.Get(ingtypes.BackSSLFingerprintLower).Bool()
+	sha2bits := d.mapper.Get(ingtypes.BackSSLFingerprintSha2Bits)
+	sha2bitsVal := sha2bits.Int()
+	if sha2bitsVal == 0 || sha2bitsVal == 224 || sha2bitsVal == 256 || sha2bitsVal == 384 || sha2bitsVal == 512 {
+		d.backend.TLS.Sha2Bits = sha2bitsVal
+	} else if sha2bits.Source != nil {
+		c.logger.Warn("ignoring SHA-2 fingerprint on %s due to an invalid number of bits: %d", sha2bits.Source, sha2bitsVal)
+	}
 	if cfg := d.mapper.Get(ingtypes.BackSSLCiphersBackend); cfg.Source != nil {
 		d.backend.Server.Ciphers = cfg.Value
 	}

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -166,6 +166,7 @@ const (
 	BackSSLCipherSuitesBackend = "ssl-cipher-suites-backend"
 	BackSSLCiphersBackend      = "ssl-ciphers-backend"
 	BackSSLFingerprintLower    = "ssl-fingerprint-lower"
+	BackSSLFingerprintSha2Bits = "ssl-fingerprint-sha2-bits"
 	BackSSLOptionsBackend      = "ssl-options-backend"
 	BackSSLRedirect            = "ssl-redirect"
 	BackTimeoutConnect         = "timeout-connect"

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1489,6 +1489,7 @@ func TestInstanceFrontingProxy(t *testing.T) {
     http-request del-header X-SSL-Client-CN if !fronting-proxy
     http-request del-header X-SSL-Client-DN if !fronting-proxy
     http-request del-header X-SSL-Client-SHA1 if !fronting-proxy
+    http-request del-header X-SSL-Client-SHA2 if !fronting-proxy
     http-request del-header X-SSL-Client-Cert if !fronting-proxy
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
     use_backend %[var(req.backend)] if { var(req.backend) -m found }`
@@ -1592,6 +1593,7 @@ func TestInstanceFrontingProxy(t *testing.T) {
     http-request del-header X-SSL-Client-CN if !fronting-proxy
     http-request del-header X-SSL-Client-DN if !fronting-proxy
     http-request del-header X-SSL-Client-SHA1 if !fronting-proxy
+    http-request del-header X-SSL-Client-SHA2 if !fronting-proxy
     http-request del-header X-SSL-Client-Cert if !fronting-proxy
     http-request set-var(req.backend) var(req.base),map_reg(/etc/haproxy/maps/_front_http_host__regex.map)
     use_backend %[var(req.backend)] if { var(req.backend) -m found }`,
@@ -1790,6 +1792,7 @@ frontend _front_https
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN
     http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert` + test.expectedACLFront + test.expectedSetvar + `
     http-request use-service lua.send-421 if tls-has-crt { ssl_fc_has_sni } !{ ssl_fc_sni,strcmp(req.host) eq 0 }
     http-request use-service lua.send-496 if { var(req.tls_nocrt_redir) -m str _internal }
@@ -2625,6 +2628,7 @@ func TestInstanceFrontendCA(t *testing.T) {
 	}
 	b.TLS.AddCertHeader = true
 	b.TLS.FingerprintLower = true
+	b.TLS.Sha2Bits = 384
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 
 	c.Update()
@@ -2639,6 +2643,7 @@ backend d_app_8080
     http-request set-header X-SSL-Client-CN   %{+Q}[ssl_c_s_dn(cn)]
     http-request set-header X-SSL-Client-DN   %{+Q}[ssl_c_s_dn]
     http-request set-header X-SSL-Client-SHA1 %{+Q}[ssl_c_sha1,hex,lower]
+    http-request set-header X-SSL-Client-SHA2 %{+Q}[ssl_c_der,sha2(384),hex,lower]
     http-request set-header X-SSL-Client-Cert %{+Q}[ssl_c_der,base64]
     server s1 172.17.0.11:8080 weight 100
 backend default_default-backend_8080
@@ -2966,6 +2971,7 @@ frontend _front_https
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN
     http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert
     # new header
     http-response set-header X-Server HAProxy
@@ -3548,6 +3554,7 @@ frontend _front_http
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN
     http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)` + test.expHTTP + `
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
@@ -3563,6 +3570,7 @@ frontend _front_https
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN
     http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     default_backend _error404
@@ -3693,6 +3701,7 @@ frontend _front_http
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN
     http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert` + test.expected + `
     http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
@@ -3708,6 +3717,7 @@ frontend _front_https
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN
     http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert
     use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
     default_backend _error404
@@ -4698,11 +4708,13 @@ func (c *testConfig) checkConfigFile(expected, fileName string) {
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN
     http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert`,
 		"    <<https-headers>>": `    http-request set-header X-Forwarded-Proto https
     http-request del-header X-SSL-Client-CN
     http-request del-header X-SSL-Client-DN
     http-request del-header X-SSL-Client-SHA1
+    http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert`,
 		"<<frontend-http>>": `frontend _front_http
     mode http

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -742,6 +742,7 @@ type BackendTLSConfig struct {
 	AddCertHeader    bool
 	FingerprintLower bool
 	HasTLSAuth       bool
+	Sha2Bits         int
 }
 
 // UserlistConfig ...

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -598,6 +598,11 @@ backend {{ $backend.ID }}
     http-request set-header {{ $global.SSL.HeadersPrefix }}-Client-SHA1 %{+Q}[ssl_c_sha1,hex
         {{- if $backend.TLS.FingerprintLower }},lower{{ end }}]
         {{- if $needSSLACL }}   if local-offload{{ end }}
+{{- if $backend.TLS.Sha2Bits }}
+    http-request set-header {{ $global.SSL.HeadersPrefix }}-Client-SHA2 %{+Q}[ssl_c_der,sha2({{ $backend.TLS.Sha2Bits }}),hex
+        {{- if $backend.TLS.FingerprintLower }},lower{{ end }}]
+        {{- if $needSSLACL }} if local-offload{{ end }}
+{{- end }}
 {{- if $backend.TLS.AddCertHeader }}
     http-request set-header {{ $global.SSL.HeadersPrefix }}-Client-Cert %{+Q}[ssl_c_der,base64]{{ if $needSSLACL }} if local-offload{{ end }}
 {{- end }}
@@ -1183,6 +1188,8 @@ frontend {{ $proxy__front_http }}
         {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-SHA1
         {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
+    http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-SHA2
+        {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-Cert
         {{- if $hasFrontingProxy }} if !fronting-proxy{{ end }}
 {{- end }}
@@ -1310,6 +1317,7 @@ frontend {{ $proxy__front_https }}
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-CN
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-DN
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-SHA1
+    http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-SHA2
     http-request del-header {{ $global.SSL.HeadersPrefix }}-Client-Cert
 
 {{- /*------------------------------------*/}}


### PR DESCRIPTION
`ssl-fingerprint-sha2-bits` defines the number of bits of the SHA-2 fingerprint of the client certificate of a mTLS request. The header `X-SSL-Client-SHA2` is only added if the configuration is declared.