### PR TITLE
Add apk upgrade on container building

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -32,7 +32,7 @@ FROM haproxy:2.4.17-alpine
 
 USER root
 
-RUN apk --no-cache add socat openssl lua5.3 lua-json4 dumb-init
+RUN apk upgrade --no-cache && apk --no-cache add socat openssl lua5.3 lua-json4 dumb-init
 
 COPY rootfs/ /
 COPY --from=builder /src/haproxy-ingress /haproxy-ingress-controller

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -16,7 +16,7 @@ FROM haproxy:2.4.17-alpine
 
 USER root
 
-RUN apk --no-cache add socat openssl lua5.3 lua-json4 dumb-init
+RUN apk upgrade --no-cache && apk --no-cache add socat openssl lua5.3 lua-json4 dumb-init
 
 COPY . /
 


### PR DESCRIPTION
Sometimes HAProxy Ingress is released a few weeks after the upstream haproxy container, or sometimes a new release is needed to fix a security vulnerability. Adding `apk upgrade` during the container building process guarantee that the most up to date dependencies, in the date of the controller release, will be used in the generated image.

This should be merged to all maintained versions.