### PR TITLE
move to endpointslice by default

### DIFF
--- a/pkg/controller/config/options.go
+++ b/pkg/controller/config/options.go
@@ -37,6 +37,7 @@ func NewOptions() *Options {
 		ElectionID:              "class-%s.haproxy-ingress.github.io",
 		ShutdownTimeout:         25 * time.Second,
 		UpdateStatusOnShutdown:  true,
+		EnableEndpointSlicesAPI: true,
 		LogLevel:                2,
 	}
 }

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -200,7 +200,6 @@ func (f *framework) StartController(ctx context.Context, t *testing.T) {
 	opt := ctrlconfig.NewOptions()
 	opt.MasterWorker = true
 	opt.LocalFSPrefix = "/tmp/haproxy-ingress"
-	opt.EnableEndpointSlicesAPI = true
 	opt.PublishService = PublishSvcName
 	opt.ConfigMap = "default/ingress-controller"
 	os.Setenv("POD_NAMESPACE", "default")


### PR DESCRIPTION
Endpoints api is being deprecated on k8s 1.33, moving to EndpointSlice by default on v0.15, all the Endpoints references should be dropped from controller on v0.16.

Should be added to v0.15 branch.