### PR TITLE
Allows secure backend configuration from global

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -802,15 +802,20 @@ func (c *updater) buildBackendProtocol(d *backData) {
 		return
 	}
 	if crt := d.mapper.Get(ingtypes.BackSecureCrtSecret); crt.Value != "" {
-		if crtFile, err := c.cache.GetTLSSecretPath(
-			crt.Source.Namespace,
-			crt.Value,
-			[]convtypes.TrackingRef{{Context: convtypes.ResourceHABackend, UniqueName: d.backend.ID}},
-		); err == nil {
+		var crtFile convtypes.CrtFile
+		namespace, name, err := crt.NamespacedName()
+		if err == nil {
+			crtFile, err = c.cache.GetTLSSecretPath(
+				namespace,
+				name,
+				[]convtypes.TrackingRef{{Context: convtypes.ResourceHABackend, UniqueName: d.backend.ID}},
+			)
+		}
+		if err == nil {
 			d.backend.Server.CrtFilename = crtFile.Filename
 			d.backend.Server.CrtHash = crtFile.SHA1Hash
 		} else {
-			c.logger.Warn("skipping client certificate on %v: %v", crt.Source, err)
+			c.logger.Warn("skipping client certificate on %s: %v", crt.Source.String(), err)
 		}
 	}
 	if sni := d.mapper.Get(ingtypes.BackSecureSNI); sni.Value != "" {
@@ -835,17 +840,22 @@ func (c *updater) buildBackendProtocol(d *backData) {
 		}
 	}
 	if ca := d.mapper.Get(ingtypes.BackSecureVerifyCASecret); ca.Value != "" {
-		if caFile, crlFile, err := c.cache.GetCASecretPath(
-			ca.Source.Namespace,
-			ca.Value,
-			[]convtypes.TrackingRef{{Context: convtypes.ResourceHABackend, UniqueName: d.backend.ID}},
-		); err == nil {
+		var caFile, crlFile convtypes.File
+		namespace, name, err := ca.NamespacedName()
+		if err == nil {
+			caFile, crlFile, err = c.cache.GetCASecretPath(
+				namespace,
+				name,
+				[]convtypes.TrackingRef{{Context: convtypes.ResourceHABackend, UniqueName: d.backend.ID}},
+			)
+		}
+		if err == nil {
 			d.backend.Server.CAFilename = caFile.Filename
 			d.backend.Server.CAHash = caFile.SHA1Hash
 			d.backend.Server.CRLFilename = crlFile.Filename
 			d.backend.Server.CRLHash = crlFile.SHA1Hash
 		} else {
-			c.logger.Warn("skipping CA on %v: %v", ca.Source, err)
+			c.logger.Warn("skipping CA on %s: %v", ca.Source.String(), err)
 		}
 	}
 }

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -2117,7 +2117,7 @@ func TestBackendServerNaming(t *testing.T) {
 
 func TestBackendProtocol(t *testing.T) {
 	testCase := []struct {
-		source     Source
+		source     *Source
 		useHTX     bool
 		annDefault map[string]string
 		ann        map[string]map[string]string
@@ -2153,7 +2153,7 @@ func TestBackendProtocol(t *testing.T) {
 		},
 		// 2
 		{
-			source: Source{Namespace: "default", Name: "app1", Type: "service"},
+			source: &Source{Namespace: "default", Name: "app1", Type: "service"},
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackSecureBackends:  "true",
@@ -2172,7 +2172,7 @@ func TestBackendProtocol(t *testing.T) {
 		},
 		// 3
 		{
-			source: Source{Namespace: "default", Name: "app1", Type: "service"},
+			source: &Source{Namespace: "default", Name: "app1", Type: "service"},
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackSecureBackends:       "true",
@@ -2197,7 +2197,7 @@ func TestBackendProtocol(t *testing.T) {
 		},
 		// 4
 		{
-			source: Source{Namespace: "default", Name: "app1", Type: "service"},
+			source: &Source{Namespace: "default", Name: "app1", Type: "service"},
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackSecureBackends:       "true",
@@ -2278,7 +2278,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 		},
 		// 10
 		{
-			source: Source{Namespace: "default", Name: "app1", Type: "service"},
+			source: &Source{Namespace: "default", Name: "app1", Type: "service"},
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackBackendProtocol: "invalid-ssl",
@@ -2289,7 +2289,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 		},
 		// 11
 		{
-			source: Source{Namespace: "default", Name: "app1", Type: "service"},
+			source: &Source{Namespace: "default", Name: "app1", Type: "service"},
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackBackendProtocol: "h2",
@@ -2344,7 +2344,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 		},
 		// 15
 		{
-			source: Source{Namespace: "default", Name: "app", Type: "ingress"},
+			source: &Source{Namespace: "default", Name: "app", Type: "ingress"},
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackBackendProtocol: "h1-ssl",
@@ -2373,7 +2373,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 		},
 		// 17
 		{
-			source: Source{Namespace: "default", Name: "app", Type: "ingress"},
+			source: &Source{Namespace: "default", Name: "app", Type: "ingress"},
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackBackendProtocol:      "h1-ssl",
@@ -2416,7 +2416,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 		},
 		// 20
 		{
-			source: Source{Namespace: "default", Name: "app", Type: "ingress"},
+			source: &Source{Namespace: "default", Name: "app", Type: "ingress"},
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackBackendProtocol:      "h1-ssl",
@@ -2429,10 +2429,58 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 			},
 			logging: `WARN skipping invalid domain (verify-hostname) on ingress 'default/app': invalid-domain`,
 		},
+		// 21
+		{
+			ann: map[string]map[string]string{
+				"/": {
+					ingtypes.BackSecureBackends:       "true",
+					ingtypes.BackSecureCrtSecret:      "cli",
+					ingtypes.BackSecureVerifyCASecret: "ca",
+				},
+			},
+			tlsSecrets: map[string]string{
+				"default/cli": "/var/haproxy/ssl/cli.pem",
+			},
+			caSecrets: map[string]string{
+				"default/ca": "/var/haproxy/ssl/ca.pem",
+			},
+			expected: hatypes.ServerConfig{
+				Protocol: "h1",
+				Secure:   true,
+			},
+			logging: `
+WARN skipping client certificate on <global>: a globally configured resource name is missing the namespace: cli
+WARN skipping CA on <global>: a globally configured resource name is missing the namespace: ca
+`,
+		},
+		// 22
+		{
+			ann: map[string]map[string]string{
+				"/": {
+					ingtypes.BackSecureBackends:       "true",
+					ingtypes.BackSecureCrtSecret:      "default/cli",
+					ingtypes.BackSecureVerifyCASecret: "default/ca",
+				},
+			},
+			tlsSecrets: map[string]string{
+				"default/cli": "/var/haproxy/ssl/cli.pem",
+			},
+			caSecrets: map[string]string{
+				"default/ca": "/var/haproxy/ssl/ca.pem",
+			},
+			expected: hatypes.ServerConfig{
+				Protocol:    "h1",
+				Secure:      true,
+				CAFilename:  "/var/haproxy/ssl/ca.pem",
+				CAHash:      "3be93154b1cddfd0e1279f4d76022221676d08c7",
+				CrtFilename: "/var/haproxy/ssl/cli.pem",
+				CrtHash:     "f916dd295030e070f4d4aca4508571bc82f549af",
+			},
+		},
 	}
 	for i, test := range testCase {
 		c := setup(t)
-		d := c.createBackendMappingData("default/app", &test.source, test.annDefault, test.ann, test.paths)
+		d := c.createBackendMappingData("default/app", test.source, test.annDefault, test.ann, test.paths)
 		c.haproxy.Global().UseHTX = test.useHTX
 		c.cache.SecretTLSPath = test.tlsSecrets
 		c.cache.SecretCAPath = test.caSecrets

--- a/pkg/converters/ingress/annotations/mapper.go
+++ b/pkg/converters/ingress/annotations/mapper.go
@@ -205,6 +205,21 @@ func (cv *ConfigValue) String() string {
 	return cv.Value
 }
 
+// NamespacedName ...
+func (cv *ConfigValue) NamespacedName() (namespace, name string, err error) {
+	value := strings.Split(cv.Value, "/")
+	if len(value) > 2 {
+		return "", "", fmt.Errorf("unpexpected format for resource name: %s", cv.Value)
+	}
+	if len(value) == 2 {
+		return value[0], value[1], nil
+	}
+	if s := cv.Source; s != nil {
+		return s.Namespace, value[0], nil
+	}
+	return "", "", fmt.Errorf("a globally configured resource name is missing the namespace: %s", cv.Value)
+}
+
 // ToLower ...
 func (cv *ConfigValue) ToLower() string {
 	return strings.ToLower(cv.Value)
@@ -240,5 +255,8 @@ func (m *PathConfig) String() string {
 
 // String ...
 func (s *Source) String() string {
+	if s == nil {
+		return "<global>"
+	}
 	return fmt.Sprintf("%s '%s'", s.Type, s.FullName())
 }


### PR DESCRIPTION
Some configuration keys were not designed to be made from global due to the lack of a namespace name. Secure backend needs a namespace to read secrets for a CA bundle and client certificate. This update allows to provide a secret in the global ConfigMap by adding the namespace along with the name of the secret.