### PR TITLE
Move embedded haproxy process to a distinct pid group

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -44,4 +44,7 @@ RUN mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
 
 STOPSIGNAL SIGTERM
 USER haproxy
+
+# dumb-init reaps the old haproxy process in the embedded, non master-worker mode,
+# after receiving SIGUSR1, avoiding it to become a zombie.
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/start.sh"]

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -637,6 +637,7 @@ func (i *instance) startHAProxySync() {
 		"-f", i.options.HAProxyCfgDir)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if err := cmd.Start(); err != nil {
 		i.logger.Error("error starting haproxy: %v", err)
 		return

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -27,4 +27,7 @@ RUN mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
 
 STOPSIGNAL SIGTERM
 USER haproxy
+
+# dumb-init reaps the old haproxy process in the embedded, non master-worker mode,
+# after receiving SIGUSR1, avoiding it to become a zombie.
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/start.sh"]


### PR DESCRIPTION
The embedded haproxy process is being created in the same pid group of the controller, which makes it receive the same signals received by the controller when running under a process supervisor. This makes haproxy be prematurely terminated when the controller is still shutting down.