### PR TITLE
Only inspect SSL handshake for SNI routing for SSL passthrough, fixes #912

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -2037,9 +2037,7 @@ frontend _front_tcp_7011
 frontend _front_tcp_7012
     bind :7012 ssl crt /ssl/7012.pem
     mode tcp
-    tcp-request inspect-delay 5s
     tcp-request content set-var(req.tcpback) ssl_fc_sni,lower,map_str(/etc/haproxy/maps/_tcp_sni_7012__exact.map)
-    tcp-request content accept if { req.ssl_hello_type 1 }
     use_backend %[var(req.tcpback)] if { var(req.tcpback) -m found }
 frontend _front_tcp_7013
     bind :7013

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1010,7 +1010,9 @@ frontend {{ $proxy_name }}
 
 {{- /*------------------------------------*/}}
 {{- if $tcpport.SNIMap.HasHost }}
+{{- if $tls.TLSFilename }}
     tcp-request inspect-delay 5s
+{{- end }}
 {{- range $match := $tcpport.SNIMap.MatchFiles }}
     tcp-request content set-var(req.tcpback) {{ if $tls.TLSFilename }}ssl_fc_sni{{ else }}req.ssl_sni{{ end }},lower
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
@@ -1028,7 +1030,9 @@ frontend {{ $proxy_name }}
 
 {{- /*------------------------------------*/}}
 {{- if $tcpport.SNIMap.HasHost }}
+{{- if $tls.TLSFilename }}
     tcp-request content accept if { req.ssl_hello_type 1 }
+{{- end }}
     use_backend %[var(req.tcpback)] if { var(req.tcpback) -m found }
 {{- end }}
 

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1010,7 +1010,7 @@ frontend {{ $proxy_name }}
 
 {{- /*------------------------------------*/}}
 {{- if $tcpport.SNIMap.HasHost }}
-{{- if $tls.TLSFilename }}
+{{- if not $tls.TLSFilename }}
     tcp-request inspect-delay 5s
 {{- end }}
 {{- range $match := $tcpport.SNIMap.MatchFiles }}
@@ -1030,7 +1030,7 @@ frontend {{ $proxy_name }}
 
 {{- /*------------------------------------*/}}
 {{- if $tcpport.SNIMap.HasHost }}
-{{- if $tls.TLSFilename }}
+{{- if not $tls.TLSFilename }}
     tcp-request content accept if { req.ssl_hello_type 1 }
 {{- end }}
     use_backend %[var(req.tcpback)] if { var(req.tcpback) -m found }


### PR DESCRIPTION
If the TCP port is bound as SSL-enabled, i.e. terminating the SSL connection, `req.ssl_hello_type` is not set and the inspection delay would block the request unnecessarily.

The solution is to only perform the inspection and add the delay if we're passing through the SSL connection and still want to route based on SNI. The delay can be optional in this case as the `ssl_fc_sni` value is immediately available at that point.