### PR TITLE
Remove generation predicate on endpoints

### DIFF
--- a/pkg/controller/reconciler/watchers.go
+++ b/pkg/controller/reconciler/watchers.go
@@ -139,7 +139,6 @@ func (w *watchers) handlersCore() []*hdlr {
 			typ: &api.Endpoints{},
 			res: types.ResourceEndpoints,
 			pr: []predicate.Predicate{
-				predicate.GenerationChangedPredicate{},
 				predicate.Funcs{
 					UpdateFunc: func(ue event.UpdateEvent) bool {
 						old := ue.ObjectOld.(*api.Endpoints)


### PR DESCRIPTION
Endpoints resource doesn't implement generation, so generation based predicates doesn't work on it, making endpoints not to dispatch events. We already have a func based predicate in place, so we can just remove the generation based one altogether.