### PR TITLE
Remove dedicated maps for SNI match

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -176,7 +176,6 @@ func (c *config) WriteFrontendMaps() error {
 	fmaps := &hatypes.FrontendMaps{
 		HTTPHostMap:  mapBuilder.AddMap(mapsDir + "/_front_http_host.map"),
 		HTTPSHostMap: mapBuilder.AddMap(mapsDir + "/_front_https_host.map"),
-		HTTPSSNIMap:  mapBuilder.AddMap(mapsDir + "/_front_https_sni.map"),
 		//
 		RedirFromRootMap:  mapBuilder.AddMap(mapsDir + "/_front_redir_fromroot.map"),
 		RedirFromMap:      mapBuilder.AddMap(mapsDir + "/_front_redir_from.map"),
@@ -223,13 +222,8 @@ func (c *config) WriteFrontendMaps() error {
 					}
 				} else if host.HasTLS() {
 					// ssl offload in place
-					if host.HasTLSAuth() {
-						fmaps.HTTPSSNIMap.AddHostnamePathMapping(host.Hostname, path, backendID)
-						fmaps.HTTPSSNIMap.AddAliasPathMapping(host.Alias, path, backendID)
-					} else {
-						fmaps.HTTPSHostMap.AddHostnamePathMapping(host.Hostname, path, backendID)
-						fmaps.HTTPSHostMap.AddAliasPathMapping(host.Alias, path, backendID)
-					}
+					fmaps.HTTPSHostMap.AddHostnamePathMapping(host.Hostname, path, backendID)
+					fmaps.HTTPSHostMap.AddAliasPathMapping(host.Alias, path, backendID)
 				}
 				fmaps.HTTPHostMap.AddHostnamePathMapping(host.Hostname, path, backendID)
 				fmaps.HTTPHostMap.AddAliasPathMapping(host.Alias, path, backendID)

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -404,7 +404,6 @@ type HostsMaps struct {
 type FrontendMaps struct {
 	HTTPHostMap  *HostsMap
 	HTTPSHostMap *HostsMap
-	HTTPSSNIMap  *HostsMap
 	//
 	RedirFromRootMap  *HostsMap
 	RedirRootSSLMap   *HostsMap

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1372,24 +1372,6 @@ frontend {{ $frontend.Name }}
     acl tls-check-crt ssl_fc_sni -i -m {{ $match.Method }} -f {{ $match.Filename }}
 {{- end }}
 
-{{- if $fmaps.HTTPSSNIMap.HasHost }}
-    http-request set-var(req.snibase) ssl_fc_sni,lower,concat(\#,req.path)
-{{- range $match := $fmaps.HTTPSSNIMap.MatchFiles }}
-    http-request set-var(req.snibackend) var(req.snibase)
-        {{- if $match.Lower }},lower{{ end }}
-        {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
-        {{- template "httpFilters" map $match "req.snibackend" 1 }}
-{{- end }}
-{{- range $match := $fmaps.HTTPSSNIMap.MatchFiles }}
-    http-request set-var(req.snibackend) var(req.base)
-        {{- if $match.Lower }},lower{{ end }}
-        {{- "" }},map_{{ $match.Method }}({{ $match.Filename }})
-        {{- "" }} if !{ var(req.snibackend) -m found } !tls-has-crt
-        {{- if $fmaps.TLSNeedCrtList.HasHost }} !tls-host-need-crt{{ end }}
-        {{- template "httpFilters" map $match "" 0 }}
-{{- end }}
-{{- end }}
-
 {{- if $mandatory }}
 {{- if not $fmaps.TLSMissingCrtPagesMap.HasHost }}
     http-request set-var(req.tls_nocrt_redir) str(_internal) if !tls-has-crt tls-need-crt


### PR DESCRIPTION
SNI maps were incorrectly used to match requests on ancient versions of HAProxy Ingress - v0.4 or so. A separated group of match files were being used since then on TLS based authentication configurations. We don't need it anymore, since all the mTLS configurations don't depend on the maps, so we're now dropping its support. Moreover, having a distinct group of match files leads to misbehavior depending on the configurations: a host and path with lower priority should be chosen if the one with more priority is added in the sni maps.

There is one behavior change with this update: a missing or misconfigured host header, for an ingress with mTLS, with optional certificate, without sending a certificate, would fallback to SNI in order to try a match. Now, since only the host header is the source of truth, a non matching host header with a distinct SNI will 404 despite of its mTLS configuration.