### PR TITLE
Create endpoints on a predictable order

### DIFF
--- a/pkg/converters/utils/services_test.go
+++ b/pkg/converters/utils/services_test.go
@@ -40,12 +40,14 @@ func TestCreateEndpointsExternalName(t *testing.T) {
 	ready, notReady, err := CreateEndpoints(cache, svc, svcPort, true)
 	expected := []*Endpoint{
 		{
-			IP:   "10.0.1.10",
-			Port: 8080,
+			IP:     "10.0.1.10",
+			Port:   8080,
+			Target: "10.0.1.10:8080",
 		},
 		{
-			IP:   "10.0.1.11",
-			Port: 8080,
+			IP:     "10.0.1.11",
+			Port:   8080,
+			Target: "10.0.1.11:8080",
 		},
 	}
 	if !reflect.DeepEqual(ready, expected) {
@@ -72,8 +74,8 @@ func TestCreateEndpoints(t *testing.T) {
 			declarePort: "svcport:8080:http",
 			findPort:    "8080",
 			expected: []*Endpoint{
-				{IP: "172.17.0.11", Port: 8080},
-				{IP: "172.17.0.12", Port: 8080},
+				{IP: "172.17.0.11", Port: 8080, Target: "172.17.0.11:8080"},
+				{IP: "172.17.0.12", Port: 8080, Target: "172.17.0.12:8080"},
 			},
 		},
 		// 1
@@ -82,7 +84,7 @@ func TestCreateEndpoints(t *testing.T) {
 			declarePort: "svcport:8080:http",
 			findPort:    "svcport",
 			expected: []*Endpoint{
-				{IP: "172.17.0.11", Port: 8080},
+				{IP: "172.17.0.11", Port: 8080, Target: "172.17.0.11:8080"},
 			},
 		},
 		// 2
@@ -91,7 +93,7 @@ func TestCreateEndpoints(t *testing.T) {
 			declarePort: "svcport:8000:http",
 			findPort:    "http",
 			expected: []*Endpoint{
-				{IP: "172.17.0.12", Port: 8000},
+				{IP: "172.17.0.12", Port: 8000, Target: "172.17.0.12:8000"},
 			},
 		},
 	}

--- a/pkg/haproxy/types/tcpbackend.go
+++ b/pkg/haproxy/types/tcpbackend.go
@@ -96,9 +96,5 @@ func (b *TCPBackend) AddEndpoint(ip string, port int) *TCPEndpoint {
 		Target: fmt.Sprintf("%s:%d", ip, port),
 	}
 	b.Endpoints = append(b.Endpoints, ep)
-	// ensures predictable result, so Changed() works properly
-	sort.Slice(b.Endpoints, func(i, j int) bool {
-		return b.Endpoints[i].Target < b.Endpoints[j].Target
-	})
 	return ep
 }


### PR DESCRIPTION
Endpoints (internal haproxy ingress struct, not the k8s one) are part of the building blocks to configure a backend or a tcp listener. HAProxy Ingress uses deep equals on some structs in order to identify equality, hence the ability to skip a reload event. When two endpoint arrays have the same content but on distinct order, they are not considered equals, although it should from the haproxy and haproxy ingress perspective. Because of that we're sorting them.

The former update (which we're reverting here) was sorting the endpoints after they get named, so the order is right but some names might be changed. Now we're sorting the endpoints on its source.