### PR TITLE
Prefer ingressClassName over annotations in docs

### DIFF
--- a/docs/content/en/docs/examples/metrics.md
+++ b/docs/content/en/docs/examples/metrics.md
@@ -58,6 +58,8 @@ The steps below configures HAProxy Ingress' Helm chart to add a new ServiceMonit
 Merge the content below to the actual `haproxy-ingress-values.yaml` file:
 ```yaml
 controller:
+  ingressClassResource:
+    enabled: true
   stats:
     enabled: true
   metrics:
@@ -139,7 +141,7 @@ kubectl --namespace default create deploy dory --image jcmoraisjr/dory
 kubectl --namespace default scale deploy dory --replicas=4
 kubectl --namespace default expose deploy dory --port 8000
 kubectl --namespace default create ingress dory\
-  --annotation kubernetes.io/ingress.class=haproxy\
+  --class=haproxy\
   --annotation haproxy-ingress.github.io/ssl-redirect=false\
   --rule="dory.localdomain/*=dory:8000,tls=dory"
 ```

--- a/docs/content/en/docs/examples/metrics.md
+++ b/docs/content/en/docs/examples/metrics.md
@@ -25,8 +25,7 @@ grafana:
   enabled: true
   ingress:
     enabled: true
-    annotations:
-      kubernetes.io/ingress.class: haproxy
+    ingressClassName: haproxy
     hosts:
     - grafana.192.168.0.11.nip.io
     tls:

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -43,6 +43,8 @@ Note that the user needs administrative privileges in the cluster to properly in
 ```yaml
 controller:
   hostNetwork: true
+  ingressClassResource:
+    enabled: true
 ```
 
 HAProxy Ingress chart [documentation](https://github.com/haproxy-ingress/charts/blob/release-0.14/haproxy-ingress/README.md#configuration) has all the available options. See also further documentation in the [default values](https://github.com/haproxy-ingress/charts/blob/release-0.14/haproxy-ingress/values.yaml) file.
@@ -60,11 +62,12 @@ $ helm install haproxy-ingress haproxy-ingress/haproxy-ingress\
 The command `install` above can be changed to `upgrade` to start a rolling update of HAProxy Ingress version or configuration. `template` can be used instead to generate the manifests without installing them - add either a redirect `... >haproxy-ingress-install.yaml` to save the output, or `--output-dir output/` command line option to save one file per manifest.
 {{% /alert %}}
 
-The controller should be running in a few seconds. There are three important customizations made in the example above:
+The controller should be running in a few seconds. There are four important customizations made in the example above:
 
 * version: a good practice, this will ensure that you'll have the same version installed even if a new release issued.
 * namespace: we're instructing helm to install HAProxy Ingress in the `ingress-controller` namespace. This namespace will be created if it does not exist yet. The default behavior, if namespace is not provided, is to deploy the controller in the kubectl's current namespace.
 * hostNetwork: we're configuring the deployment to expose haproxy in the host network, which means bind all haproxy ports, including but not limited to 80 and 443, in the node's IPs. Maybe this isn't a proper configuration for your production - it depends on the options you have to expose a Kubernetes' service, but doing so we'll be able to send http/s requests on local development environments, or even baremetal and on premise deployments that doesn't have a fronting router or load balancer to expose the controller. In any case a service is also configured in the `ingress-controller` namespace which tries to expose haproxy.
+* ingressClassResource.enabled: This causes the helm chart to apply an [IngressClass](https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class) to your cluster. IngressClasses are how HAProxy Ingress knows which of your Ingresses that it should control. IngressClasses replace the [kubernetes.io/ingress.class](https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation) annotation used in Kubernetes versions before v1.18.
 
 HAProxy Ingress' Helm chart has a few more configuration options, see all of them in the chart [documentation](https://github.com/haproxy-ingress/charts/blob/release-0.14/haproxy-ingress/README.md) and in the [default values](https://github.com/haproxy-ingress/charts/blob/release-0.14/haproxy-ingress/values.yaml) file.
 

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -92,8 +92,8 @@ echoserver-5b6fb6dd96-68jwp   1/1     Running   0          27s
 Obs.: `nip.io` is a convenient service which converts a valid domain name to any IP, either public or local. See [here](https://nip.io) how it works.
 
 ```shell
-$ kubectl --namespace default create ingress echoserver\
-  --annotation kubernetes.io/ingress.class=haproxy\
+$ kubectl --namespace default create ingress echoserver \
+  --class=haproxy \
   --rule="echoserver.local/*=echoserver:8080,tls"
 ```
 


### PR DESCRIPTION
Apparently using ingressClassName has been preferred over annotations since k8s 1.18: https://kubernetes.io/docs/concepts/services-networking/ingress/#deprecated-annotation

This PR just updates the two examples we have in the docs to use ingressClassName instead of the annotations. Figure we ought to send new users down the right path!