### PR TITLE
Redirect hosts only to domains with associated backends

### DIFF
--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -110,14 +110,14 @@ func (c *updater) buildHostRedirect(d *hostData) {
 	if target := c.haproxy.Hosts().FindTargetRedirect(redir.Value, false); target != nil {
 		c.logger.Warn("ignoring redirect from '%s' on %v, it's already targeting to '%s'",
 			redir.Value, redir.Source, target.Hostname)
-	} else {
+	} else if len(d.host.Paths) > 0 {
 		d.host.Redirect.RedirectHost = redir.Value
 	}
 	redirRegex := d.mapper.Get(ingtypes.HostRedirectFromRegex)
 	if target := c.haproxy.Hosts().FindTargetRedirect(redirRegex.Value, true); target != nil {
 		c.logger.Warn("ignoring regex redirect from '%s' on %v, it's already targeting to '%s'",
 			redirRegex.Value, redirRegex.Source, target.Hostname)
-	} else {
+	} else if len(d.host.Paths) > 0 {
 		d.host.Redirect.RedirectHostRegex = redirRegex.Value
 	}
 }


### PR DESCRIPTION
Redirect-from configuration key defines the source hostnames that should redirect to the one configured in the ingress manifest. This is not properly working with ingress that adds more hostnames in the TLS section because haproxy ingress adds all those hostnames as regular ones. Adding as a regular hostname is needed in order to make haproxy choose the right certificate in the TLS handshake.

The following change is making redirect-from apply redirects only on hosts that have a backend association, which would be otherwise ending up in a 404 error anyway.