### PR TITLE
[release-0.14] Bump 2.4.24

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: 1.19.10
+        go-version: 1.19.12
     - uses: actions/checkout@v3
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v3

--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19.10-alpine AS builder
+FROM golang:1.19.12-alpine AS builder
 
 ARG GIT_TAG
 WORKDIR /src
@@ -28,7 +28,7 @@ RUN GIT_TAG=${GIT_TAG:-latest}\
     -ldflags "-s -w -X ${VERSION_PKG}.RELEASE=${GIT_TAG} -X ${VERSION_PKG}.COMMIT=${GIT_COMMIT} -X ${VERSION_PKG}.REPO=${GIT_REPO}"\
     -o haproxy-ingress pkg/main.go
 
-FROM haproxy:2.4.23-alpine
+FROM haproxy:2.4.24-alpine
 
 USER root
 

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM haproxy:2.4.23-alpine
+FROM haproxy:2.4.24-alpine
 
 USER root
 


### PR DESCRIPTION
https://www.haproxy.org/download/2.4/src/CHANGELOG


go1.19.11 (released 2023-07-11) includes a security fix to the net/http package, as well as bug fixes to cgo, the cover tool, the go command, the runtime, and the go/printer package. See the [Go 1.19.11 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.11+label%3ACherryPickApproved) on our issue tracker for details.

go1.19.12 (released 2023-08-01) includes a security fix to the crypto/tls package, as well as bug fixes to the assembler and the compiler. See the [Go 1.19.12 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.19.12+label%3ACherryPickApproved) on our issue tracker for details.