### PR TITLE
[release-0.13] Bump haproxy 2.4.24

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -29,7 +29,7 @@ RUN cd /src\
     -ldflags "-s -w -X ${VERSION_PKG}.RELEASE=${GIT_TAG} -X ${VERSION_PKG}.COMMIT=${GIT_COMMIT} -X ${VERSION_PKG}.REPO=${GIT_REPO}"\
     -o haproxy-ingress pkg/main.go
 
-FROM haproxy:2.4.23-alpine
+FROM haproxy:2.4.24-alpine
 
 USER root
 

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM haproxy:2.4.23-alpine
+FROM haproxy:2.4.24-alpine
 
 USER root
 


### PR DESCRIPTION
See: https://www.haproxy.org/download/2.4/src/CHANGELOG