### PR TITLE
retry reload haproxy if failed

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -53,8 +53,9 @@ The following command-line options are supported:
 | [`--publish-address`](#publish-address)                 | list of hostname/IP        |                         | v0.15 |
 | [`--publish-service`](#publish-service)                 | namespace/servicename      |                         |       |
 | [`--rate-limit-update`](#rate-limit-update)             | uploads per second (float) | `0.5`                   |       |
-| [`--reload-interval`](#reload-interval)                 | time                       | `0`                     | v0.13 |
 | [`--ready-check-path`](#stats)                          | path                       | `/readyz`               | v0.15 |
+| [`--reload-interval`](#reload-interval)                 | time                       | `0`                     | v0.13 |
+| [`--reload-retry`](#reload-retry)                       | time                       | `30s`                   | v0.15 |
 | [`--reload-strategy`](#reload-strategy)                 | [native\|reusesocket]      | `reusesocket`           |       |
 | [`--report-node-internal-ip-address`](#report-node-internal-ip-address) | [true\|false] | `false`              |       |
 | [`--sort-backends`](#sort-backends)                     | [true\|false]              | `false`                 |       |
@@ -492,6 +493,14 @@ this interval.
 Higher values help to limit the number of active instances and save some memory on large clusters
 with long connections. Note however that, if two consecutive updates require a reload, the second
 one will delay up to the configured duration to be reflected by HAProxy.
+
+---
+
+## reload-retry
+
+* `--reload-retry`
+
+How long HAProxy Ingress should wait before trying to reload HAProxy if an error happens. Defaults to `30s`.
 
 ---
 

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -506,6 +506,7 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		RateLimitUpdate:          opt.RateLimitUpdate,
 		ReadyzURL:                opt.ReadyzURL,
 		ReloadInterval:           opt.ReloadInterval,
+		ReloadRetry:              opt.ReloadRetry,
 		ReloadStrategy:           opt.ReloadStrategy,
 		ResyncPeriod:             &opt.ResyncPeriod,
 		RootContext:              rootcontext,
@@ -689,6 +690,7 @@ type Config struct {
 	RateLimitUpdate          float64
 	ReadyzURL                string
 	ReloadInterval           time.Duration
+	ReloadRetry              time.Duration
 	ReloadStrategy           string
 	ResyncPeriod             *time.Duration
 	RootContext              context.Context

--- a/pkg/controller/config/options.go
+++ b/pkg/controller/config/options.go
@@ -24,6 +24,7 @@ func NewOptions() *Options {
 		AnnPrefix:               "haproxy-ingress.github.io,ingress.kubernetes.io",
 		RateLimitUpdate:         0.5,
 		WaitBeforeUpdate:        200 * time.Millisecond,
+		ReloadRetry:             30 * time.Second,
 		ResyncPeriod:            10 * time.Hour,
 		WatchNamespace:          corev1.NamespaceAll,
 		StatsCollectProcPeriod:  500 * time.Millisecond,
@@ -71,6 +72,7 @@ type Options struct {
 	AnnPrefix                string
 	RateLimitUpdate          float64
 	ReloadInterval           time.Duration
+	ReloadRetry              time.Duration
 	WaitBeforeUpdate         time.Duration
 	ResyncPeriod             time.Duration
 	WatchNamespace           string
@@ -287,6 +289,10 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 		"the second reload will be enqueued until 30 seconds have passed from the first "+
 		"one, applying every new configuration changes made between this interval.",
 	)
+
+	fs.DurationVar(&o.ReloadRetry, "reload-retry", o.ReloadRetry, ""+
+		"How long HAProxy Ingress should wait before trying to reload HAProxy if an error "+
+		"happens.")
 
 	fs.DurationVar(&o.WaitBeforeUpdate, "wait-before-update", o.WaitBeforeUpdate, ""+
 		"Amount of time to wait before start a reconciliation and update haproxy, giving "+

--- a/pkg/controller/services/svcacme.go
+++ b/pkg/controller/services/svcacme.go
@@ -115,6 +115,13 @@ func (s *svcAcmeClient) Add(item interface{}) {
 }
 
 // implements utils.QueueFacade
+func (s *svcAcmeClient) AddAfter(item interface{}, duration time.Duration) {
+	if s.leader.isLeader() {
+		s.queue.AddAfter(item, duration)
+	}
+}
+
+// implements utils.QueueFacade
 func (s *svcAcmeClient) Remove(item interface{}) {
 	s.queue.Remove(item)
 }

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -5674,7 +5674,7 @@ INFO haproxy successfully reloaded (embedded daemon)`
 func (c *testConfig) Update() {
 	timer := utils.NewTimer(nil)
 	c.instance.AcmeUpdate()
-	c.instance.HAProxyUpdate(timer)
+	_ = c.instance.HAProxyUpdate(timer)
 }
 
 func (c *testConfig) checkConfig(expected string) {

--- a/pkg/main.go
+++ b/pkg/main.go
@@ -14,7 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//go:debug default=go1.18
 package main
+
+// TODO remove go1.18 compatibility after dropping legacy mode
 
 import (
 	"flag"

--- a/pkg/utils/queue.go
+++ b/pkg/utils/queue.go
@@ -40,6 +40,7 @@ type Queue interface {
 // QueueFacade ...
 type QueueFacade interface {
 	Add(item interface{})
+	AddAfter(item interface{}, duration time.Duration)
 	Remove(item interface{})
 	Start(context.Context) error
 }
@@ -104,6 +105,13 @@ func (q *queue) Add(item interface{}) {
 	defer q.mutex.Unlock()
 	delete(q.forget, item)
 	q.workqueue.Add(item)
+}
+
+func (q *queue) AddAfter(item interface{}, duration time.Duration) {
+	q.mutex.Lock()
+	defer q.mutex.Unlock()
+	delete(q.forget, item)
+	q.workqueue.AddAfter(item, duration)
 }
 
 func (q *queue) Notify() {

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -836,5 +836,5 @@ func RandomName(prefix string) string {
 var currentPortOffset atomic.Int32
 
 func RandomPort() int32 {
-	return 49152 + currentPortOffset.Add(1)
+	return 16384 + currentPortOffset.Add(1)
 }


### PR DESCRIPTION
HAProxy Ingress does not use to restart a failed operation because the majority of the failed operations come from misconfiguration, so the configuration fix itself will make the retry.

Former HAProxy Ingress had only embedded and non master-worker mode, so other failures despite misconfigurations would be resource constraint related, like disk space, or bugs in haproxy or controller. Since master-worker mode and external haproxy, other sort of failures might happen, like connection refused to the admin socket. Because of that, a retry operation becomes mandatory, avoiding healthy but outdated load balancer config.