### PR TITLE
Fix host redirects when acme is enabled

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -4065,6 +4065,7 @@ func TestInstanceRedirectFrom(t *testing.T) {
 	testCases := []struct {
 		data     [3]hatypes.HostRedirectConfig
 		code     int
+		acme     bool
 		expHTTP  string
 		expHTTPS string
 		expMaps  map[string]string
@@ -4113,6 +4114,25 @@ sub.d2.local d2.local
 `,
 			},
 		},
+		// 2
+		{
+			data: [3]hatypes.HostRedirectConfig{
+				{RedirectHost: "*.d1.local"},
+			},
+			code: 301,
+			acme: true,
+			expHTTP: `
+    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_from__regex.map) if !acme-challenge !{ var(req.backend) -m found }
+    http-request redirect prefix //%[var(req.redirdest)] code 301 if !acme-challenge { var(req.redirdest) -m found }`,
+			expHTTPS: `
+    http-request set-var(req.redirdest) var(req.host),map_reg(/etc/haproxy/maps/_front_redir_from__regex.map) if !{ var(req.hostbackend) -m found }
+    http-request redirect prefix //%[var(req.redirdest)] code 301 if { var(req.redirdest) -m found }`,
+			expMaps: map[string]string{
+				"_front_redir_from__regex.map": `
+^[^.]+\.d1\.local$ d1.local
+`,
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -4144,6 +4164,20 @@ sub.d2.local d2.local
 			c.config.frontend.RedirectFromCode = 302
 		}
 
+		var acmeBackend, acmeACL, acmeUseBackend string
+		if test.acme {
+			acmeBackend = `
+backend _acme_challenge
+    mode http
+    server _acme_server unix@local`
+			acmeACL = `
+    acl acme-challenge path_beg `
+			acmeUseBackend = `
+    use_backend _acme_challenge if acme-challenge`
+			c.config.global.Acme.Socket = "local"
+			c.config.global.Acme.Enabled = true
+		}
+
 		c.Update()
 		c.checkConfig(`
 <<global>>
@@ -4156,11 +4190,11 @@ backend d2_app_8080
     server s21 172.17.0.121:8080 weight 100
 backend d3_app_8080
     mode http
-    server s31 172.17.0.131:8080 weight 100
+    server s31 172.17.0.131:8080 weight 100` + acmeBackend + `
 <<backends-default>>
 frontend _front_http
     mode http
-    bind :80
+    bind :80` + acmeACL + `
     http-request set-var(req.path) path
     http-request set-var(req.host) hdr(host),field(1,:),lower
     http-request set-var(req.base) var(req.host),concat(\#,req.path)
@@ -4170,7 +4204,7 @@ frontend _front_http
     http-request del-header X-SSL-Client-SHA1
     http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert
-    http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)` + test.expHTTP + `
+    http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)` + test.expHTTP + acmeUseBackend + `
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
     default_backend _error404
 frontend _front_https
@@ -4201,7 +4235,9 @@ func TestInstanceRedirectTo(t *testing.T) {
 	testCases := []struct {
 		to       [3]string
 		code     int
+		acme     bool
 		expected string
+		expHTTPS string
 		expMaps  map[string]string
 	}{
 		// 0
@@ -4254,6 +4290,24 @@ d1.local#/app2 https://app.local/app2
 `,
 			},
 		},
+		// 3
+		{
+			to: [3]string{
+				"https://app.local",
+			},
+			acme: true,
+			expected: `
+    http-request set-var(req.redirto) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_redir_to__begin.map) if !acme-challenge
+    http-request redirect location %[var(req.redirto)] code 302 if !acme-challenge { var(req.redirto) -m found }`,
+			expHTTPS: `
+    http-request set-var(req.redirto) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_redir_to__begin.map)
+    http-request redirect location %[var(req.redirto)] code 302 if { var(req.redirto) -m found }`,
+			expMaps: map[string]string{
+				"_front_redir_to__begin.map": `
+d1.local#/ https://app.local
+`,
+			},
+		},
 	}
 
 	for _, test := range testCases {
@@ -4285,10 +4339,28 @@ d1.local#/app2 https://app.local/app2
 			h.AddPath(b, "/app3", hatypes.MatchBegin)
 		}
 
+		if test.expHTTPS == "" {
+			test.expHTTPS = test.expected
+		}
+
 		if test.code != 0 {
 			c.config.frontend.RedirectToCode = test.code
 		} else {
 			c.config.frontend.RedirectToCode = 302
+		}
+
+		var acmeBackend, acmeACL, acmeUseBackend string
+		if test.acme {
+			acmeBackend = `
+backend _acme_challenge
+    mode http
+    server _acme_server unix@local`
+			acmeACL = `
+    acl acme-challenge path_beg `
+			acmeUseBackend = `
+    use_backend _acme_challenge if acme-challenge`
+			c.config.global.Acme.Socket = "local"
+			c.config.global.Acme.Enabled = true
 		}
 
 		c.Update()
@@ -4303,11 +4375,11 @@ backend d2_app_8080
     server s21 172.17.0.121:8080 weight 100
 backend d3_app_8080
     mode http
-    server s31 172.17.0.131:8080 weight 100
+    server s31 172.17.0.131:8080 weight 100` + acmeBackend + `
 <<backends-default>>
 frontend _front_http
     mode http
-    bind :80
+    bind :80` + acmeACL + `
     http-request set-var(req.path) path
     http-request set-var(req.host) hdr(host),field(1,:),lower
     http-request set-var(req.base) var(req.host),concat(\#,req.path)
@@ -4317,7 +4389,7 @@ frontend _front_http
     http-request del-header X-SSL-Client-SHA1
     http-request del-header X-SSL-Client-SHA2
     http-request del-header X-SSL-Client-Cert` + test.expected + `
-    http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)
+    http-request set-var(req.backend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_http_host__begin.map)` + acmeUseBackend + `
     use_backend %[var(req.backend)] if { var(req.backend) -m found }
     default_backend _error404
 frontend _front_https
@@ -4325,7 +4397,7 @@ frontend _front_https
     bind :443 ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_bind_crt.list ca-ignore-err all crt-ignore-err all
     http-request set-var(req.path) path
     http-request set-var(req.host) hdr(host),field(1,:),lower
-    http-request set-var(req.base) var(req.host),concat(\#,req.path)` + test.expected + `
+    http-request set-var(req.base) var(req.host),concat(\#,req.path)` + test.expHTTPS + `
     http-request set-var(req.hostbackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_host__begin.map)
     http-request set-header X-Forwarded-Proto https
     http-request del-header X-SSL-Client-CN

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1220,7 +1220,11 @@ frontend {{ $proxy__front_http }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- template "redirectTo" map $frontend $fmaps }}
+{{- if $global.Acme.Enabled }}
+    {{- template "redirectTo" map $frontend $fmaps "!acme-challenge" }}
+{{- else }}
+    {{- template "redirectTo" map $frontend $fmaps "" }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- range $match := $fmaps.HTTPHostMap.MatchFiles }}
@@ -1238,7 +1242,11 @@ frontend {{ $proxy__front_http }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- template "redirectFrom" map $frontend $fmaps "req.backend" }}
+{{- if $global.Acme.Enabled }}
+    {{- template "redirectFrom" map $frontend $fmaps "req.backend" "!acme-challenge" }}
+{{- else }}
+    {{- template "redirectFrom" map $frontend $fmaps "req.backend" "" }}
+{{- end }}
 
 {{- /*------------------------------------*/}}
 {{- range $snippet := $global.CustomFrontendLate }}
@@ -1301,7 +1309,7 @@ frontend {{ $frontend.Name }}
     http-request set-var(req.base) var(req.host),concat(\#,req.path)
 
 {{- /*------------------------------------*/}}
-{{- template "redirectTo" map $frontend $fmaps }}
+{{- template "redirectTo" map $frontend $fmaps "" }}
 
 {{- /*------------------------------------*/}}
 {{- range $match := $fmaps.HTTPSHostMap.MatchFiles }}
@@ -1319,7 +1327,7 @@ frontend {{ $frontend.Name }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
-{{- template "redirectFrom" map $frontend $fmaps "req.hostbackend" }}
+{{- template "redirectFrom" map $frontend $fmaps "req.hostbackend" "" }}
 
 {{- /*------------------------------------*/}}
 {{- if $fmaps.RedirFromRootMap.HasHost }}
@@ -1462,17 +1470,22 @@ frontend {{ $frontend.Name }}
 {{- $frontend := .p1 }}
 {{- $fmaps := .p2 }}
 {{- $varbe := .p3 }}
+{{- $acls := .p4 }}
 {{- if $fmaps.RedirFromMap.MatchFiles }}
 {{- range $match := $fmaps.RedirFromMap.MatchFiles }}
     http-request set-var(req.redirdest) var(req.host)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
-        {{- "" }} if !{ var({{ $varbe }}) -m found }
+        {{- "" }} if
+        {{- if $acls }} {{ $acls }}{{ end }}
+        {{- "" }} !{ var({{ $varbe }}) -m found }
         {{- if not $match.First }} !{ var(req.redirdest) -m found }{{ end }}
 {{- end }}
     http-request redirect prefix //%[var(req.redirdest)]
         {{- "" }} code {{ $frontend.RedirectFromCode }}
-        {{- "" }} if { var(req.redirdest) -m found }
+        {{- "" }} if
+        {{- if $acls }} {{ $acls }}{{ end }}
+        {{- "" }} { var(req.redirdest) -m found }
 {{- end }}
 {{- end }}
 
@@ -1481,16 +1494,20 @@ frontend {{ $frontend.Name }}
 {{- define "redirectTo" }}
 {{- $frontend := .p1 }}
 {{- $fmaps := .p2 }}
+{{- $acls := .p3 }}
 {{- if $fmaps.RedirToMap.MatchFiles }}
 {{- range $match := $fmaps.RedirToMap.MatchFiles }}
     http-request set-var(req.redirto) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
         {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
-        {{- template "httpFilters" map $match "req.redirto" 1 }}
+        {{- if $acls }} if {{ $acls }}{{ end }}
+        {{- template "httpFilters" map $match "req.redirto" (not $acls) }}
 {{- end }}
     http-request redirect location %[var(req.redirto)]
         {{- "" }} code {{ $frontend.RedirectToCode }}
-        {{- "" }} if { var(req.redirto) -m found }
+        {{- "" }} if
+        {{- if $acls }} {{ $acls }}{{ end }}
+        {{- "" }} { var(req.redirto) -m found }
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Acme validation happens on plain HTTP and should skip redirects, so that the acme service (e.g. Let's Encrypt) can properly validate the domain ownership. This wasn't properly happening with `redirect-from` and `redirect-to` keys, which makes the signer to fail. This update skips those redirects when acme is enabled and path matches the acme challenge.