### PR TITLE
Make WAF errors fail closed by default. Add waf-fail-closed=false to override

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -2856,7 +2856,7 @@ See also:
 | Configuration key | Scope  | Default | Since |
 |-------------------|--------|---------|-------|
 | `waf`             | `Path` |         |       |
-| `waf-fail-closed` | `Path` | `true`  | v0.15 |
+| `waf-fail-closed` | `Path` | `true`  | v0.14 |
 | `waf-mode`        | `Path` | `deny`  | v0.9  |
 
 
@@ -2866,7 +2866,7 @@ to validate requests. Currently the only supported value is `modsecurity`.
 This configuration has no effect if the ModSecurity endpoints are not configured.
 
 The `waf-fail-closed` key determines whether an error from the WAF (such as a timeout) should
-cause the request to be denied ("true") or allowed ("false"). The default value of "true" means that errors or timeouts will cause requests to be denied.
+cause the request to be denied ("true") or allowed ("false"). In v0.14, this defaults to "false" for backwards compatibility. In v0.15, this defaults to "true" which means that errors or timeouts will cause requests to be denied.
 
 The `waf-mode` key defines whether the WAF should be `deny` or `detect` for that Backend.
 If the WAF is in `detect` mode the requests are passed to ModSecurity and logged, but not denied.

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -503,6 +503,7 @@ The table below describes all supported configuration keys.
 | [`username`](#security)                              | haproxy user name                       | Global  | `haproxy`          |
 | [`var-namespace`](#var-namespace)                    | [true\|false]                           | Host    | `false`            |
 | [`waf`](#waf)                                        | "modsecurity"                           | Path    |                    |
+| [`waf-fail-closed`](#waf)                            | [true\|false]                           | Path    | `true` |
 | [`waf-mode`](#waf)                                   | [deny\|detect]                          | Path    | `deny` (if waf is set) |
 | [`whitelist-source-range`](#allowlist)               | Comma-separated IPs or CIDRs            | Path    |                    |
 | [`worker-max-reloads`](#master-worker)               | number of reloads                       | Global  | `0`                |
@@ -2855,16 +2856,20 @@ See also:
 | Configuration key | Scope  | Default | Since |
 |-------------------|--------|---------|-------|
 | `waf`             | `Path` |         |       |
+| `waf-fail-closed` | `Path` | `true`  | v0.15 |
 | `waf-mode`        | `Path` | `deny`  | v0.9  |
+
 
 Defines which web application firewall (WAF) implementation should be used
 to validate requests. Currently the only supported value is `modsecurity`.
 
 This configuration has no effect if the ModSecurity endpoints are not configured.
 
+The `waf-fail-closed` key determines whether an error from the WAF (such as a timeout) should
+cause the request to be denied ("true") or allowed ("false"). The default value of "true" means that errors or timeouts will cause requests to be denied.
+
 The `waf-mode` key defines whether the WAF should be `deny` or `detect` for that Backend.
 If the WAF is in `detect` mode the requests are passed to ModSecurity and logged, but not denied.
-
 The default behavior here is `deny` if `waf` is set to `modsecurity`.
 
 See also:

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -997,8 +997,11 @@ func (c *updater) buildBackendWAF(d *backData) {
 			c.logger.Warn("ignoring invalid WAF mode '%s' on %s, using 'deny' instead", mode, wafMode.Source)
 			mode = "deny"
 		}
+		wafFailClosed := config.Get(ingtypes.BackWAFFailClosed).Bool()
+
 		path.WAF.Module = module
 		path.WAF.Mode = mode
+		path.WAF.FailClosed = wafFailClosed
 	}
 }
 

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -73,6 +73,7 @@ func createDefaults() map[string]string {
 		types.BackTimeoutServer:          "50s",
 		types.BackTimeoutServerFin:       "50s",
 		types.BackTimeoutTunnel:          "1h",
+		types.BackWAFFailClosed:          "true",
 		types.BackWAFMode:                "deny",
 		//
 		types.GlobalAcmeExpiring:                 "30",

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -181,6 +181,7 @@ const (
 	BackTimeoutTunnel          = "timeout-tunnel"
 	BackUseResolver            = "use-resolver"
 	BackWAF                    = "waf"
+	BackWAFFailClosed          = "waf-fail-closed"
 	BackWAFMode                = "waf-mode"
 	BackWhitelistSourceRange   = "whitelist-source-range"
 )

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -4794,6 +4794,7 @@ frontend healthz
 func TestModSecurity(t *testing.T) {
 	testCases := []struct {
 		waf             string
+		wafFailClosed   bool
 		wafmode         string
 		path            string
 		endpoints       []string
@@ -4803,38 +4804,42 @@ func TestModSecurity(t *testing.T) {
 		modsecAgentExp  string
 	}{
 		{
-			waf:        "modsecurity",
-			wafmode:    "On",
-			endpoints:  []string{},
-			backendExp: ``,
-			modsecExp:  ``,
+			waf:           "modsecurity",
+			wafFailClosed: true,
+			wafmode:       "On",
+			endpoints:     []string{},
+			backendExp:    ``,
+			modsecExp:     ``,
 		},
 		{
-			waf:        "",
-			wafmode:    "",
-			endpoints:  []string{"10.0.0.101:12345"},
-			backendExp: ``,
+			waf:           "",
+			wafFailClosed: true,
+			wafmode:       "",
+			endpoints:     []string{"10.0.0.101:12345"},
+			backendExp:    ``,
 			modsecExp: `
     timeout connect 1s
     timeout server  2s
     server modsec-spoa0 10.0.0.101:12345`,
 		},
 		{
-			waf:       "modsecurity",
-			wafmode:   "deny",
-			endpoints: []string{"10.0.0.101:12345"},
+			waf:           "modsecurity",
+			wafFailClosed: true,
+			wafmode:       "deny",
+			endpoints:     []string{"10.0.0.101:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
-    http-request deny if { var(txn.modsec.code) -m int gt 0 }`,
+    http-request deny if !{ var(txn.modsec.code) -m int eq 0 }`,
 			modsecExp: `
     timeout connect 1s
     timeout server  2s
     server modsec-spoa0 10.0.0.101:12345`,
 		},
 		{
-			waf:       "modsecurity",
-			wafmode:   "detect",
-			endpoints: []string{"10.0.0.101:12345"},
+			waf:           "modsecurity",
+			wafFailClosed: true,
+			wafmode:       "detect",
+			endpoints:     []string{"10.0.0.101:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf`,
 			modsecExp: `
@@ -4843,12 +4848,13 @@ func TestModSecurity(t *testing.T) {
     server modsec-spoa0 10.0.0.101:12345`,
 		},
 		{
-			waf:       "modsecurity",
-			wafmode:   "deny",
-			endpoints: []string{"10.0.0.101:12345", "10.0.0.102:12345"},
+			waf:           "modsecurity",
+			wafFailClosed: true,
+			wafmode:       "deny",
+			endpoints:     []string{"10.0.0.101:12345", "10.0.0.102:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
-    http-request deny if { var(txn.modsec.code) -m int gt 0 }`,
+    http-request deny if !{ var(txn.modsec.code) -m int eq 0 }`,
 			modsecExp: `
     timeout connect 1s
     timeout server  2s
@@ -4856,16 +4862,17 @@ func TestModSecurity(t *testing.T) {
     server modsec-spoa1 10.0.0.102:12345`,
 		},
 		{
-			waf:       "modsecurity",
-			wafmode:   "deny",
-			endpoints: []string{"10.0.0.101:12345"},
-			path:      "/sub",
+			waf:           "modsecurity",
+			wafFailClosed: true,
+			wafmode:       "deny",
+			endpoints:     []string{"10.0.0.101:12345"},
+			path:          "/sub",
 			backendExp: `
     # path02 = d1.local/
     # path01 = d1.local/sub
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_idpath__begin.map)
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
-    http-request deny if { var(txn.modsec.code) -m int gt 0 } { var(txn.pathID) -m str path01 }`,
+    http-request deny if !{ var(txn.modsec.code) -m int eq 0 } { var(txn.pathID) -m str path01 }`,
 			modsecExp: `
     timeout connect 1s
     timeout server  2s
@@ -4873,9 +4880,10 @@ func TestModSecurity(t *testing.T) {
 		},
 		// Test setting custom args
 		{
-			waf:       "modsecurity",
-			wafmode:   "detect",
-			endpoints: []string{"10.0.0.101:12345"},
+			waf:           "modsecurity",
+			wafFailClosed: true,
+			wafmode:       "detect",
+			endpoints:     []string{"10.0.0.101:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf`,
 			modsecExp: `
@@ -4887,6 +4895,20 @@ func TestModSecurity(t *testing.T) {
 			modsecAgentExp: `
     args   unique-id method path query req.ver req.hdrs_bin
     event  on-backend-http-request`,
+		},
+		// Test waf-fail-closed=false
+		{
+			waf:           "modsecurity",
+			wafFailClosed: false,
+			wafmode:       "deny",
+			endpoints:     []string{"10.0.0.101:12345"},
+			backendExp: `
+    filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
+    http-request deny if { var(txn.modsec.code) -m int gt 0 }`,
+			modsecExp: `
+    timeout connect 1s
+    timeout server  2s
+    server modsec-spoa0 10.0.0.101:12345`,
 		},
 	}
 	for _, test := range testCases {
@@ -4901,8 +4923,9 @@ func TestModSecurity(t *testing.T) {
 		}
 		h.AddPath(b, test.path, hatypes.MatchBegin)
 		b.FindBackendPath(h.FindPath(test.path)[0].Link).WAF = hatypes.WAF{
-			Module: test.waf,
-			Mode:   test.wafmode,
+			Module:     test.waf,
+			Mode:       test.wafmode,
+			FailClosed: test.wafFailClosed,
 		}
 		if test.path != "/" {
 			h.AddPath(b, "/", hatypes.MatchBegin)

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -850,6 +850,8 @@ type HSTS struct {
 type WAF struct {
 	// Mode defines On or DetectionOnly
 	Mode string
+	// Whether WAF errors should cause the request to be denied
+	FailClosed bool
 	// Which WAF Module should be used
 	Module string
 }

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -582,11 +582,11 @@ backend {{ $backend.ID }}
 {{- range $i, $waf := $wafCfg.Items }}
 {{- if eq $waf.Mode "deny" }}
 {{- range $pathIDs := $wafCfg.PathIDs $i }}
-    {{- if $waf.FailClosed }}
+{{- if $waf.FailClosed }}
     http-request deny if !{ var(txn.modsec.code) -m int eq 0 }
-    {{- else }}
+{{- else }}
     http-request deny if { var(txn.modsec.code) -m int gt 0 }
-    {{- end }}
+{{- end }}
         {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -582,7 +582,11 @@ backend {{ $backend.ID }}
 {{- range $i, $waf := $wafCfg.Items }}
 {{- if eq $waf.Mode "deny" }}
 {{- range $pathIDs := $wafCfg.PathIDs $i }}
+    {{- if $waf.FailClosed }}
+    http-request deny if !{ var(txn.modsec.code) -m int eq 0 }
+    {{- else }}
     http-request deny if { var(txn.modsec.code) -m int gt 0 }
+    {{- end }}
         {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Full issue is described here: https://github.com/haproxy/spoa-modsecurity/issues/3

**Note: This is a breaking change from 0.14 to 0.15**

This PR changes the default behavior (that we copied from the upstream spoa-modsecurity docs) of allowing requests through if modsecurity errors out or times out. Now, only a valid response from modsecurity (`txn.modsec.code=0`) will allow requests through.

Users can go back to the old behavior by setting `waf-fail-closed: false` which would mean that e.g. a flood of requests could overload modsecurity-spoa and trigger timeouts, which would allow requests through without being scanned by modsecurity.