### PR TITLE
Coraza support

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,5 @@
 package-lock.json
 public/
 resources/
+!static/resources/
 node_modules/

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -415,6 +415,7 @@ The table below describes all supported configuration keys.
 | [`modsecurity-timeout-hello`](#modsecurity)          | time with suffix                        | Global  | `100ms`            |
 | [`modsecurity-timeout-idle`](#modsecurity)           | time with suffix                        | Global  | `30s`              |
 | [`modsecurity-timeout-processing`](#modsecurity)     | time with suffix                        | Global  | `1s`               |
+| [`modsecurity-use-coraza`](#modsecurity)             | [true\|false]                           | Global  | `false`               |
 | [`nbproc-ssl`](#nbproc)                              | number of process                       | Global  | `0`                |
 | [`nbthread`](#nbthread)                              | number of threads                       | Global  |                    |
 | [`no-tls-redirect-locations`](#ssl-redirect)         | comma-separated list of URIs            | Global  | `/.well-known/acme-challenge` |
@@ -1997,6 +1998,7 @@ See also:
 | `modsecurity-timeout-idle`       | `Global` | `30s`   |       |
 | `modsecurity-timeout-processing` | `Global` | `1s`    |       |
 | `modsecurity-timeout-server`     | `Global` | `5s`    | v0.10 |
+| `modsecurity-use-coraza`         | `Global` | `false` | v0.14 |
 
 
 Configure modsecurity agent. These options only have effect if `modsecurity-endpoints`
@@ -2019,10 +2021,11 @@ The following keys are supported:
 * `modsecurity-timeout-idle`: Defines the maximum time to wait before close an idle connection. Default value is `30s`.
 * `modsecurity-timeout-processing`: Defines the maximum time to wait for the whole ModSecurity processing. Default value is `1s`.
 * `modsecurity-timeout-server`: Defines the maximum time to wait for an agent response. Configures the haproxy's timeout server. Defaults to `5s` if not configured.
+* `modsecurity-use-coraza`: Defines whether the generated SPOE config should include Coraza-specific values. In order to use Coraza instead of Modsecurity, you must set this to "true" and also set `modsecurity-args` based on the instructions in the [coraza-spoa repository](https://github.com/corazawaf/coraza-spoa). A full example can be found [here]({{% relref "../examples/modsecurity#using-coraza-instead-of-modsecurity" %}}).
 
 See also:
 
-* [example]({{% relref "../examples/modsecurity" %}}) page.
+* [modsecurity example]({{% relref "../examples/modsecurity" %}}) page.
 * [`waf`](#waf) configuration key.
 * https://www.haproxy.org/download/2.0/doc/SPOE.txt
 * https://docs.haproxy.org/2.4/configuration.html#9.3
@@ -2858,7 +2861,7 @@ See also:
 | `waf-mode`        | `Path` | `deny`  | v0.9  |
 
 Defines which web application firewall (WAF) implementation should be used
-to validate requests. Currently the only supported value is `modsecurity`.
+to validate requests. Currently the only supported value is `modsecurity`, which also supports Coraza endpoints when `modsecurity-use-coraza` is set to "true".
 
 This configuration has no effect if the ModSecurity endpoints are not configured.
 

--- a/docs/static/resources/coraza-deployment.yaml
+++ b/docs/static/resources/coraza-deployment.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    run: coraza-spoa
+  name: coraza-spoa
+  namespace: ingress-controller
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      run: coraza-spoa
+  template:
+    metadata:
+      labels:
+        run: coraza-spoa
+    spec:
+      containers:
+      - name: coraza-spoa
+        # NOTE: Built based on this PR: https://github.com/corazawaf/coraza-spoa/pull/36
+        # An official coraza-spoa image will be released by the upstream project soon.
+        image: quay.io/jcmoraisjr/coraza-spoa:experimental
+        ports:
+        - containerPort: 12345
+          name: spop
+          protocol: TCP
+        resources:
+          limits:
+            cpu: 200m
+            memory: 150Mi
+          requests:
+            cpu: 200m
+            memory: 150Mi
+        livenessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 30
+          periodSeconds: 5
+          successThreshold: 1
+          tcpSocket:
+            port: 12345
+          timeoutSeconds: 4
+      volumeMounts:
+      - name: coraza-config
+        mountPath: /config.yaml
+        subPath: config.yaml
+        readOnly: true
+    volumes:
+    - name: coraza-config
+      configMap:
+        name: coraza-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coraza-config
+  namespace: ingress-controller
+data:
+  # Check the official documentation: https://github.com/corazawaf/coraza-spoa
+  config.yaml: |
+    bind: :12345
+    default_application: default_app
+    applications:
+      default_app:
+        include:
+          - /etc/coraza-spoa/coraza.conf
+          - /etc/coraza-spoa/crs-setup.conf
+          - /etc/coraza-spoa/rules/*.conf
+
+        transaction_ttl: 60000
+        transaction_active_limit: 100000
+        log_level: info
+        log_file: /dev/stdout

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -345,6 +345,7 @@ func (c *updater) buildGlobalModSecurity(d *globalData) {
 	d.global.ModSecurity.Timeout.Processing = c.validateTime(d.mapper.Get(ingtypes.GlobalModsecurityTimeoutProcessing))
 	d.global.ModSecurity.Timeout.Server = c.validateTime(d.mapper.Get(ingtypes.GlobalModsecurityTimeoutServer))
 	d.global.ModSecurity.Args = utils.Split(d.mapper.Get(ingtypes.GlobalModsecurityArgs).Value, " ")
+	d.global.ModSecurity.UseCoraza = d.mapper.Get(ingtypes.GlobalModsecurityUseCoraza).Bool()
 }
 
 func (c *updater) buildGlobalDNS(d *globalData) {

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -99,6 +99,7 @@ const (
 	GlobalModsecurityTimeoutIdle       = "modsecurity-timeout-idle"
 	GlobalModsecurityTimeoutProcessing = "modsecurity-timeout-processing"
 	GlobalModsecurityTimeoutServer     = "modsecurity-timeout-server"
+	GlobalModsecurityUseCoraza         = "modsecurity-use-coraza"
 	GlobalNbprocBalance                = "nbproc-balance"
 	GlobalNbprocSSL                    = "nbproc-ssl"
 	GlobalNbthread                     = "nbthread"

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -4801,6 +4801,8 @@ func TestModSecurity(t *testing.T) {
 		modsecExp       string
 		modsecAgentArgs []string
 		modsecAgentExp  string
+		modsecUseCoraza bool
+		modsecOtherExp  string
 	}{
 		{
 			waf:        "modsecurity",
@@ -4882,11 +4884,38 @@ func TestModSecurity(t *testing.T) {
     timeout connect 1s
     timeout server  2s
     server modsec-spoa0 10.0.0.101:12345`,
+			modsecOtherExp: `
+    messages     check-request
+    option       var-prefix  modsec`,
 
 			modsecAgentArgs: []string{"unique-id", "method", "path", "query", "req.ver", "req.hdrs_bin"},
 			modsecAgentExp: `
+spoe-message check-request
     args   unique-id method path query req.ver req.hdrs_bin
     event  on-backend-http-request`,
+		},
+		// Test modsecurity-use-coraza
+		{
+			waf:       "modsecurity",
+			wafmode:   "deny",
+			endpoints: []string{"10.0.0.101:12345"},
+			backendExp: `
+    filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
+    http-request deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }
+    http-request deny if !{ var(txn.coraza.fail) -m int eq 0 }`,
+			modsecExp: `
+    timeout connect 1s
+    timeout server  2s
+    server modsec-spoa0 10.0.0.101:12345`,
+			modsecAgentArgs: []string{"app=hdr(host)", "id=unique-id", "src-ip=src", "src-port=src_port", "dst-ip=dst", "dst-port=dst_port", "method=method", "path=path", "query=query", "version=req.ver", "headers=req.hdrs", "body=req.body"},
+			modsecAgentExp: `
+spoe-message coraza-req
+    args   app=hdr(host) id=unique-id src-ip=src src-port=src_port dst-ip=dst dst-port=dst_port method=method path=path query=query version=req.ver headers=req.hdrs body=req.body
+    event  on-backend-http-request`,
+			modsecOtherExp: `
+    messages     coraza-req
+    option       var-prefix  coraza`,
+			modsecUseCoraza: true,
 		},
 	}
 	for _, test := range testCases {
@@ -4913,7 +4942,7 @@ func TestModSecurity(t *testing.T) {
 		globalModsec.Timeout.Connect = "1s"
 		globalModsec.Timeout.Server = "2s"
 		globalModsec.Args = test.modsecAgentArgs
-
+		globalModsec.UseCoraza = test.modsecUseCoraza
 		c.Update()
 
 		var modsec string
@@ -4922,7 +4951,20 @@ func TestModSecurity(t *testing.T) {
 backend spoe-modsecurity
     mode tcp` + test.modsecExp
 		}
-		c.checkConfig(`
+		// unique-id-format must be set when using Coraza
+		if test.modsecUseCoraza {
+			c.checkConfig(`
+<<global>>
+<<defaults>>
+    unique-id-format        %[uuid()]
+backend d1_app_8080
+    mode http` + test.backendExp + `
+    server s1 172.17.0.11:8080 weight 100
+<<backends-default>>
+<<frontends-default>>
+<<support>>` + modsec)
+		} else {
+			c.checkConfig(`
 <<global>>
 <<defaults>>
 backend d1_app_8080
@@ -4931,8 +4973,12 @@ backend d1_app_8080
 <<backends-default>>
 <<frontends-default>>
 <<support>>` + modsec)
+		}
 		if test.modsecAgentExp != "" {
 			c.containsText("spoe-modsecurity.conf", c.readConfig(c.tempdir+"/spoe-modsecurity.conf"), test.modsecAgentExp)
+		}
+		if test.modsecOtherExp != "" {
+			c.containsText("spoe-modsecurity.conf", c.readConfig(c.tempdir+"/spoe-modsecurity.conf"), test.modsecOtherExp)
 		}
 
 		c.logger.CompareLogging(defaultLogging)

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -183,6 +183,7 @@ type ModSecurityConfig struct {
 	Endpoints []string
 	Timeout   ModSecurityTimeoutConfig
 	Args      []string
+	UseCoraza bool
 }
 
 // CookieConfig ...

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -184,6 +184,10 @@ defaults
 {{- if $global.Timeout.Tunnel }}
     timeout tunnel          {{ $global.Timeout.Tunnel }}
 {{- end }}
+{{- /* Coraza will crash if the unique-id isn't set, which requires us to set the format here */}}
+{{- if $global.ModSecurity.UseCoraza }}
+    unique-id-format        %[uuid()]
+{{- end }}
 {{- range $snippet := $global.CustomDefaults }}
     {{ $snippet }}
 {{- end }}
@@ -582,7 +586,12 @@ backend {{ $backend.ID }}
 {{- range $i, $waf := $wafCfg.Items }}
 {{- if eq $waf.Mode "deny" }}
 {{- range $pathIDs := $wafCfg.PathIDs $i }}
+{{- if $global.ModSecurity.UseCoraza }}
+    http-request deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }
+    http-request deny if !{ var(txn.coraza.fail) -m int eq 0 }
+{{- else }}
     http-request deny if { var(txn.modsec.code) -m int gt 0 }
+{{- end }}
         {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
 {{- end }}
 {{- end }}

--- a/rootfs/etc/templates/modsecurity/modsecurity.tmpl
+++ b/rootfs/etc/templates/modsecurity/modsecurity.tmpl
@@ -9,12 +9,24 @@
 {{- $modsec := .Global.ModSecurity }}
 [modsecurity]
 spoe-agent modsecurity-agent
+{{- if .Global.ModSecurity.UseCoraza }}
+    messages     coraza-req
+    option       var-prefix  coraza
+{{- else }}
     messages     check-request
     option       var-prefix  modsec
+{{- end }}
     timeout      hello       {{ $modsec.Timeout.Hello }}
     timeout      idle        {{ $modsec.Timeout.Idle }}
     timeout      processing  {{ $modsec.Timeout.Processing }}
     use-backend  spoe-modsecurity
+    log          global
+    option       dontlog-normal
+
+{{- if .Global.ModSecurity.UseCoraza }}
+spoe-message coraza-req
+{{- else }}
 spoe-message check-request
+{{- end }}
     args   {{ $modsec.Args | join " " }}
     event  on-backend-http-request


### PR DESCRIPTION
This PR adds a new config value, `modsecurity-use-coraza`, which changes the WAF/SPOE configuration to support https://github.com/corazawaf/coraza-spoa

Specifically, this config matches the "experimental" branch of coraza-spoa. Slight changes in the args may be required in the future as the API stabilizes, so we do not provide default args in the source code (only in the docs).

To use, just set these values in the helm chart:

```
controller:
  image:
    repository: <must use an image based on this branch>
    tag: <must use an image based on this branch>
  config:
    modsecurity-use-coraza: "true"
    modsecurity-endpoints: 127.0.0.1:12345
    modsecurity-args: "app=hdr(host) id=unique-id src-ip=src src-port=src_port dst-ip=dst dst-port=dst_port method=method path=path query=query version=req.ver headers=req.hdrs body=req.body"
    waf: modsecurity
  extraVolumes:
    - name: coraza-config
      configMap:
        name: coraza-config
  extraContainers:
    - name: coraza-spoa
      image: <you must supply your own image based on the "experimental" branch with this PR applied https://github.com/corazawaf/coraza-spoa/pull/36 >
      ports:
      - containerPort: 12345
        name: spop
        protocol: TCP
      resources:
        limits:
          memory: 500Mi
        requests:
          cpu: 1000m
          memory: 250Mi
      volumeMounts:
      - name: coraza-config
        mountPath: /config.yaml
        subPath: config.yaml
        readOnly: true
      livenessProbe:
        tcpSocket:
          port: 12345
        failureThreshold: 3
        initialDelaySeconds: 30
        periodSeconds: 5
        successThreshold: 1
        timeoutSeconds: 4
```

The above values will mount a ConfigMap for Coraza's config.yaml, which must be created separately. Here is that configmap:

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: coraza-config
  namespace: haproxy-ingress
data:
  config.yaml: |
    bind: 127.0.0.1:12345
    default_application: default_app
    applications:
      default_app:
        include:
          - /etc/coraza-spoa/coraza.conf
          - /etc/coraza-spoa/crs-setup.conf
          - /etc/coraza-spoa/rules/*.conf

        transaction_ttl: 60000
        transaction_active_limit: 100000
        log_level: debug
        log_file: /dev/stdout

```
Note the `default_application` line, that is from this PR: https://github.com/corazawaf/coraza-spoa/pull/36
That PR is needed because I set the `app` arg to be the `Host` header, so you need a default_application to configure WAF rules for all hosts. Otherwise, you'd need a different config block for every single Ingress hostname in your cluster.