### PR TITLE
Add support for service external name without port

### DIFF
--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -26,6 +26,7 @@ import (
 
 	api "k8s.io/api/core/v1"
 	networking "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/annotations"
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
@@ -753,7 +754,18 @@ func (c *converter) addBackendWithClass(source *annotations.Source, pathLink hat
 	}
 	port := convutils.FindServicePort(svc, svcPort)
 	if port == nil {
-		return nil, fmt.Errorf("port not found: '%s'", svcPort)
+		if svc.Spec.Type != api.ServiceTypeExternalName || len(svc.Spec.Ports) > 0 {
+			return nil, fmt.Errorf("port not found: '%s'", svcPort)
+		}
+		portNumber, _ := strconv.Atoi(svcPort)
+		if portNumber == 0 {
+			return nil, fmt.Errorf("service %s has no port and ingress port is not numerical: '%s'",
+				api.ServiceTypeExternalName, svcPort)
+		}
+		port = &api.ServicePort{
+			Port:       int32(portNumber),
+			TargetPort: intstr.FromInt(portNumber),
+		}
 	}
 	backend := c.haproxy.Backends().AcquireBackend(namespace, svcName, port.TargetPort.String())
 	c.tracker.TrackNames(source.Type, source.FullName(), convtypes.ResourceHABackend, backend.ID)

--- a/pkg/converters/utils/services.go
+++ b/pkg/converters/utils/services.go
@@ -115,7 +115,6 @@ func CreateSvcEndpoint(svc *api.Service, svcPort *api.ServicePort) (endpoint *En
 }
 
 func createEndpointsExternalName(cache types.Cache, svc *api.Service, svcPort *api.ServicePort) (endpoints []*Endpoint, err error) {
-	// TODO add support to undeclared ServicePort
 	port := int(svcPort.Port)
 	if port <= 0 {
 		return nil, fmt.Errorf("invalid port number: %d", port)


### PR DESCRIPTION
A backend server is configured with the port number declared in the
service. However, services of type ExternalName doesn't need to have
a port declared, and since the v0.8 refactor, HAProxy Ingress refuses
to configure backends for services without port.

This update checks if the service is of type ExternalName and if the
ingress referencing this service uses a numeric port number. If true,
the port number declared in the ingress will be used as the port to
connect to the backend.