### PR TITLE
fix panic if gw does not have a valid class

### DIFF
--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -257,11 +257,15 @@ func (c *converter) newGatewaySource(namespace, name string, gwtyp client.Object
 		c.logger.Error("error reading gateway: %v", err)
 		return nil
 	}
-	if gw == nil {
+	vgw := reflect.ValueOf(gw)
+	if vgw.IsNil() {
+		// Checking via reflection, since `gw` will always be `!= nil`
+		// because all cache methods return a pointer to the underlying struct.
+		// https://go.dev/doc/faq#nil_error
 		return nil
 	}
 	return &gatewaySource{
-		spec:   reflect.ValueOf(gw).Elem().FieldByName("Spec").Addr().Interface().(*gatewayv1.GatewaySpec),
+		spec:   vgw.Elem().FieldByName("Spec").Addr().Interface().(*gatewayv1.GatewaySpec),
 		source: newSource(gw),
 	}
 }

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -155,7 +155,10 @@ func (c *CacheMock) GetGatewayB1(namespace, name string) (*gatewayv1beta1.Gatewa
 func (c *CacheMock) GetGateway(namespace, name string) (*gatewayv1.Gateway, error) {
 	for _, gw := range c.GatewayList {
 		if gw.Namespace == namespace && gw.Name == name {
-			return gw, nil
+			if gw.Spec.GatewayClassName == "haproxy" {
+				return gw, nil
+			}
+			return nil, nil
 		}
 	}
 	return nil, fmt.Errorf("gateway not found: %s/%s", namespace, name)


### PR DESCRIPTION
Existing gateway resources that does not have a valid gateway class - either by being non existent or not matching haproxy ingress, will neither return an error not return a valid instance, but instead nil,nil from the cache. We're checking for nil before trying to use the gw, but since we're assigning a nil pointer to a struct into an interface var, we cannot simply check for our `var == nil`:
https://go.dev/doc/faq#nil_error