### PR TITLE
Fix label generation for node discovery

### DIFF
--- a/pkg/common/k8s/main.go
+++ b/pkg/common/k8s/main.go
@@ -91,10 +91,18 @@ func GetPodDetails(kubeClient clientset.Interface) (*PodInfo, error) {
 		return nil, fmt.Errorf("unable to get POD information")
 	}
 
+	podNodeIP := GetNodeIP(kubeClient, pod.Spec.NodeName, true)
+	podLabels := pod.GetLabels()
+
+	// remove labels that uniquely identify a pod
+	delete(podLabels, "controller-revision-hash")
+	delete(podLabels, "pod-template-generation")
+	delete(podLabels, "pod-template-hash")
+
 	return &PodInfo{
 		Name:      podName,
 		Namespace: podNs,
-		NodeIP:    GetNodeIP(kubeClient, pod.Spec.NodeName, true),
-		Labels:    pod.GetLabels(),
+		NodeIP:    podNodeIP,
+		Labels:    podLabels,
 	}, nil
 }

--- a/pkg/controller/services/svcstatusing.go
+++ b/pkg/controller/services/svcstatusing.go
@@ -253,10 +253,17 @@ func (s *svcStatusIng) getControllerPodList(ctx context.Context) ([]api.Pod, err
 	if err := s.cli.Get(ctx, types.NamespacedName{Namespace: s.cfg.PodNamespace, Name: s.cfg.PodName}, &pod); err != nil {
 		return nil, err
 	}
+
+	// remove labels that uniquely identify a pod
+	podLabels := pod.GetLabels()
+	delete(podLabels, "controller-revision-hash")
+	delete(podLabels, "pod-template-generation")
+	delete(podLabels, "pod-template-hash")
+
 	// read all controller's pod
 	podList := api.PodList{}
 	if err := s.cli.List(ctx, &podList, &client.ListOptions{
-		LabelSelector: labels.SelectorFromSet(pod.GetLabels()),
+		LabelSelector: labels.SelectorFromSet(podLabels),
 		Namespace:     s.cfg.PodNamespace,
 	}); err != nil {
 		return nil, err


### PR DESCRIPTION
A set of labels are used to find all the nodes of a cluster of ingress controllers. The controller instance running the code takes its own set of labels and use it to find the others via apiserver. The set of labels has, however, some labels that uniquely identify a pod, like pod-template-hash created by the ReplicaSet, making the node discovery to discover only one node, the one being running. On shutdowns, this makes the controller to incorrectly think it is running alone, leading to remove the status of all the ingress resources. Removing all the well-known label keys that uniquely identifies a pod solves this issue.