### PR TITLE
Disable async and pipelining for coraza-spoa to avoid frame drops

### DIFF
--- a/rootfs/etc/templates/modsecurity/modsecurity.tmpl
+++ b/rootfs/etc/templates/modsecurity/modsecurity.tmpl
@@ -12,6 +12,8 @@ spoe-agent modsecurity-agent
 {{- if .Global.ModSecurity.UseCoraza }}
     messages     coraza-req
     option       var-prefix  coraza
+    no option    async
+    no option    pipelining
 {{- else }}
     messages     check-request
     option       var-prefix  modsec


### PR DESCRIPTION
Hello! I was struggling with this issue https://github.com/corazawaf/coraza-spoa/issues/217 

Fortunately, I've managed to fix the problem by hotpatching `/etc/haproxy/spoe-modsecurity.conf` and reloading haproxy from inside the container. 

For the context, in the newer spoa versions (>=3.1), async is removed at all: https://github.com/haproxy/haproxy/blob/master/doc/SPOE.txt#L256 due to its known issues. But in 2.4 we will have to disable it manually as well as pipelining. 

This PR aims to codify the fix.