### PR TITLE
Fix shard render when the last backend is removed

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -414,6 +414,12 @@ func (c *config) Userlists() *hatypes.Userlists {
 
 func (c *config) Clear() {
 	config := createConfig(c.options)
+
+	// copying backend state, so shards with all the backends removed can be
+	// properly identified and updated when a full reconciliation happens
+	config.backends = c.backends
+	config.backends.Clear()
+
 	*c = *config
 }
 


### PR DESCRIPTION
Backend template rendering is the most CPU consumption of the reconciliation process, so sharding backends reduces haproxy ingress processing on workloads with thousands of services. Once sharding, haproxy ingress can update only the shards whose backends were changed since the last update.

When a full reconciliation happens, usually triggered by changing a global config, all the resources need to be parsed again, and this happen by clearing the state and building it again from scratch. This building process clears old states, removing from the controller the ability to find shards that had backends and doesn't have anymore. Since the file continues on the disk, the backend is registered on HAProxy, although it's not referenced anymore.

This is likely not to happen with ingress resources because the removal of a service triggers a partial parsing, which preserves the old state and old shards are always found, despite of being empty or not. However, if a global is changed exactly at the same time of a service removal, the backend of that service should leak if it's the last one of a backend shard. When using gateway API this is more likely to happen because currently gateway API uses full reconciliation.