### PR TITLE
Allows to configure auth-url globally

### DIFF
--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -25,7 +25,7 @@ import (
 func (c *updater) buildHostAuthExternal(d *hostData) {
 	isFrontend := d.mapper.Get(ingtypes.BackAuthExternalPlacement).ToLower() == "frontend"
 	url := d.mapper.Get(ingtypes.BackAuthURL)
-	if isFrontend && url.Source != nil && url.Value != "" {
+	if isFrontend && url.Value != "" {
 		for _, path := range d.host.Paths {
 			path.AuthExt = &types.AuthExternal{}
 			c.setAuthExternal(d.mapper, path.AuthExt, url)

--- a/pkg/converters/ingress/annotations/mapper.go
+++ b/pkg/converters/ingress/annotations/mapper.go
@@ -240,5 +240,8 @@ func (m *PathConfig) String() string {
 
 // String ...
 func (s *Source) String() string {
+	if s == nil {
+		return "<global>"
+	}
 	return fmt.Sprintf("%s '%s'", s.Type, s.FullName())
 }


### PR DESCRIPTION
Adds the option to configure auth-url globally. Global configurations don't rely on a namespace name, so the only change in the configuration is that a service url needs to add the namespace of the service when configured globally.