### PR TITLE
Enable Load Server State feature for external haproxy

### DIFF
--- a/pkg/haproxy/connections.go
+++ b/pkg/haproxy/connections.go
@@ -37,6 +37,7 @@ type connections struct {
 	masterSock   string
 	adminSock    string
 	oldInstances []socket.HAProxySocket
+	admin        socket.HAProxySocket
 	master       socket.HAProxySocket
 	dynUpdate    socket.HAProxySocket
 	idleChk      socket.HAProxySocket
@@ -124,6 +125,13 @@ func shutdownSessionsSync(sock socket.HAProxySocket, duration time.Duration) {
 		// but it's currently between the end of the former and the start of the next.
 		time.Sleep(interval)
 	}
+}
+
+func (c *connections) Admin() socket.HAProxySocket {
+	if c.admin == nil {
+		c.admin = socket.NewSocket(c.adminSock, false)
+	}
+	return c.admin
 }
 
 func (c *connections) Master() socket.HAProxySocket {

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -729,21 +729,23 @@ func (i *instance) waitWorker() error {
 }
 
 func (i *instance) retrieveServersState() (string, error) {
-	if state, err := i.conns.Admin().Send(nil, "show servers state"); err != nil {
+	state, err := i.conns.Admin().Send(nil, "show servers state")
+	if err != nil {
 		return "", fmt.Errorf("failed to retrieve servers state from external haproxy; %w", err)
-	} else {
-		return state[0], nil
 	}
+
+	return state[0], nil
 }
 
 func (i *instance) persistServersState() error {
-	if state, err := i.retrieveServersState(); err != nil {
+	state, err := i.retrieveServersState()
+	if err != nil {
 		return err
-	} else {
-		stateFilePath := filepath.Join(i.config.Global().LocalFSPrefix, "/var/lib/haproxy/state-global")
-		if err := os.WriteFile(stateFilePath, []byte(state), 0o644); err != nil {
-			return fmt.Errorf("failed to persist servers state to file '%s': %w", stateFilePath, err)
-		}
+	}
+
+	stateFilePath := filepath.Join(i.config.Global().LocalFSPrefix, "/var/lib/haproxy/state-global")
+	if err := os.WriteFile(stateFilePath, []byte(state), 0o644); err != nil {
+		return fmt.Errorf("failed to persist servers state to file '%s': %w", stateFilePath, err)
 	}
 
 	return nil

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -741,7 +741,7 @@ func (i *instance) persistServersState() error {
 		return err
 	} else {
 		stateFilePath := filepath.Join(i.config.Global().LocalFSPrefix, "/var/lib/haproxy/state-global")
-		if err := os.WriteFile(stateFilePath, []byte(state), os.ModePerm); err != nil {
+		if err := os.WriteFile(stateFilePath, []byte(state), 0o644); err != nil {
 			return fmt.Errorf("failed to persist servers state to file '%s': %w", stateFilePath, err)
 		}
 	}

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -705,7 +705,9 @@ func (i *instance) waitMaster() error {
 
 func (i *instance) reloadWorker() error {
 	if i.config.Global().LoadServerState {
-		i.persistServersState()
+		if err := i.persistServersState(); err != nil {
+			i.logger.Warn("failed to persist servers state before worker reload: %w", err)
+		}
 	}
 	if _, err := i.conns.Master().Send(nil, "reload"); err != nil {
 		return fmt.Errorf("error sending reload to master socket: %w", err)


### PR DESCRIPTION
This should make the [Load Server State](https://haproxy-ingress.github.io/docs/configuration/keys/#load-server-state) feature work for setups where external haproxy is used. 