### PR TITLE
Change klog.Fatal to klog.Exit

### DIFF
--- a/pkg/common/ingress/controller/controller.go
+++ b/pkg/common/ingress/controller/controller.go
@@ -219,7 +219,7 @@ func (ic *GenericController) CreateDefaultSSLCertificate() (path, hash string, c
 	)
 	c, err := ssl.AddOrUpdateCertAndKey("default-fake-certificate", defCert, defKey, []byte{})
 	if err != nil {
-		klog.Fatalf("Error generating self signed certificate: %v", err)
+		klog.Exitf("Error generating self signed certificate: %v", err)
 	}
 	return c.PemFileName, c.PemSHA, c.Certificate
 }

--- a/pkg/common/ingress/controller/launch.go
+++ b/pkg/common/ingress/controller/launch.go
@@ -333,7 +333,7 @@ tracked.`)
 	}
 
 	if !(*reloadStrategy == "native" || *reloadStrategy == "reusesocket" || *reloadStrategy == "multibinder") {
-		klog.Fatalf("Unsupported reload strategy: %v", *reloadStrategy)
+		klog.Exitf("Unsupported reload strategy: %v", *reloadStrategy)
 	}
 	if *reloadStrategy == "multibinder" {
 		klog.Warningf("multibinder is deprecated, using reusesocket strategy instead. update your deployment configuration")
@@ -349,12 +349,12 @@ tracked.`)
 	if *configMap != "" {
 		ns, name, err := k8s.ParseNameNS(*configMap)
 		if err != nil {
-			klog.Fatalf("invalid format for configmap %s: %v", *configMap, err)
+			klog.Exitf("invalid format for configmap %s: %v", *configMap, err)
 		}
 
 		_, err = kubeClient.CoreV1().ConfigMaps(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			klog.Fatalf("error reading configmap '%s': %v", *configMap, err)
+			klog.Exitf("error reading configmap '%s': %v", *configMap, err)
 		}
 		klog.Infof("watching for global config options from configmap '%s' - --configmap was defined", *configMap)
 	}
@@ -362,15 +362,15 @@ tracked.`)
 	if *defaultSvc != "" {
 		ns, name, err := k8s.ParseNameNS(*defaultSvc)
 		if err != nil {
-			klog.Fatalf("invalid format for service %v: %v", *defaultSvc, err)
+			klog.Exitf("invalid format for service %v: %v", *defaultSvc, err)
 		}
 
 		_, err = kubeClient.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
 			if strings.Contains(err.Error(), "cannot get services in the namespace") {
-				klog.Fatalf("✖ It seems the cluster it is running with Authorization enabled (like RBAC) and there is no permissions for the ingress controller. Please check the configuration")
+				klog.Exitf("✖ It seems the cluster it is running with Authorization enabled (like RBAC) and there is no permissions for the ingress controller. Please check the configuration")
 			}
-			klog.Fatalf("no service with name %v found: %v", *defaultSvc, err)
+			klog.Exitf("no service with name %v found: %v", *defaultSvc, err)
 		}
 		klog.Infof("validated %v as the default backend", *defaultSvc)
 	}
@@ -378,12 +378,12 @@ tracked.`)
 	if *publishSvc != "" {
 		ns, name, err := k8s.ParseNameNS(*publishSvc)
 		if err != nil {
-			klog.Fatalf("invalid service format: %v", err)
+			klog.Exitf("invalid service format: %v", err)
 		}
 
 		svc, err := kubeClient.CoreV1().Services(ns).Get(ctx, name, metav1.GetOptions{})
 		if err != nil {
-			klog.Fatalf("unexpected error getting information about service %v: %v", *publishSvc, err)
+			klog.Exitf("unexpected error getting information about service %v: %v", *publishSvc, err)
 		}
 
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
@@ -391,7 +391,7 @@ tracked.`)
 				klog.Infof("service %v validated as assigned with externalIP", *publishSvc)
 			} else {
 				// We could poll here, but we instead just exit and rely on k8s to restart us
-				klog.Fatalf("service %s does not (yet) have ingress points", *publishSvc)
+				klog.Exitf("service %s does not (yet) have ingress points", *publishSvc)
 			}
 		} else {
 			klog.Infof("service %v validated as source of Ingress status", *publishSvc)
@@ -401,30 +401,30 @@ tracked.`)
 	if *watchNamespace != "" {
 		_, err = kubeClient.NetworkingV1().Ingresses(*watchNamespace).List(ctx, metav1.ListOptions{Limit: 1})
 		if err != nil {
-			klog.Fatalf("no watchNamespace with name %v found: %v", *watchNamespace, err)
+			klog.Exitf("no watchNamespace with name %v found: %v", *watchNamespace, err)
 		}
 	} else {
 		_, err = kubeClient.CoreV1().Services("default").Get(ctx, "kubernetes", metav1.GetOptions{})
 		if err != nil {
-			klog.Fatalf("error connecting to the apiserver: %v", err)
+			klog.Exitf("error connecting to the apiserver: %v", err)
 		}
 	}
 
 	if *rateLimitUpdate <= 0 {
-		klog.Fatalf("rate limit must be greater than zero")
+		klog.Exitf("rate limit must be greater than zero")
 	}
 
 	if *rateLimitUpdate < 0.05 {
-		klog.Fatalf("rate limit update (%v) is too low: %v seconds between Ingress reloads. Use at least 0.05, which means 20 seconds between reloads",
+		klog.Exitf("rate limit update (%v) is too low: %v seconds between Ingress reloads. Use at least 0.05, which means 20 seconds between reloads",
 			*rateLimitUpdate, 1.0 / *rateLimitUpdate)
 	}
 
 	if *rateLimitUpdate > 10 {
-		klog.Fatalf("rate limit update is too high: up to %v Ingress reloads per second (max is 10)", *rateLimitUpdate)
+		klog.Exitf("rate limit update is too high: up to %v Ingress reloads per second (max is 10)", *rateLimitUpdate)
 	}
 
 	if resyncPeriod.Seconds() < 10 {
-		klog.Fatalf("resync period (%vs) is too low", resyncPeriod.Seconds())
+		klog.Exitf("resync period (%vs) is too low", resyncPeriod.Seconds())
 	}
 
 	for _, dir := range []*string{
@@ -440,12 +440,12 @@ tracked.`)
 		// TODO evolve this ugly trick to a proper struct that allows custom configuration
 		*dir = *localFSPrefix + *dir
 		if err := os.MkdirAll(*dir, 0755); err != nil {
-			klog.Fatalf("Failed to mkdir %s: %v", *dir, err)
+			klog.Exitf("Failed to mkdir %s: %v", *dir, err)
 		}
 	}
 
 	if *forceIsolation && *allowCrossNamespace {
-		klog.Fatal("Cannot use --allow-cross-namespace if --force-namespace-isolation is true")
+		klog.Exit("Cannot use --allow-cross-namespace if --force-namespace-isolation is true")
 	}
 
 	var annPrefixList []string
@@ -457,7 +457,7 @@ tracked.`)
 	}
 	switch len(annPrefixList) {
 	case 0:
-		klog.Fatal("At least one annotation prefix should be configured")
+		klog.Exit("At least one annotation prefix should be configured")
 	case 1:
 		klog.Infof("using annotations prefix: %s", annPrefixList[0])
 	default:
@@ -474,7 +474,7 @@ tracked.`)
 		}
 	}
 	if !stringInSlice(sortEndpoints, []string{"ep", "endpoint", "ip", "name", "random"}) {
-		klog.Fatalf("Unsupported --sort-endpoint-by option: %s", sortEndpoints)
+		klog.Exitf("Unsupported --sort-endpoint-by option: %s", sortEndpoints)
 	}
 
 	config := &Configuration{
@@ -590,7 +590,7 @@ func registerHandlers(enableProfiling bool, port int, ic *GenericController) {
 		Addr:    fmt.Sprintf(":%v", port),
 		Handler: mux,
 	}
-	klog.Fatal(server.ListenAndServe())
+	klog.Exit(server.ListenAndServe())
 }
 
 const (
@@ -682,7 +682,7 @@ func createApiserverClient(apiserverHost string, kubeConfig string, disableWarni
  * message and quits the server.
  */
 func handleFatalInitError(err error) {
-	klog.Fatalf("Error while initializing connection to Kubernetes apiserver. "+
+	klog.Exitf("Error while initializing connection to Kubernetes apiserver. "+
 		"This most likely means that the cluster is misconfigured (e.g., it has "+
 		"invalid apiserver certificates or service accounts configuration). Reason: %s", err)
 }

--- a/pkg/common/ingress/controller/status.go
+++ b/pkg/common/ingress/controller/status.go
@@ -152,7 +152,7 @@ func (s statusSync) keyfunc(input interface{}) (interface{}, error) {
 func NewStatusSyncer(ic *GenericController) StatusSync {
 	pod, err := k8s.GetPodDetails(ic.cfg.Client)
 	if err != nil {
-		klog.Fatalf("unexpected error obtaining pod information: %v", err)
+		klog.Exitf("unexpected error obtaining pod information: %v", err)
 	}
 
 	st := statusSync{
@@ -198,7 +198,7 @@ func NewStatusSyncer(ic *GenericController) StatusSync {
 	)
 
 	if err != nil {
-		klog.Fatalf("unexpected error configuring leader election resource lock: %v", err)
+		klog.Exitf("unexpected error configuring leader election resource lock: %v", err)
 	}
 
 	ttl := 30 * time.Second
@@ -211,7 +211,7 @@ func NewStatusSyncer(ic *GenericController) StatusSync {
 	})
 
 	if err != nil {
-		klog.Fatalf("unexpected error starting leader election: %v", err)
+		klog.Exitf("unexpected error starting leader election: %v", err)
 	}
 
 	st.elector = le

--- a/pkg/common/net/ssl/ssl.go
+++ b/pkg/common/net/ssl/ssl.go
@@ -375,7 +375,7 @@ func GetFakeSSLCert(o []string, cn string, dns []string) (cert, key []byte) {
 	priv, err = rsa.GenerateKey(rand.Reader, 2048)
 
 	if err != nil {
-		klog.Fatalf("failed to generate fake private key: %s", err)
+		klog.Exitf("failed to generate fake private key: %s", err)
 	}
 
 	notBefore := time.Now()
@@ -386,7 +386,7 @@ func GetFakeSSLCert(o []string, cn string, dns []string) (cert, key []byte) {
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 
 	if err != nil {
-		klog.Fatalf("failed to generate fake serial number: %s", err)
+		klog.Exitf("failed to generate fake serial number: %s", err)
 	}
 
 	template := x509.Certificate{
@@ -405,7 +405,7 @@ func GetFakeSSLCert(o []string, cn string, dns []string) (cert, key []byte) {
 	}
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.(*rsa.PrivateKey).PublicKey, priv)
 	if err != nil {
-		klog.Fatalf("Failed to create fake certificate: %s", err)
+		klog.Exitf("Failed to create fake certificate: %s", err)
 	}
 
 	cert = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -151,7 +151,7 @@ func (hc *HAProxyController) configController() {
 	}
 	hc.instance = haproxy.CreateInstance(hc.logger, instanceOptions)
 	if err := hc.instance.ParseTemplates(); err != nil {
-		klog.Fatalf("error creating HAProxy instance: %v", err)
+		klog.Exitf("error creating HAProxy instance: %v", err)
 	}
 	hc.converterOptions = &convtypes.ConverterOptions{
 		Logger:           hc.logger,
@@ -228,7 +228,7 @@ func (hc *HAProxyController) createFakeCAFile() (crtFile convtypes.CrtFile) {
 	fakeCA, _ := ssl.GetFakeSSLCert([]string{}, "Fake CA", []string{})
 	fakeCAFile, err := ssl.AddCertAuth("fake-ca", fakeCA, []byte{})
 	if err != nil {
-		klog.Fatalf("error generating fake CA: %v", err)
+		klog.Exitf("error generating fake CA: %v", err)
 	}
 	crtFile = convtypes.CrtFile{
 		Filename: fakeCAFile.PemFileName,

--- a/pkg/controller/logger.go
+++ b/pkg/controller/logger.go
@@ -52,5 +52,5 @@ func (l *logger) Error(msg string, args ...interface{}) {
 }
 
 func (l *logger) Fatal(msg string, args ...interface{}) {
-	klog.FatalDepth(l.depth, l.build(msg, args))
+	klog.ExitDepth(l.depth, l.build(msg, args))
 }

--- a/pkg/haproxy/template/funcmap.go
+++ b/pkg/haproxy/template/funcmap.go
@@ -65,7 +65,7 @@ func createFuncMap() gotemplate.FuncMap {
 		},
 	}
 	if err := mergo.Merge(&fnc, sprig.TxtFuncMap()); err != nil {
-		klog.Fatalf("Cannot merge funcMap and sprig.FuncMap(): %v", err)
+		klog.Exitf("Cannot merge funcMap and sprig.FuncMap(): %v", err)
 	}
 	return fnc
 }


### PR DESCRIPTION
`klog.Fatal()` adds stack traces alongside the message and we don't need that. All the logs comes from a bootstrap validation error, so we just need the message and quit the process with code>0. Changing all the `klog.Fatal()` to `klog.Exit()` do that.