### PR TITLE
Improve dashboard compatibility and cpu display

### DIFF
--- a/docs/content/en/docs/examples/metrics/haproxy-ingress-dashboard.json
+++ b/docs/content/en/docs/examples/metrics/haproxy-ingress-dashboard.json
@@ -1381,7 +1381,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "rate(process_cpu_seconds_total{cluster=~\"$cluster\",hostname=~\"$hostname\"}[1m])",
+              "expr": "rate(process_cpu_seconds_total{cluster=~\"$cluster\",hostname=~\"$hostname\",job=\"haproxy-ingress\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -3020,7 +3020,7 @@
         "type": "query"
       },
       {
-        "allValue": ".+",
+        "allValue": ".*",
         "current": {},
         "datasource": {
           "type": "prometheus",


### PR DESCRIPTION
* Changed the panel for displaying CPU usage to specifically select haproxy. The old panel would show CPU usage for every container in the cluster without the extra label I added.
* The `cluster` and `hostname` labels seem to be specific to other people's Prometheus instances since I don't have those labels. As a result, I rely on the "allValue" to still see stuff in the dashboard, but the old value of `.+` for hostname meant that nothing would appear even if I did select "All". Changing it to `.*` to match the other "allValue"s means the hostname is no longer required.