### PR TITLE
Update to hugo v0.110.0 and update node deps

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,4 @@ package-lock.json
 public/
 resources/
 node_modules/
+.hugo_build.lock

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "/v0.14"
+baseURL = "https://haproxy-ingress.github.io"
 title = "HAProxy Ingress"
 
 enableRobotsTXT = true
@@ -31,12 +31,11 @@ pygmentsStyle = "tango"
 [permalinks]
 blog = "/:section/:year/:month/:day/:slug/"
 
-## Configuration for BlackFriday markdown parser: https://github.com/russross/blackfriday
-[blackfriday]
-plainIDAnchors = true
-hrefTargetBlank = false
-angledQuotes = false
-latexDashes = true
+# Needed to display the home page properly
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
 
 # Image processing configuration.
 [imaging]

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://haproxy-ingress.github.io"
+baseURL = "/"
 title = "HAProxy Ingress"
 
 enableRobotsTXT = true

--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -9,9 +9,7 @@ linkTitle: HAProxy Ingress
 		Learn More <i class="fas fa-arrow-alt-circle-right ml-2"></i>
 	</a>
 	<p class="lead mt-5">The first and most complete ingress controller implementation for HAProxy.</p>
-	<div class="mx-auto mt-5">
-		{{< blocks/link-down color="info" >}}
-	</div>
+	<div class="mx-auto mt-5">{{< blocks/link-down color="info" >}}</div>
 </div>
 {{< /blocks/cover >}}
 

--- a/docs/content/en/docs/contribution-guidelines/_index.md
+++ b/docs/content/en/docs/contribution-guidelines/_index.md
@@ -35,7 +35,7 @@ Docsy has a shortcut for you:
 
 If you want to run your own local Hugo server to preview your changes as you work:
 
-1. Install [Hugo](https://gohugo.io/getting-started/installing) and any other tools you need. You'll need at least **Hugo version 0.60** (we recommend using the most recent available version), and it must be the **extended** version, which supports SCSS.
+1. Install [Hugo](https://gohugo.io/getting-started/installing) and any other tools you need. You'll need at least **Hugo version 0.110.0** (we recommend using the most recent available version), and it must be the **extended** version, which supports SCSS.
 1. Fork the [HAProxy Ingress](https://github.com/jcmoraisjr/haproxy-ingress) repo into your own project, then create a local copy using `git clone`. Don’t forget to use `--recurse-submodules` or you won’t pull down some of the code you need to generate a working site. The clone may take a while since the docsy submodules are large.
 
        git clone --recurse-submodules --depth 1 https://github.com/jcmoraisjr/haproxy-ingress.git
@@ -44,6 +44,7 @@ If you want to run your own local Hugo server to preview your changes as you wor
        git submodule update --init --recursive --recommend-shallow
 
 1. From inside the `/docs` directory, install the node modules: `npm install`
+1. You'll also need to install Docsy's node modules: `cd themes/docsy && npm install`
 1. Run `hugo server` in the `/docs` subdirectory. By default your site will be available at http://localhost:1313/. Now that you're serving your site locally, Hugo will watch for changes to the content and automatically refresh your site.
     - On macOS, if you get a `pipe failed` error, you may need to add the `--watch=false` flag.
 1. Continue with the usual GitHub workflow to edit files, commit them, push the changes up to your fork, and create a pull request.

--- a/docs/content/en/docs/contribution-guidelines/_index.md
+++ b/docs/content/en/docs/contribution-guidelines/_index.md
@@ -35,14 +35,17 @@ Docsy has a shortcut for you:
 
 If you want to run your own local Hugo server to preview your changes as you work:
 
-1. Install [Hugo](https://gohugo.io/getting-started/installing) and any other tools you need. You'll need at least **Hugo version 0.45** (we recommend using the most recent available version), and it must be the **extended** version, which supports SCSS.
-1. Fork the [HAProxy Ingress](https://github.com/jcmoraisjr/haproxy-ingress) repo into your own project, then create a local copy using `git clone`. Don’t forget to use `--recurse-submodules` or you won’t pull down some of the code you need to generate a working site.
+1. Install [Hugo](https://gohugo.io/getting-started/installing) and any other tools you need. You'll need at least **Hugo version 0.60** (we recommend using the most recent available version), and it must be the **extended** version, which supports SCSS.
+1. Fork the [HAProxy Ingress](https://github.com/jcmoraisjr/haproxy-ingress) repo into your own project, then create a local copy using `git clone`. Don’t forget to use `--recurse-submodules` or you won’t pull down some of the code you need to generate a working site. The clone may take a while since the docsy submodules are large.
 
-```
-git clone --recurse-submodules --depth 1 https://github.com/jcmoraisjr/haproxy-ingress.git
-```
+       git clone --recurse-submodules --depth 1 https://github.com/jcmoraisjr/haproxy-ingress.git
 
+       # Or if you already have the repo cloned, you can run this instead:
+       git submodule update --init --recursive --recommend-shallow
+
+1. From inside the `/docs` directory, install the node modules: `npm install`
 1. Run `hugo server` in the `/docs` subdirectory. By default your site will be available at http://localhost:1313/. Now that you're serving your site locally, Hugo will watch for changes to the content and automatically refresh your site.
+    - On macOS, if you get a `pipe failed` error, you may need to add the `--watch=false` flag.
 1. Continue with the usual GitHub workflow to edit files, commit them, push the changes up to your fork, and create a pull request.
 
 ## Creating an issue

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {},
   "devDependencies": {
-    "autoprefixer": "^9.6.1",
-    "postcss-cli": "^5.0.1"
+    "autoprefixer": "^10.4.13",
+    "postcss-cli": "^10.0.0"
   }
 }


### PR DESCRIPTION
I noticed while working on the Coraza docs that my version of Hugo was too new to render the docs locally, specifically the change from `blackfriday` to `goldmark` as the markdown renderer on v0.60. I also updated the node deps too.

**NOTE:** @jcmoraisjr It looks like you build and publish the site locally. If so, you'll need to update your local hugo version and run `npm update` before publishing if this PR is merged.

Other changes:

* Gitignore'd the .hugo_build.lock file (which was added [in a later version of Hugo](https://gohugo.io/news/0.89.0-relnotes/))
* Changed the baseURL, it's apparently supposed to be the full URL where the site is hosted: https://gohugo.io/getting-started/configuration/#baseurl Without this change, I just get 404s locally.
* Allowed rendering raw HTML which is needed on the home page
* Removed some tab characters on the home page which were causing the HTML to render as code blocks for some reason
* Added some extra tips to the contribution guide
    - Indented the code block with spaces, which is needed to prevent the numbered list from re-starting at "1."
 * Updated to docsy 0.6.0