### PR TITLE
Change controller container to non root user

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -37,12 +37,10 @@ RUN apk upgrade --no-cache && apk --no-cache add socat openssl lua5.3 lua-json4 
 COPY rootfs/ /
 COPY --from=builder /src/haproxy-ingress /haproxy-ingress-controller
 
-RUN deluser haproxy\
- && addgroup -g 1001 haproxy\
- && adduser -u 1001 -G haproxy -D -s /bin/false haproxy\
- && mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
+RUN mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
  && chown -R haproxy:haproxy /etc/haproxy /var/lib/haproxy /var/run/haproxy\
  && chmod 0 /var/empty
 
 STOPSIGNAL SIGTERM
+USER haproxy
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/start.sh"]

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -20,12 +20,10 @@ RUN apk upgrade --no-cache && apk --no-cache add socat openssl lua5.3 lua-json4 
 
 COPY . /
 
-RUN deluser haproxy\
- && addgroup -g 1001 haproxy\
- && adduser -u 1001 -G haproxy -D -s /bin/false haproxy\
- && mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
+RUN mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
  && chown -R haproxy:haproxy /etc/haproxy /var/lib/haproxy /var/run/haproxy\
  && chmod 0 /var/empty
 
 STOPSIGNAL SIGTERM
+USER haproxy
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/start.sh"]


### PR DESCRIPTION
HAProxy used to need to start as root due to binding ports, which's not needed anymore on somewhat modern kernels and container runtime.

This change breaks backward compatibility and should be added to the breaking changes of the changelog.