### PR TITLE
Documents the expected format for --configmap key

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -71,7 +71,7 @@ The following sections describe in a few more details about configuration strate
 
 ConfigMap key/value options are read in the following conditions:
 
-* Global config, using `--configmap` command-line option. The installation process configures a Global config ConfigMap named `haproxy-ingress` in the controller namespace. This is the only way to configure keys from the `Global` scope. See about scopes [later](#scope) in this page.
+* Global config, using `--configmap` command-line option. The installation process configures a Global config ConfigMap named `haproxy-ingress` in the controller namespace. This is the only way to configure keys from the `Global` scope. See about scopes [later](#scope) in this page. Note, `--configmap` needs to be in the following format: `<namespace>/<configmap-name>`.
 * IngressClass config, using its `parameters` field linked to a ConfigMap declared in the same namespace of the controller. See about IngressClass [later](#ingressclass) in this same section.
 
 A configuration key is used verbatim as the ConfigMap key name, without any prefix.


### PR DESCRIPTION
If this format is not followed following error is thrown:

`
2022/08/01 08:50:43 unable to parse static config: error reading global ConfigMap 'haproxy-ingress': an empty namespace may not be set when a resource name is provided
`

that actually is thrown by k8.

I'm not sure if it is a common knowledge to always use namespace when specifying a configmap. Ignore this if that is the case.
If not, then i guess the format can also be enforced at the time of parsing `--configmap` arg?