### PR TITLE
improve metrics doc and configuration

### DIFF
--- a/docs/content/en/docs/examples/metrics.md
+++ b/docs/content/en/docs/examples/metrics.md
@@ -87,9 +87,10 @@ There are two important configurations in the snippet above:
 * Added a label `release: prometheus` in the ServiceMonitor. HAProxy Ingress metrics will share the same Prometheus instance installed by Prometheus Operator. This can be changed to another dedicated instance, and must be checked if using another customized Prometheus Operator deployment.
 * Added relabels to HAProxy and HAProxy Ingress metrics. The HAProxy Ingress dashboard uses `hostname` label as a way to distinguish two controller instances, and also `cluster` label to distinguish controllers running on distinct clusters. The source of the name can be adjusted but the label name should be the same.
 
-Now upgrade the chart - change `upgrade` to `install` if HAProxy Ingress isn't installed yet:
+Now install or upgrade the chart:
 ```
 helm upgrade haproxy-ingress haproxy-ingress/haproxy-ingress\
+  --install\
   --create-namespace --namespace ingress-controller\
   -f haproxy-ingress-values.yaml
 ```
@@ -121,7 +122,7 @@ Import [this](https://grafana.com/grafana/dashboards/12056) Grafana dashboard. I
 
 * Open Grafana page - the URL is the same provided in the `prometheus-operator-values.yaml` file and should resolve to the ingress deployment
 * Log in to Grafana, user is `admin` and the first password is `prom-operator`
-* Click the big plus `+` sign in the left side, Import, type `12056` as the Grafana.com ID, Load, select a Prometheus datasource, Import
+* Click `Dashboards`, `New`, `Import`, type `12056` as the Grafana.com ID, Load, select a Prometheus datasource, Import
 
 If everything worked as expected, the dashboard should look like this:
 

--- a/docs/content/en/docs/examples/metrics/haproxy-ingress-dashboard.json
+++ b/docs/content/en/docs/examples/metrics/haproxy-ingress-dashboard.json
@@ -1381,7 +1381,7 @@
                 "uid": "${DS_PROMETHEUS}"
               },
               "exemplar": true,
-              "expr": "rate(process_cpu_seconds_total{cluster=~\"$cluster\",hostname=~\"$hostname\"}[1m])",
+              "expr": "rate(process_cpu_seconds_total{cluster=~\"$cluster\",hostname=~\"$hostname\",job=\"haproxy-ingress\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 1,
@@ -3020,7 +3020,7 @@
         "type": "query"
       },
       {
-        "allValue": ".+",
+        "allValue": ".*",
         "current": {},
         "datasource": {
           "type": "prometheus",

--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -124,6 +124,10 @@ The following steps deploy an echoserver image and exposes it in the current nam
 
 ## What's next
 
+Expose HAProxy Ingress metrics:
+
+* See the [metrics example page]({{% relref "../examples/metrics" %}})
+
 See what differs to expose services using Gateway API:
 
 * [Gateway API introduction](https://gateway-api.sigs.k8s.io/) from Kubernetes' SIG-Network documentation

--- a/pkg/controller/services/svchealthz.go
+++ b/pkg/controller/services/svchealthz.go
@@ -121,9 +121,8 @@ func (s *svcHealthz) createBuildHandler(cfg *config.Config) http.HandlerFunc {
 
 func (s *svcHealthz) createMetricsHandler(metrics *metrics) (http.Handler, error) {
 	registry := prometheus.NewRegistry()
-	if err := registry.Register(collectors.NewGoCollector()); err != nil {
-		return nil, err
-	}
+	registry.MustRegister(collectors.NewGoCollector())
+	registry.MustRegister(collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}))
 	metrics.register(registry)
 	return promhttp.HandlerFor(registry, promhttp.HandlerOpts{}), nil
 }


### PR DESCRIPTION
improve metrics doc and configuration

* Update documentation
* Link metrics page in the getting started
* Add process collector metrics
* Improve dashboard compatibility and cpu display
* Changed the panel for displaying CPU usage to specifically select HAProxy Ingress job
* Flexibe hostname label filter for deployments without it