### PR TITLE
Fix reload failure detection on 2.5+

### DIFF
--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -670,7 +670,9 @@ func (i *instance) waitWorker() error {
 	if err != nil {
 		return fmt.Errorf("error reading procs from master socket: %w", err)
 	}
-	if len(out.Workers) == 0 {
+	if len(out.Workers) == 0 || out.Master.Failed > 0 {
+		// `len(out.Workers) == 0` => haproxy 2.2 to 2.4
+		// `out.Master.Failed > 0` => haproxy 2.5+
 		return fmt.Errorf("external haproxy was not successfully reloaded")
 	}
 	return nil


### PR DESCRIPTION
HAProxy 2.5 and newer has a new lay out for the `show proc` command. The compatibility change was recently implemented in the controller. Besides the lay out, the way to identity if an instance was properly started was changed as well. This update fixes the reading of this information. This impacts only haproxy running as an external process, and only with haproxy 2.5 and newer.

This update should be merged as far as v0.12, where external haproxy was first implemented.