### PR TITLE
fix coraza configuration to use the action variable

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -5090,8 +5090,14 @@ spoe-message check-request
 			endpoints: []string{"10.0.0.101:12345"},
 			backendExp: `
     filter spoe engine modsecurity config /etc/haproxy/spoe-modsecurity.conf
+    http-request redirect code 302 location %[var(txn.coraza.data)] if { var(txn.coraza.action) -m str redirect }
+    http-response redirect code 302 location %[var(txn.coraza.data)] if { var(txn.coraza.action) -m str redirect }
+    http-request deny deny_status 403 hdr waf-block "request"  if { var(txn.coraza.action) -m str deny }
+    http-response deny deny_status 403 hdr waf-block "response" if { var(txn.coraza.action) -m str deny }
+    http-request silent-drop if { var(txn.coraza.action) -m str drop }
+    http-response silent-drop if { var(txn.coraza.action) -m str drop }
     http-request deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }
-    http-request deny if !{ var(txn.coraza.fail) -m int eq 0 }`,
+    http-response deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }`,
 			modsecExp: `
     timeout connect 1s
     timeout server  2s

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -595,8 +595,14 @@ backend {{ $backend.ID }}
 {{- if eq $waf.Mode "deny" }}
 {{- range $pathIDs := $wafCfg.PathIDs $i }}
 {{- if $global.ModSecurity.UseCoraza }}
+    http-request redirect code 302 location %[var(txn.coraza.data)] if { var(txn.coraza.action) -m str redirect }
+    http-response redirect code 302 location %[var(txn.coraza.data)] if { var(txn.coraza.action) -m str redirect }
+    http-request deny deny_status 403 hdr waf-block "request"  if { var(txn.coraza.action) -m str deny }
+    http-response deny deny_status 403 hdr waf-block "response" if { var(txn.coraza.action) -m str deny }
+    http-request silent-drop if { var(txn.coraza.action) -m str drop }
+    http-response silent-drop if { var(txn.coraza.action) -m str drop }
     http-request deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }
-    http-request deny if !{ var(txn.coraza.fail) -m int eq 0 }
+    http-response deny deny_status 504 if { var(txn.coraza.error) -m int gt 0 }
 {{- else }}
     http-request deny if { var(txn.modsec.code) -m int gt 0 }
 {{- end }}


### PR DESCRIPTION
This is a fix for #1085 

The snippet used in the fix was provided by the issue's op (@tomklapka)

It uses txn.coraza.action instead of the txn.coraza.fail and allow for a more fine grained control about how requests should be rejected and fixes the issue that with the current coraza version all requests are rejected (txn.coraza.fail is most likely not set anymore).

I've based this fix of 0.14 because I wasn't able to get master running in our testing environment. Please let me know if I need to change anything here.