### PR TITLE
Ensure predictable tcp by sorting endpoints

### DIFF
--- a/pkg/haproxy/types/tcpbackend.go
+++ b/pkg/haproxy/types/tcpbackend.go
@@ -96,5 +96,9 @@ func (b *TCPBackend) AddEndpoint(ip string, port int) *TCPEndpoint {
 		Target: fmt.Sprintf("%s:%d", ip, port),
 	}
 	b.Endpoints = append(b.Endpoints, ep)
+	// ensures predictable result, so Changed() works properly
+	sort.Slice(b.Endpoints, func(i, j int) bool {
+		return b.Endpoints[i].Target < b.Endpoints[j].Target
+	})
 	return ep
 }


### PR DESCRIPTION
Dynamic update code relies on comparing tcp services structs in order to verify whether any tcp service has changed or not, and if so, haproxy need to be restarted. Endpoint list is the only tcp data that might lead to differences in the case the same values are present, but in distinct order. Because of that we're applying a sort in order to generate predictable, hence comparable results.