### PR TITLE
Ensure https redirect happens before root redirect

### DIFF
--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -314,6 +314,7 @@ func (c *updater) buildGlobalSSL(d *globalData) {
 	ssl.ModeAsync = d.mapper.Get(ingtypes.GlobalSSLModeAsync).Bool()
 	ssl.Options = d.mapper.Get(ingtypes.GlobalSSLOptions).Value
 	ssl.RedirectCode = d.mapper.Get(ingtypes.GlobalSSLRedirectCode).Int()
+	ssl.SSLRedirect = d.mapper.Get(ingtypes.BackSSLRedirect).Bool()
 }
 
 func (c *updater) buildGlobalHTTPStoHTTP(d *globalData) {

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -405,6 +405,12 @@ func (l *PathLink) Equals(other *PathLink) bool {
 	return l.hash == other.hash
 }
 
+// ComposeMatch returns true if the pathLink has composing match,
+// by adding method, header or cookie match.
+func (l *PathLink) ComposeMatch() bool {
+	return len(l.headers) > 0
+}
+
 // WithHostname ...
 func (l *PathLink) WithHostname(hostname string) *PathLink {
 	l.hostname = hostname

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -151,6 +151,7 @@ type SSLConfig struct {
 	ModeAsync           bool
 	Options             string
 	RedirectCode        int
+	SSLRedirect         bool
 }
 
 // DHParamConfig ...
@@ -406,6 +407,7 @@ type FrontendMaps struct {
 	HTTPSSNIMap  *HostsMap
 	//
 	RedirFromRootMap  *HostsMap
+	RedirRootSSLMap   *HostsMap
 	RedirFromMap      *HostsMap
 	RedirToMap        *HostsMap
 	SSLPassthroughMap *HostsMap

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1156,8 +1156,19 @@ frontend {{ $proxy__front_http }}
     http-request set-var(req.host) hdr(host),field(1,:),lower
     http-request set-var(req.base) var(req.host),concat(\#,req.path)
 
-{{- /*------------------------------------*/}}
 {{- $acmeexclusive := and $global.Acme.Enabled (not $global.Acme.Shared) }}
+
+{{- /*------------------------------------*/}}
+{{- if $fmaps.RedirRootSSLMap.HasHost }}
+{{- range $match := $fmaps.RedirRootSSLMap.MatchFiles }}
+    http-request redirect scheme https
+        {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
+        {{- "" }} if{{ if $acmeexclusive }} !acme-challenge{{ end }}
+        {{- "" }} { path / } { var(req.host) -i -m {{ $match.Method }} -f {{ $match.Filename }} }
+{{- end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
 {{- if $fmaps.RedirFromRootMap.HasHost }}
 {{- range $match := $fmaps.RedirFromRootMap.MatchFiles }}
     http-request set-var(req.rootredir) var(req.host)

--- a/tests/framework/options/objects.go
+++ b/tests/framework/options/objects.go
@@ -8,15 +8,13 @@ import (
 
 type Object func(o *objectOpt)
 
-func AddConfigKeyAnnotations(ann map[string]string) Object {
+func AddConfigKeyAnnotation(key, value string) Object {
 	annprefix := "haproxy-ingress.github.io/"
 	return func(o *objectOpt) {
 		if o.Ann == nil {
 			o.Ann = make(map[string]string)
 		}
-		for k, v := range ann {
-			o.Ann[annprefix+k] = v
-		}
+		o.Ann[annprefix+key] = value
 	}
 }
 


### PR DESCRIPTION
`app-root` config key configures the root path redirect in haproxy frontend. https redirect however is configured in the backend. Because of that haproxy is redirecting from the root path to the application path in plain http, before redirecting to https. This is not a good approach because it makes security scanners infer that the application does not have a secure proxy.

This update adds a https redirect before the application redirect, in the case the root path of the host renders its ssl-redirect to true.