### PR TITLE
Check type assertion on all informers

### DIFF
--- a/pkg/controller/cache.go
+++ b/pkg/controller/cache.go
@@ -870,6 +870,8 @@ func (c *k8scache) Notify(old, cur interface{}) {
 			if cur == nil {
 				ch.ConfigMapsDel = append(ch.ConfigMapsDel, old)
 			}
+		case cache.DeletedFinalStateUnknown:
+			ch.NeedFullSync = true
 		}
 	}
 	if cur != nil {
@@ -969,6 +971,8 @@ func (c *k8scache) Notify(old, cur interface{}) {
 			}
 		case *api.Pod:
 			ch.PodsNew = append(ch.PodsNew, cur)
+		case cache.DeletedFinalStateUnknown:
+			ch.NeedFullSync = true
 		}
 	}
 	if old == nil && cur == nil {

--- a/pkg/controller/listers.go
+++ b/pkg/controller/listers.go
@@ -300,17 +300,8 @@ func (l *listers) createIngressLister(informer informersnetworking.IngressInform
 		DeleteFunc: func(obj interface{}) {
 			ing, ok := obj.(*networking.Ingress)
 			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					l.logger.Error("couldn't get object from tombstone %#v", obj)
-					l.events.Notify(nil, nil)
-					return
-				}
-				if ing, ok = tombstone.Obj.(*networking.Ingress); !ok {
-					l.logger.Error("Tombstone contained object that is not an Ingress: %#v", obj)
-					l.events.Notify(nil, nil)
-					return
-				}
+				l.events.Notify(nil, nil)
+				return
 			}
 			if !l.events.IsValidIngress(ing) {
 				return
@@ -579,19 +570,7 @@ func (l *listers) createServiceLister(informer informerscore.ServiceInformer) {
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			svc, ok := obj.(*api.Service)
-			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					l.logger.Error("couldn't get object from tombstone %#v", obj)
-					return
-				}
-				if svc, ok = tombstone.Obj.(*api.Service); !ok {
-					l.logger.Error("Tombstone contained object that is not a Service: %#v", obj)
-					return
-				}
-			}
-			l.events.Notify(svc, nil)
+			l.events.Notify(obj, nil)
 		},
 	})
 }
@@ -609,19 +588,7 @@ func (l *listers) createSecretLister(informer informerscore.SecretInformer) {
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			sec, ok := obj.(*api.Secret)
-			if !ok {
-				tombstone, ok := obj.(cache.DeletedFinalStateUnknown)
-				if !ok {
-					l.logger.Error("couldn't get object from tombstone %#v", obj)
-					return
-				}
-				if sec, ok = tombstone.Obj.(*api.Secret); !ok {
-					l.logger.Error("Tombstone contained object that is not a Secret: %#v", obj)
-					return
-				}
-			}
-			l.events.Notify(sec, nil)
+			l.events.Notify(obj, nil)
 		},
 	})
 }
@@ -645,8 +612,13 @@ func (l *listers) createConfigMapLister(informer informerscore.ConfigMapInformer
 			}
 		},
 		DeleteFunc: func(obj interface{}) {
-			if l.events.IsValidConfigMap(obj.(*api.ConfigMap)) {
-				l.events.Notify(obj, nil)
+			cm, ok := obj.(*api.ConfigMap)
+			if !ok {
+				l.events.Notify(nil, nil)
+				return
+			}
+			if l.events.IsValidConfigMap(cm) {
+				l.events.Notify(cm, nil)
 			}
 		},
 	})


### PR DESCRIPTION
Delete event from informers might return `cache.DeletedFinalStateUnknown` instead of the actual object if the object is removed from the api while the watch is closed, e.g. during an outage. Informers that need to check the state of a removed object must check the type, otherwise a panic would be issued. This update implements a safe typecast on the delete event of all informers that were missing it.