### PR TITLE
configure test matrix for haproxy and kubernetes

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,19 +26,29 @@ jobs:
       run: make test
   integration:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        haproxy-version:
+        - "2.2" # minimum supported
+        - "2.6" # embedded version
+        - "3.1" # latest
+        envtest-version:
+        - "1.23.5" # oldest supported version
+        - "1.32.0" # latest Kubernetes version
+      fail-fast: false
     steps:
     - name: Install dependencies
       run: sudo apt-get install -y lua-json
-    - name: Install HAProxy
+    - name: Install HAProxy ${{ matrix.haproxy-version }}
       uses: timwolla/action-install-haproxy@main
       id: install-haproxy
       with:
-        branch: "2.2"
+        branch: ${{ matrix.haproxy-version }}
         use_openssl: yes
         use_lua: yes
     - uses: actions/checkout@v4
     - uses: actions/setup-go@v5
       with:
-        go-version: "1.22.4"
-    - name: Run integration tests
-      run: make test-integration
+        go-version: "1.23.6"
+    - name: Run integration tests on Kubernetes ${{ matrix.envtest-version }}
+      run: HAPROXY_INGRESS_ENVTEST=${{ matrix.envtest-version }} make test-integration

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ LOCAL_FS_PREFIX?=/tmp/haproxy-ingress
 KUBECONFIG?=$(HOME)/.kube/config
 CONTROLLER_CONFIGMAP?=
 CONTROLLER_ARGS?=
+HAPROXY_INGRESS_ENVTEST?=1.32.0
 
 LOCALBIN?=$(shell pwd)/bin
 LOCAL_GOTESTSUM=$(LOCALBIN)/gotestsum
@@ -57,19 +58,13 @@ lint: golangci-lint
 .PHONY: setup-envtest
 setup-envtest:
 	test -x $(LOCAL_SETUP_ENVTEST) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest
-	$(LOCAL_SETUP_ENVTEST) use 1.23.5 --bin-dir $(LOCALBIN)
-	$(LOCAL_SETUP_ENVTEST) use 1.32.0 --bin-dir $(LOCALBIN)
+	$(LOCAL_SETUP_ENVTEST) use $(HAPROXY_INGRESS_ENVTEST) --bin-dir $(LOCALBIN)
 
 .PHONY: test-integration
 test-integration: gotestsum setup-envtest
 	@echo
-	@echo "Running Kubernetes 1.23.5"
-	KUBEBUILDER_ASSETS="$(shell $(LOCAL_SETUP_ENVTEST) use 1.23.5 --bin-dir $(LOCALBIN) -i -p path)"\
-		$(LOCAL_GOTESTSUM) --format=testname -- -count=1 -tags=cgo ./tests/integration/...
-
-	@echo
-	@echo "Running Kubernetes 1.32.0"
-	KUBEBUILDER_ASSETS="$(shell $(LOCAL_SETUP_ENVTEST) use 1.32.0 --bin-dir $(LOCALBIN) -i -p path)"\
+	@echo "Running Kubernetes $(HAPROXY_INGRESS_ENVTEST)"
+	KUBEBUILDER_ASSETS="$(shell $(LOCAL_SETUP_ENVTEST) use $(HAPROXY_INGRESS_ENVTEST) --bin-dir $(LOCALBIN) -i -p path)"\
 		$(LOCAL_GOTESTSUM) --format=testname -- -count=1 -tags=cgo ./tests/integration/...
 
 .PHONY: linux-build


### PR DESCRIPTION
Configures an integration test matrix for:

* minimum, latest and currently embedded haproxy versions
* oldest and latest Kubernetes versions