### PR TITLE
Fixes configmap based tcp sync

### DIFF
--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -88,7 +88,12 @@ func (c *converters) Sync() {
 	//
 	// configmap converters
 	//
-	if changed.TCPConfigMapDataCur != nil {
+	if changed.TCPConfigMapDataCur != nil || changed.TCPConfigMapDataNew != nil {
+		// We always need to run configmap based tcp sync, when configured, because
+		// we don't have any tracking in place asking us to do it on, e.g., endpoint
+		// or secret updates. Although cur is always assigned if configmap based tcp
+		// is configured, only new is assigned in the very first run. Otoh new is
+		// only assigned when the configmap is changed. So we need to check both.
 		tcpSvcConverter := configmap.NewTCPServicesConverter(c.options, c.haproxy, changed)
 		tcpSvcConverter.Sync()
 		c.timer.Tick("parse_tcp_svc")


### PR DESCRIPTION
This update ensures that configmap based TCP services are applied in the very first controller reconciliation. Cur config is only defined from the second reconciliation, so the TCP service would be empty if the controller bootstrap doesn't call the reconciliation at least twice.