### PR TITLE
Add optional frontend based external authentication call

### DIFF
--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -524,10 +524,11 @@ func TestAuthExternal(t *testing.T) {
 			ann["/"][ingtypes.BackAuthHeadersFail] = test.hdrFail
 		}
 		defaults := map[string]string{
-			ingtypes.BackAuthHeadersRequest: "*",
-			ingtypes.BackAuthHeadersSucceed: "*",
-			ingtypes.BackAuthHeadersFail:    "*",
-			ingtypes.BackAuthMethod:         "GET",
+			ingtypes.BackAuthExternalPlacement: "backend",
+			ingtypes.BackAuthHeadersRequest:    "*",
+			ingtypes.BackAuthHeadersSucceed:    "*",
+			ingtypes.BackAuthHeadersFail:       "*",
+			ingtypes.BackAuthMethod:            "GET",
 		}
 		d := c.createBackendMappingData("default/app", source, defaults, ann, []string{"/"})
 		u.buildBackendAuthExternal(d)

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -22,6 +22,17 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 )
 
+func (c *updater) buildHostAuthExternal(d *hostData) {
+	isFrontend := d.mapper.Get(ingtypes.BackAuthExternalPlacement).ToLower() == "frontend"
+	url := d.mapper.Get(ingtypes.BackAuthURL)
+	if isFrontend && url.Source != nil && url.Value != "" {
+		for _, path := range d.host.Paths {
+			path.AuthExt = &types.AuthExternal{}
+			c.setAuthExternal(d.mapper, path.AuthExt, url)
+		}
+	}
+}
+
 func (c *updater) setAuthTLSConfig(mapper *Mapper, target *types.TLSConfig, hostname string) bool {
 	tlsSecret := mapper.Get(ingtypes.HostAuthTLSSecret)
 	if tlsSecret.Source == nil || tlsSecret.Value == "" {

--- a/pkg/converters/ingress/annotations/mapper.go
+++ b/pkg/converters/ingress/annotations/mapper.go
@@ -19,11 +19,16 @@ package annotations
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/types"
 )
+
+type ConfigValueGetter interface {
+	Get(key string) *ConfigValue
+}
 
 // MapBuilder ...
 type MapBuilder struct {
@@ -198,6 +203,11 @@ func (c *KeyConfig) Get(key string) *ConfigValue {
 // String ...
 func (cv *ConfigValue) String() string {
 	return cv.Value
+}
+
+// ToLower ...
+func (cv *ConfigValue) ToLower() string {
+	return strings.ToLower(cv.Value)
 }
 
 // Bool ...

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -213,6 +213,7 @@ func (c *updater) UpdateHostConfig(host *hatypes.Host, mapper *Mapper) {
 	host.Alias.AliasRegex = mapper.Get(ingtypes.HostServerAliasRegex).Value
 	host.TLS.UseDefaultCrt = mapper.Get(ingtypes.HostSSLAlwaysAddHTTPS).Bool()
 	host.VarNamespace = mapper.Get(ingtypes.HostVarNamespace).Bool()
+	c.buildHostAuthExternal(data)
 	c.buildHostAuthTLS(data)
 	c.buildHostCertSigner(data)
 	c.buildHostRedirect(data)

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -39,6 +39,7 @@ func createDefaults() map[string]string {
 		types.HostSSLOptionsHost:    "",
 		types.HostTLSALPN:           "h2,http/1.1",
 		//
+		types.BackAuthExternalPlacement:  "backend",
 		types.BackAuthHeadersFail:        "*",
 		types.BackAuthHeadersRequest:     "*",
 		types.BackAuthHeadersSucceed:     "*",

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -1013,6 +1013,9 @@ func (c *converter) readAnnotations(source *annotations.Source, ann map[string]s
 			// later when creating the TCP mapper.
 			annTCP[key] = value
 		} else {
+			if _, isDuoAnn := ingtypes.AnnDuo[key]; isDuoAnn {
+				annHost[key] = value
+			}
 			annBack[key] = value
 		}
 	}

--- a/pkg/converters/ingress/types/annotations.go
+++ b/pkg/converters/ingress/types/annotations.go
@@ -80,6 +80,19 @@ var (
 		HostTLSALPN:                {},
 		HostVarNamespace:           {},
 	}
+
+	// AnnDuo is the list of annotations that should be added
+	// on both host and backend annotations list.
+	// TODO: merge tcp, host and backend config keys into a single list?
+	AnnDuo = map[string]struct{}{
+		BackAuthExternalPlacement: {},
+		BackAuthHeadersFail:       {},
+		BackAuthHeadersRequest:    {},
+		BackAuthHeadersSucceed:    {},
+		BackAuthMethod:            {},
+		BackAuthSignin:            {},
+		BackAuthURL:               {},
+	}
 )
 
 // Backend Annotations
@@ -92,14 +105,15 @@ const (
 	BackAllowlistSourceRange   = "allowlist-source-range"
 	BackAllowlistSourceHeader  = "allowlist-source-header"
 	BackAssignBackendServerID  = "assign-backend-server-id"
-	BackAuthRealm              = "auth-realm"
-	BackAuthSecret             = "auth-secret"
-	BackAuthSignin             = "auth-signin"
-	BackAuthTLSCertHeader      = "auth-tls-cert-header"
+	BackAuthExternalPlacement  = "auth-external-placement"
 	BackAuthHeadersFail        = "auth-headers-fail"
 	BackAuthHeadersRequest     = "auth-headers-request"
 	BackAuthHeadersSucceed     = "auth-headers-succeed"
 	BackAuthMethod             = "auth-method"
+	BackAuthRealm              = "auth-realm"
+	BackAuthSecret             = "auth-secret"
+	BackAuthSignin             = "auth-signin"
+	BackAuthTLSCertHeader      = "auth-tls-cert-header"
 	BackAuthURL                = "auth-url"
 	BackBackendCheckInterval   = "backend-check-interval"
 	BackBackendProtocol        = "backend-protocol"

--- a/pkg/haproxy/types/maps.go
+++ b/pkg/haproxy/types/maps.go
@@ -416,7 +416,11 @@ func (mf *hostsMapMatchFile) lower() bool {
 }
 
 func (mf *hostsMapMatchFile) method() string {
-	switch mf.match {
+	return haMatchMethod(mf.match)
+}
+
+func haMatchMethod(match MatchType) string {
+	switch match {
 	case MatchExact:
 		return "str"
 	case MatchPrefix:
@@ -426,7 +430,7 @@ func (mf *hostsMapMatchFile) method() string {
 	case MatchRegex:
 		return "reg"
 	}
-	panic(fmt.Errorf("unsupported match type: %s", mf.match))
+	panic(fmt.Errorf("unsupported match type: %s", match))
 }
 
 // Filename ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -540,6 +540,7 @@ type PathLink struct {
 type HostPath struct {
 	order   int
 	Link    *PathLink
+	AuthExt *AuthExternal
 	Backend HostBackend
 	RedirTo string
 }

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -642,31 +642,7 @@ backend {{ $backend.ID }}
 {{- $authCfg := $backend.PathConfig "AuthExternal" }}
 {{- range $i, $auth := $authCfg.Items }}
 {{- range $pathIDs := $authCfg.PathIDs $i }}
-{{- if $auth.AlwaysDeny }}
-    http-request deny
-        {{- if $pathIDs }} if { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
-{{- else }}
-{{- if $auth.AuthBackendName }}
-    http-request lua.auth-intercept {{ $auth.AuthBackendName }} {{ $auth.AuthPath }} {{ $auth.Method }}
-        {{- printf " '%s' '%s' '%s'" ($auth.HeadersRequest | join ",") ($auth.HeadersSucceed | join ",") ($auth.HeadersFail | join ",") }}
-        {{- if or $auth.AllowedPath $pathIDs }} if{{ end }}
-        {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
-        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
-{{- if $auth.RedirectOnFail }}
-    http-request redirect location {{ $auth.RedirectOnFail }}
-{{- else }}
-    http-request deny
-{{- end }}
-        {{- "" }} if !{ var(txn.auth_response_successful) -m bool }
-        {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
-        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
-{{- range $header, $attr := $auth.HeadersVars }}
-    http-request set-header {{ $header }} %[var({{ $attr }})] if { var({{ $attr }}) -m found }
-        {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
-        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
-{{- end }}
-{{- end }}
-{{- end }}
+{{- template "authExternal" map $auth (iif (eq $pathIDs "") "" (printf "{ var(txn.pathID) -m str %s }" $pathIDs)) }}
 {{- end }}
 {{- end }}
 
@@ -1215,6 +1191,9 @@ frontend {{ $proxy__front_http }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- template "authExternalFrontend" map $hosts }}
+
+{{- /*------------------------------------*/}}
 {{- range $match := $fmaps.HTTPHostMap.MatchFiles }}
     http-request set-var(req.backend) var(req.base)
         {{- if $match.Lower }},lower{{ end }}
@@ -1301,6 +1280,9 @@ frontend {{ $frontend.Name }}
 
 {{- /*------------------------------------*/}}
 {{- template "redirectTo" map $frontend $fmaps "" }}
+
+{{- /*------------------------------------*/}}
+{{- template "authExternalFrontend" map $hosts }}
 
 {{- /*------------------------------------*/}}
 {{- range $match := $fmaps.HTTPSHostMap.MatchFiles }}
@@ -1527,6 +1509,51 @@ frontend {{ $frontend.Name }}
         {{- "" }} if
         {{- if $acls }} {{ $acls }}{{ end }}
         {{- "" }} { var(req.redirto) -m found }
+{{- end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
+{{- /*------------------------------------*/}}
+{{- define "authExternal" }}
+{{- $auth := .p1 }}
+{{- $condition := .p2 }}
+{{- if $auth.AlwaysDeny }}
+    http-request deny
+        {{- if $condition }} if {{ $condition }}{{ end }}
+{{- else }}
+{{- if $auth.AuthBackendName }}
+    http-request lua.auth-intercept {{ $auth.AuthBackendName }} {{ $auth.AuthPath }} {{ $auth.Method }}
+        {{- printf " '%s' '%s' '%s'" ($auth.HeadersRequest | join ",") ($auth.HeadersSucceed | join ",") ($auth.HeadersFail | join ",") }}
+        {{- if or $auth.AllowedPath $condition }} if{{ end }}
+        {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
+        {{- if $condition }} {{ $condition }}{{ end }}
+{{- if $auth.RedirectOnFail }}
+    http-request redirect location {{ $auth.RedirectOnFail }}
+{{- else }}
+    http-request deny
+{{- end }}
+        {{- "" }} if !{ var(txn.auth_response_successful) -m bool }
+        {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
+        {{- if $condition }} {{ $condition }}{{ end }}
+{{- range $header, $attr := $auth.HeadersVars }}
+    http-request set-header {{ $header }} %[var({{ $attr }})] if { var({{ $attr }}) -m found }
+        {{- if $auth.AllowedPath }} !{ path_beg {{ $auth.AllowedPath }} }{{ end }}
+        {{- if $condition }} {{ $condition }}{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
+{{- /*------------------------------------*/}}
+{{- define "authExternalFrontend" }}
+{{- $hosts := .p1 }}
+{{- range $host := $hosts.Items }}
+{{- range $path := $host.Paths }}
+{{- if $path.AuthExt }}
+{{- template "authExternal" map $path.AuthExt (printf "{ var(req.base) -m str %s '%s' }" $path.Link.HAMatch $path.Link.Key) }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
External authentication services has the ability to inject headers on the fly in the current request. Such header will be visible to the backend server in the case the authentication succeed, and to the caller/client in the case the authentication fails. This works that way since v0.13.

Starting on v0.15 HAProxy Ingress has the ability to route requests based on HTTP headers, along with the well known hostname+path supported since the very first version. However headers added or updated by the authentication service isn't visible to HAProxy Ingress routing rules, this happens because the authentication service is called from the backend declaration for performance reasons, but the routing rules must be configured in the frontend due to its logic: it needs to choose a backend based on hostname, path, and now HTTP headers.

This is a very first step on behalf of optionally bringing the authentication service call to the frontend. This should start in a very rudimentar way and with some performance impact if used on several distinct pathlinks, but it's good enough on use cases that such functionality is far more important than a small performance penalty. Other than that: 1) this is optional, enabled by the user, and doesn't make any difference on the former configuration; 2) future versions will make improvements on such frontend configuration; 3) the performance penalty grows based on the number of pathlinks, so adding a dozen or so on moderately used proxy won't hurt, as much as adding one or two on a highly used one.

TODO

* [x] haproxy types and logic
* [x] haproxy template
* [x] converter implementation
* [x] docs
* [x] unit tests
* [x] exploratory tests