### PR TITLE
Add wildcard as a valid cors allowed header

### DIFF
--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -1386,6 +1386,26 @@ func TestCors(t *testing.T) {
 				},
 			},
 		},
+		// 8
+		{
+			ann: map[string]map[string]string{
+				"/": {
+					ingtypes.BackCorsEnable:       "true",
+					ingtypes.BackCorsAllowHeaders: "*",
+				},
+			},
+			expected: map[string]hatypes.Cors{
+				"/": {
+					Enabled:          true,
+					AllowCredentials: false,
+					AllowHeaders:     "*",
+					AllowMethods:     corsDefaultMethods,
+					AllowOrigin:      corsDefaultOrigin,
+					ExposeHeaders:    "",
+					MaxAge:           corsDefaultMaxAge,
+				},
+			},
+		},
 	}
 	annDefault := map[string]string{
 		ingtypes.BackCorsAllowHeaders: corsDefaultHeaders,

--- a/pkg/converters/ingress/annotations/validator.go
+++ b/pkg/converters/ingress/annotations/validator.go
@@ -35,7 +35,7 @@ type validate struct {
 var (
 	corsOriginRegex  = regexp.MustCompile(`^(https?://[A-Za-z0-9\-\.]*(:[0-9]+)?|\*)$`)
 	corsMethodsRegex = regexp.MustCompile(`^([A-Za-z]+,?\s?)+$`)
-	corsHeadersRegex = regexp.MustCompile(`^([A-Za-z0-9\-\_]+,?\s?)+$`)
+	corsHeadersRegex = regexp.MustCompile(`^([A-Za-z0-9\-\_]+,?\s?)|\*+$`)
 )
 
 var validators = map[string]func(v validate) (string, bool){


### PR DESCRIPTION
Wildcard is a valid cors allowed header option, but validation wasn't allowing to configure it.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers