### PR TITLE
Update RBAC configuration and docs to include leases resource for leader election

### DIFF
--- a/docs/haproxy-ingress.yaml
+++ b/docs/haproxy-ingress.yaml
@@ -72,6 +72,14 @@ metadata:
   namespace: ingress-controller
 rules:
   - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - ""
     resources:
       - configmaps

--- a/docs/static/resources/haproxy-ingress.yaml
+++ b/docs/static/resources/haproxy-ingress.yaml
@@ -40,9 +40,10 @@ rules:
       - list
       - watch
   - apiGroups:
-      - "extensions"
-      - "networking.k8s.io"
+      - extensions
+      - networking.k8s.io
     resources:
+      - ingressclasses
       - ingresses
     verbs:
       - get
@@ -56,8 +57,8 @@ rules:
       - create
       - patch
   - apiGroups:
-      - "extensions"
-      - "networking.k8s.io"
+      - extensions
+      - networking.k8s.io
     resources:
       - ingresses/status
     verbs:
@@ -69,6 +70,14 @@ metadata:
   name: ingress-controller
   namespace: ingress-controller
 rules:
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
   - apiGroups:
       - ""
     resources:

--- a/examples/rbac/README.md
+++ b/examples/rbac/README.md
@@ -41,9 +41,11 @@ The Role permissions are:
 * `endpoints`: create, get, update
 
 Furthermore to support leader-election, the ingress controller needs to
-have access to a `configmap` in the `ingress-controller` namespace:
+have access to both the `configmap` and `leases` resources in the
+`ingress-controller` namespace:
 
 * `configmaps`: get, update, create
+* `coordination.k8s.io/leases`: get, update, create
 
 ## Namespace created in this example
 

--- a/examples/rbac/ingress-controller-rbac.yml
+++ b/examples/rbac/ingress-controller-rbac.yml
@@ -72,6 +72,14 @@ metadata:
   namespace: ingress-controller
 rules:
   - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
       - ""
     resources:
       - configmaps


### PR DESCRIPTION
Same change as done in the helm chart:
https://github.com/haproxy-ingress/charts/pull/58