### PR TITLE
fix memory leak on gateway reconciliation

### DIFF
--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -591,8 +591,8 @@ func (c *converter) handlePassthrough(path string, h *hatypes.Host, b *hatypes.B
 		return
 	}
 	for _, hpath := range h.FindPath("/") {
-		modeTCP := hpath.Backend.ModeTCP
-		if modeTCP != nil && !*modeTCP {
+		backend := c.haproxy.Backends().FindBackend(hpath.Backend.Namespace, hpath.Backend.Name, hpath.Backend.Port)
+		if backend != nil && !backend.ModeTCP {
 			// current path has a HTTP backend in the root path of a passthrough
 			// domain, and the current haproxy.Host implementation uses this as the
 			// target HTTPS backend. So we need to:

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -278,7 +278,6 @@ func (h *Host) addLink(backend *Backend, link *PathLink, redirTo string) *HostPa
 			Namespace: backend.Namespace,
 			Name:      backend.Name,
 			Port:      backend.Port,
-			ModeTCP:   &backend.ModeTCP,
 		}
 		bpath := backend.AddBackendPath(link)
 		bpath.Host = &hostResolver{

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -558,7 +558,6 @@ type HostBackend struct {
 	Namespace string
 	Name      string
 	Port      string
-	ModeTCP   *bool
 }
 
 // HostAliasConfig ...


### PR DESCRIPTION
Ingress and Gateway data are converted to haproxy frontend and backend data via their converter implementations. Some configurations need data from both sides, so frontend is linked to backend via a pathlink object. A pathlink has path specific data, as well as the ID of the backend it represents. A pointer from the pathlink to the ModeTCP field in the backend, along with a backend data substitution used by shard mode, were contributing to preserve old representations of a backend in memory, depending on the type of the changes made to gateway resources.

This update breaks the link between a new resource and an old backend representation, which fixes the memory leak.