### PR TITLE
keep restarting leader election

### DIFF
--- a/pkg/controller/services/svcstatus.go
+++ b/pkg/controller/services/svcstatus.go
@@ -24,9 +24,11 @@ import (
 	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	controllerutils "github.com/jcmoraisjr/haproxy-ingress/pkg/controller/utils"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
 )
 
+var _ controllerutils.DelayedService = &svcStatusUpdater{}
 var _ svcStatusUpdateFnc = (&svcStatusUpdater{}).update
 
 type svcStatusUpdateFnc func(client.Object)
@@ -50,7 +52,9 @@ type svcStatusUpdater struct {
 func (s *svcStatusUpdater) Start(ctx context.Context) error {
 	s.ctx = ctx
 	s.run = true
+	s.log.Info("starting working queue")
 	s.queue.RunWithContext(ctx)
+	s.log.Info("working queue stopped")
 	s.run = false
 	return nil
 }

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -33,6 +33,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -177,8 +178,7 @@ func (f *framework) StartController(ctx context.Context, t *testing.T) {
 	require.NoError(t, err)
 
 	publishService := corev1.Service{}
-	publishService.Namespace = "default"
-	publishService.Name = "publish"
+	publishService.Namespace, publishService.Name, _ = cache.SplitMetaNamespaceKey(PublishSvcName)
 	publishService.Spec.Type = corev1.ServiceTypeLoadBalancer
 	publishService.Spec.Ports = []corev1.ServicePort{{Port: 80}}
 	err = f.cli.Create(ctx, &publishService)


### PR DESCRIPTION
Leader election is designed to attempt leading just once. It will finish in the case it was elected the leader and for any reason couldn't update the lease resource. This update starts a for-loop, making the leader election to be restart in the case it is not leading anymore.