### PR TITLE
Makes auth-headers not copying on empty string

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -833,7 +833,7 @@ There are three distinct configurations to forward header names:
 
 The first option will always be used, the second one only on succeeded requests, the last one only on failures.
 
-These configuration keys can be defined as a comma-separated list of header names. All HTTP headers will be copied if not declared. Each header name can use wildcard.
+These configuration keys can be defined as a comma-separated list of header names. All HTTP headers will be copied if not declared. Each header name can use wildcard. Using a dash `-` or an empty string instructs the controller not to copy any header.
 
 Configuration examples:
 

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -217,9 +217,21 @@ func (c *updater) buildBackendAuthExternal(d *backData) {
 			signin = ""
 		}
 
-		hdrRequest := strings.Split(config.Get(ingtypes.BackAuthHeadersRequest).Value, ",")
-		hdrSucceed := strings.Split(config.Get(ingtypes.BackAuthHeadersSucceed).Value, ",")
-		hdrFail := strings.Split(config.Get(ingtypes.BackAuthHeadersFail).Value, ",")
+		annHdrRequest := config.Get(ingtypes.BackAuthHeadersRequest).Value
+		if annHdrRequest == "" {
+			annHdrRequest = "-"
+		}
+		annHdrSucceed := config.Get(ingtypes.BackAuthHeadersSucceed).Value
+		if annHdrSucceed == "" {
+			annHdrSucceed = "-"
+		}
+		annHdrFail := config.Get(ingtypes.BackAuthHeadersFail).Value
+		if annHdrFail == "" {
+			annHdrFail = "-"
+		}
+		hdrRequest := strings.Split(annHdrRequest, ",")
+		hdrSucceed := strings.Split(annHdrSucceed, ",")
+		hdrFail := strings.Split(annHdrFail, ",")
 
 		if signin != "" {
 			if !reflect.DeepEqual(hdrFail, []string{"*"}) {

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -202,6 +202,7 @@ func TestAuthExternal(t *testing.T) {
 		hdrReq     string
 		hdrSucceed string
 		hdrFail    string
+		hdrEmpty   bool
 		isExternal bool
 		hasLua     bool
 		expBack    hatypes.AuthExternal
@@ -464,6 +465,19 @@ func TestAuthExternal(t *testing.T) {
 			expIP:   []string{"10.0.0.2:80"},
 			logging: `WARN invalid request method '**' on ingress 'default/ing1', using GET instead`,
 		},
+		// 27
+		{
+			url:      "http://app1.local",
+			hdrEmpty: true,
+			expBack: hatypes.AuthExternal{
+				AuthBackendName: "_auth_4001",
+				AuthPath:        "/",
+				HeadersRequest:  []string{"-"},
+				HeadersSucceed:  []string{"-"},
+				HeadersFail:     []string{"-"},
+			},
+			expIP: []string{"10.0.0.2:80"},
+		},
 	}
 	source := &Source{
 		Namespace: "default",
@@ -500,13 +514,13 @@ func TestAuthExternal(t *testing.T) {
 		if test.method != "" {
 			ann["/"][ingtypes.BackAuthMethod] = test.method
 		}
-		if test.hdrReq != "" {
+		if test.hdrEmpty || test.hdrReq != "" {
 			ann["/"][ingtypes.BackAuthHeadersRequest] = test.hdrReq
 		}
-		if test.hdrSucceed != "" {
+		if test.hdrEmpty || test.hdrSucceed != "" {
 			ann["/"][ingtypes.BackAuthHeadersSucceed] = test.hdrSucceed
 		}
-		if test.hdrFail != "" {
+		if test.hdrEmpty || test.hdrFail != "" {
 			ann["/"][ingtypes.BackAuthHeadersFail] = test.hdrFail
 		}
 		defaults := map[string]string{


### PR DESCRIPTION
By default `auth-headers-*` copy all provided headers to/from auth service, client or backend. A non documented `-` makes no header to be copied and an empty string breaks the configuration. Now an empty string is internally converted to a dash and this option is also documented.