### PR TITLE
Cleanup outdated properties of golangci-lint gh actions plugin

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,8 +22,6 @@ jobs:
       with:
         version: latest
         args: --verbose
-        skip-pkg-cache: true
-        skip-build-cache: true
     - name: Run unit tests
       run: make test
   integration:


### PR DESCRIPTION
From golangci-lint-action [release notes](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#compatibility):

> v5.0.0+ removes skip-pkg-cache and skip-build-cache because the cache related to Go itself is already handled by actions/setup-go.