### PR TITLE
Remove readiness endpoint from starting config

### DIFF
--- a/rootfs/start.sh
+++ b/rootfs/start.sh
@@ -26,10 +26,6 @@ defaults
     timeout server 1s
     timeout client 1s
     timeout connect 1s
-frontend healthz
-    mode http
-    bind :$port
-    monitor-uri /healthz
 EOF
 else
     # Copy static files to /etc/haproxy, which cannot have static content


### PR DESCRIPTION
External HAProxy starts with a bare minimum configuration, just to serve as a placeholder to the first real configuration. We need this first configuration so we have a process to be reloaded remotely. This needs to be a bare minimum / invalid because in that stage we don't have information enough to create a real configuration.

This starting configuration however might lead to a false positive ready state from the cluster perspective because of the /healthz endpoint implemented in the starting configuration. This endpoint is being removed from that stage, so the cluster can property mark the pod as not ready and remove from load balancers until the real configuration is in place.