### PR TITLE
Skip status update when update-status is false

### DIFF
--- a/pkg/converters/types/options.go
+++ b/pkg/converters/types/options.go
@@ -41,7 +41,6 @@ type ConverterOptions struct {
 	AcmeTrackTLSAnn  bool
 	TrackInstances   bool
 	HasGateway       bool
-	UpdateStatus     bool
 }
 
 // DynamicConfig ...


### PR DESCRIPTION
Bypass the ingress status update when update-status flag is disabled. The ability to skip sstatus update wasn't implemented in the new controller.