### PR TITLE
Fix path scoped annotation on service resources

### DIFF
--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -808,16 +808,16 @@ func (c *converter) addBackendWithClass(source *annotations.Source, pathLink *ha
 	backend.DNSPort = readDNSPort(svc.Spec.ClusterIP == api.ClusterIPNone, port)
 	mapper, found := c.backendAnnotations[backend]
 	if !found {
-		// New backend, initialize with service annotations, giving precedence
 		mapper = c.mapBuilder.NewMapper()
-		_, _, ann := c.readAnnotations(source, svc.Annotations)
-		mapper.AddAnnotations(&annotations.Source{
-			Namespace: namespace,
-			Name:      svcName,
-			Type:      convtypes.ResourceService,
-		}, pathLink, ann)
 		c.backendAnnotations[backend] = mapper
 	}
+	// Starting with service annotations, giving precedence
+	_, _, svcann := c.readAnnotations(source, svc.Annotations)
+	mapper.AddAnnotations(&annotations.Source{
+		Namespace: namespace,
+		Name:      svcName,
+		Type:      convtypes.ResourceService,
+	}, pathLink, svcann)
 	// Merging Ingress annotations
 	conflict := mapper.AddAnnotations(source, pathLink, ann)
 	if len(conflict) > 0 {

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -2198,6 +2198,33 @@ func TestSyncAnnBacksSvcIng(t *testing.T) {
   maxconnserver: 10` + defaultBackendConfig)
 }
 
+func TestSyncAnnBackSvcPath(t *testing.T) {
+	c := setup(t)
+	defer c.teardown()
+
+	c.createSvc1Ann("default/echo1", "8080", "172.17.0.11", map[string]string{
+		"ingress.kubernetes.io/proxy-body-size": "32768",
+	})
+
+	c.Sync(
+		c.createIng1("default/echo1", "echo.example.com", "/app1", "echo1:8080"),
+		c.createIng1("default/echo2", "echo.example.com", "/app2", "echo1:8080"),
+	)
+
+	c.compareConfigBack(`
+- id: default_echo1_8080
+  endpoints:
+  - ip: 172.17.0.11
+    port: 8080
+  paths:
+  - path: /app1
+    match: begin
+    maxbodysize: 32768
+  - path: /app2
+    match: begin
+    maxbodysize: 32768` + defaultBackendConfig)
+}
+
 func TestSyncAnnBackDefault(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()


### PR DESCRIPTION
Backend scoped annotations apply just once per service resource, and have the most precedence. With this behavior in mind, service annotations were being applied along with the annotation mapper creation. This works nice with backend scoped annotations.

Path scoped, however, has the ability to apply distinct values to the same backend. When path scoped annotations are applied via a service resource, only the first path is being applied, along with annotation mapper creation. This update ensures that the service annotations are applied on every pathlink that points to it. This change will spread service annotations over all referenced pathlinks, however this doesn't end up with duplicated configurations because the config builder already deduplicates configurations on the same key, with the same value, to the same backend. Warning on annotation conflict isn't a problem as well, a conflict is only warned on distinct values.