### PR TITLE
bump haproxy to patch 2.6.15 for security vuln.

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -28,7 +28,7 @@ RUN GIT_TAG=${GIT_TAG:-latest}\
     -ldflags "-s -w -X ${VERSION_PKG}.RELEASE=${GIT_TAG} -X ${VERSION_PKG}.COMMIT=${GIT_COMMIT} -X ${VERSION_PKG}.REPO=${GIT_REPO}"\
     -o haproxy-ingress pkg/main.go
 
-FROM haproxy:2.6.14-alpine
+FROM haproxy:2.6.15-alpine
 
 USER root
 

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM haproxy:2.6.14-alpine
+FROM haproxy:2.6.15-alpine
 
 USER root
 


### PR DESCRIPTION
Tiny bump to the patch version of core haproxy due to [CVE-2023-40225](https://ubuntu.com/security/CVE-2023-40225).

* https://ubuntu.com/security/notices/USN-6294-1 
* http://git.haproxy.org/?p=haproxy-2.6.git;a=commit;h=d17c50010d591d1c070e1cb0567a06032d8869e9