### PR TITLE
Change default master-worker config to true

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -360,9 +360,10 @@ Since v0.14
 
 Defines if haproxy should be configured in master-worker mode. If `false`, one single process
 is forked in the background. If `true`, a master process is started in the foreground and can
-be used to manage current and old worker processes. The default value is `false`, which
-preserves historical behavior of HAProxy Ingress. External HAProxy deployment needs
-master-worker mode and will enforce `--master-worker` as `true` if configured.
+be used to manage current and old worker processes. The default value is `false` in v0.14, which
+preserves historical behavior of HAProxy Ingress. v0.15 and newer defaults to `true` if not
+declared. External HAProxy deployment needs master-worker mode and will enforce
+`--master-worker` as `true` if configured.
 
 ---
 

--- a/pkg/controller/config/options.go
+++ b/pkg/controller/config/options.go
@@ -14,6 +14,7 @@ func NewOptions() *Options {
 		IngressClass:            "haproxy",
 		ReloadStrategy:          "reusesocket",
 		WatchGateway:            true,
+		MasterWorker:            true,
 		AcmeCheckPeriod:         24 * time.Hour,
 		AcmeFailInitialDuration: 5 * time.Minute,
 		AcmeFailMaxDuration:     8 * time.Hour,


### PR DESCRIPTION
Master worker mode has a better process handling, more config key options, and should be the option if the user doesn't have a reason to choose the standalone daemon.