### PR TITLE
add endpoints even if duplicated

### DIFF
--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -489,7 +489,7 @@ func (c *converter) createBackend(routeSource *source, index string, backendRefs
 	convutils.RebalanceWeight(cl, 128)
 	for i := range backends {
 		for _, addr := range backends[i].epready {
-			ep := habackend.AcquireEndpoint(addr.IP, addr.Port, addr.TargetRef)
+			ep := habackend.AddEndpoint(addr.IP, addr.Port, addr.TargetRef)
 			ep.Weight = cl[i].Weight
 		}
 	}

--- a/pkg/haproxy/types/backend_test.go
+++ b/pkg/haproxy/types/backend_test.go
@@ -318,3 +318,51 @@ func TestPathIDs(t *testing.T) {
 		c.teardown()
 	}
 }
+
+func TestEndpointDeduplication(t *testing.T) {
+	c := setup(t)
+	b := createBackend(0, "default", "echoserver", "8080")
+	b.EpNaming = EpIPPort
+	testCases := []struct {
+		ip   string
+		port int
+		name string
+	}{
+		{
+			ip:   "10.0.0.1",
+			port: 8080,
+			name: "10.0.0.1:8080",
+		},
+		{
+			ip:   "10.0.0.2",
+			port: 8080,
+			name: "10.0.0.2:8080",
+		},
+		{
+			ip:   "10.0.0.1",
+			port: 8080,
+			name: "10.0.0.1:8080__2",
+		},
+		{
+			ip:   "10.0.0.1",
+			port: 8080,
+			name: "10.0.0.1:8080__3",
+		},
+		{
+			ip:   "10.0.0.2",
+			port: 8080,
+			name: "10.0.0.2:8080__2",
+		},
+		{
+			ip:   "10.0.0.3",
+			port: 8080,
+			name: "10.0.0.3:8080",
+		},
+	}
+	for i, test := range testCases {
+		ep := b.AddEndpoint(test.ip, test.port, "")
+		c.compareObjects("ep", i, ep.Name, test.name)
+	}
+	c.compareObjects("len(ep)", 0, len(b.Endpoints), 6)
+	c.teardown()
+}


### PR DESCRIPTION
Gateway API allows to assign distinct backend refs behind the same hostname and path match. These refs can reference the same service, or even distinct services to the same endpoint. Gateway converter were using the same approach from ingress, by acquiring an existing endpoint if it exists, which end up of old ref configurations being overwritten by newer ones, if there is an endpoint duplication. This update changes this behavior, now every new backend ref entry will have a new set of endpoint entries in the backend, despite of these endpoints exist or not.

Fixes #1182 