### PR TITLE
Add net bind capability to haproxy bin

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -32,14 +32,15 @@ FROM haproxy:2.6.16-alpine
 
 USER root
 
-RUN apk upgrade --no-cache && apk --no-cache add socat openssl lua5.3 lua-json4 dumb-init
+RUN apk upgrade --no-cache && apk --no-cache add libcap-utils socat openssl lua5.3 lua-json4 dumb-init
 
 COPY rootfs/ /
 COPY --from=builder /src/haproxy-ingress /haproxy-ingress-controller
 
 RUN mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
  && chown -R haproxy:haproxy /etc/haproxy /var/lib/haproxy /var/run/haproxy\
- && chmod 0 /var/empty
+ && chmod 0 /var/empty\
+ && setcap 'cap_net_bind_service=+ep' /usr/local/sbin/haproxy
 
 STOPSIGNAL SIGTERM
 USER haproxy

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -16,13 +16,14 @@ FROM haproxy:2.6.16-alpine
 
 USER root
 
-RUN apk upgrade --no-cache && apk --no-cache add socat openssl lua5.3 lua-json4 dumb-init
+RUN apk upgrade --no-cache && apk --no-cache add libcap-utils socat openssl lua5.3 lua-json4 dumb-init
 
 COPY . /
 
 RUN mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
  && chown -R haproxy:haproxy /etc/haproxy /var/lib/haproxy /var/run/haproxy\
- && chmod 0 /var/empty
+ && chmod 0 /var/empty\
+ && setcap 'cap_net_bind_service=+ep' /usr/local/sbin/haproxy
 
 STOPSIGNAL SIGTERM
 USER haproxy


### PR DESCRIPTION
HAProxy Ingress starts now as the non privileged user haproxy, and this is the same user that starts the embedded haproxy process. Some container runtimes do not configure the unprivileged_port_start param from the default 1024 to 0, which makes the embedded haproxy process fail to bind to 80/443 ports. Adding the net bind capability to the haproxy binary allows it to bind to any tcp port, without running as a privileged user, and without configuring unprivileged_port_start param.