### PR TITLE
deprecate v1.endpoints api

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,11 +15,6 @@ linters:
       - third_party$
       - builtin$
       - examples$
-    ## TODO: drop Endpoints api
-    rules:
-      - linters:
-          - staticcheck
-        text: "SA1019: [a-z0-9]+.Endpoints is deprecated"
 formatters:
   enable:
     - gofmt

--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -32,6 +32,7 @@ The following command-line options are supported:
 | [`--disable-external-name`](#disable-external-name)     | [true\|false]              | `false`                 | v0.10 |
 | [`--disable-pod-list`](#disable-pod-list)               | [true\|false]              | `false`                 | v0.11 |
 | [`--election-id`](#election-id)                         | identifier                 | `ingress-controller-leader` |   |
+| [`--enable-endpointslices-api`](#enable-endpointslices-api) | [true\|false]          | `true`                  | v0.14 |
 | [`--force-namespace-isolation`](#force-namespace-isolation) | [true\|false]          | `false`                 |       |
 | [`--health-check-path`](#stats)                         | path                       | `/healthz`              |       |
 | [`--healthz-addr`](#stats)                              | tcp address                | `:10254`                | v0.15 |
@@ -61,7 +62,6 @@ The following command-line options are supported:
 | [`--sort-backends`](#sort-backends)                     | [true\|false]              | `false`                 |       |
 | [`--shutdown-timeout`](#shutdown-timeout)               | time                       | `25s`                   | v0.15 |
 | [`--sort-endpoints-by`](#sort-endpoints-by)             | [endpoint\|ip\|name\|random] | `endpoint`            | v0.11 |
-| [`--enable-endpointslices-api`](#enable-endpointslices-api)             | [true\|false] | `false`              | v0.14 |
 | [`--stats-collect-processing-period`](#stats)           | time                       | `500ms`                 | v0.10 |
 | [`--stop-handler`](#stats)                              | [true\|false]              | `false`                 | v0.15 |
 | [`--sync-period`](#sync-period)                         | time                       | `10m`                   |       |
@@ -266,6 +266,18 @@ Election ID configuration has no efect if none of Ingress Status update, Embedde
 Since v0.15 a `%s` placeholder is used to define where the IngressClass value should be added to the election ID. Up to v0.14 the IngressClass was concatenated in the end of the provided value to compose the real election ID value. Ingress class is added to the election ID name to avoid conflict when two or more HAProxy Ingress controllers are running in the same cluster.
 
 Election ID defaults to `class-%s.haproxy-ingress.github.io` if not configured, which is rendered to `class-haproxy.haproxy-ingress.github.io` if the IngressClass is not changed from the default value.
+
+---
+
+## enable-endpointslices-api
+
+* `--enable-endpointslices-api`
+
+Since v0.14, deprecated since v0.16
+
+Uses EndpointSlices API info, rather than Endpoints API, to fetch service endpoints info.
+
+Endpoints API is deprecated since Kubernetes 1.33, and HAProxy Ingress only supports EndpointSlices API since v0.16. This option is ignored if configured.
 
 ---
 
@@ -575,16 +587,6 @@ Defines in which order the endpoints of a backend should be sorted.
 * `ip`: sort endpoints by the IP and port of the destination server
 * `name`: sort the endpoints by the name given to the server, see also [backend-server-naming]({{% relref "keys#backend-server-naming" %}})
 * `random`: randomly shuffle the endpoints every time haproxy needs to be reloaded, this option avoids to always send requests to the same endpoints depending on the balancing algorithm
-
----
-
-## enable-endpointslices-api
-
-* `--enable-endpointslices-api`
-
-Since v0.14
-
-Uses EndpointSlices API info, rather than Endpoints API, to fetch service endpoints info. By default it is disabled. EndpointSlices API was stablised from Kubernetes v1.21.
 
 ---
 

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -165,6 +165,9 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 	if opt.ForceIsolation {
 		configLog.Info("DEPRECATED: --force-namespace-isolation is ignored, use allow-cross-namespace command-line options or cross-namespace configuration keys instead.")
 	}
+	if !opt.EnableEndpointSlicesAPI {
+		configLog.Info("DEPRECATED: Endpoints API is deprecated since Kubernetes 1.33, --enable-endpointslices-api cannot be disabled and EndpointSlices API will always be used.")
+	}
 
 	if opt.IngressClass != "" {
 		configLog.Info("watching for ingress resources with 'kubernetes.io/ingress.class'", "annotation", opt.IngressClass)
@@ -484,7 +487,6 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		Election:                 election,
 		ElectionID:               electionID,
 		ElectionNamespace:        podNamespace,
-		EnableEndpointSliceAPI:   opt.EnableEndpointSlicesAPI,
 		ForceNamespaceIsolation:  opt.ForceIsolation,
 		HasGatewayA2:             hasGatewayA2,
 		HasGatewayB1:             hasGatewayB1,
@@ -668,7 +670,6 @@ type Config struct {
 	Election                 bool
 	ElectionID               string
 	ElectionNamespace        string
-	EnableEndpointSliceAPI   bool
 	ForceNamespaceIsolation  bool
 	HasGatewayA2             bool
 	HasGatewayB1             bool

--- a/pkg/controller/config/options.go
+++ b/pkg/controller/config/options.go
@@ -98,7 +98,6 @@ type Options struct {
 	SortEndpointsBy          string
 	TrackOldInstances        bool
 	UseNodeInternalIP        bool
-	EnableEndpointSlicesAPI  bool
 	LogZap                   bool
 	LogDev                   bool
 	LogCaller                bool
@@ -119,6 +118,8 @@ type Options struct {
 	ForceIsolation bool
 	// Deprecated option
 	IgnoreIngressWithoutClass bool
+	// Deprecated option
+	EnableEndpointSlicesAPI bool
 
 	//
 	Version bool
@@ -419,11 +420,6 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 		"the internal instead of the external IP address.",
 	)
 
-	fs.BoolVar(&o.EnableEndpointSlicesAPI, "enable-endpointslices-api", o.EnableEndpointSlicesAPI, ""+
-		"Enables EndpointSlices API and disables watching Endpoints API. Only enable in "+
-		"k8s >=1.21+",
-	)
-
 	fs.BoolVar(&o.LogZap, "log-zap", o.LogZap, ""+
 		"Enables zap as the log sink for all the logging outputs.",
 	)
@@ -490,6 +486,12 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 	fs.BoolVar(&o.IgnoreIngressWithoutClass, "ignore-ingress-without-class", o.IgnoreIngressWithoutClass, ""+
 		"DEPRECATED: Use --watch-ingress-without-class command-line option instead to "+
 		"define if ingress without class should be tracked.",
+	)
+
+	fs.BoolVar(&o.EnableEndpointSlicesAPI, "enable-endpointslices-api", o.EnableEndpointSlicesAPI, ""+
+		"DEPRECATED: Enables EndpointSlices API and disables watching Endpoints API. "+
+		"Endpoints is deprecated since 1.33, so endpointslices is always enabled and "+
+		"this option is ignored.",
 	)
 
 	//

--- a/pkg/controller/services/cache.go
+++ b/pkg/controller/services/cache.go
@@ -427,15 +427,6 @@ func (c *c) GetEndpointSlices(service *api.Service) ([]*discoveryv1.EndpointSlic
 	return eps, err
 }
 
-func (c *c) GetEndpoints(service *api.Service) (*api.Endpoints, error) {
-	ep := api.Endpoints{}
-	err := c.client.Get(c.ctx, types.NamespacedName{
-		Namespace: service.Namespace,
-		Name:      service.Name,
-	}, &ep)
-	return &ep, err
-}
-
 func (c *c) GetConfigMap(configMapName string) (*api.ConfigMap, error) {
 	cm := api.ConfigMap{}
 	err := c.get(configMapName, &cm)

--- a/pkg/controller/services/services.go
+++ b/pkg/controller/services/services.go
@@ -167,7 +167,6 @@ func (s *Services) setup(ctx context.Context) error {
 		HasGatewayB1:     cfg.HasGatewayB1,
 		HasGatewayV1:     cfg.HasGatewayV1,
 		HasTCPRouteA2:    cfg.HasTCPRouteA2,
-		EnableEPSlices:   cfg.EnableEndpointSliceAPI,
 	}
 	instance := haproxy.CreateInstance(s.legacylogger.new("haproxy"), instanceOptions)
 	if err := instance.ParseTemplates(); err != nil {

--- a/pkg/converters/configmap/tcpservices.go
+++ b/pkg/converters/configmap/tcpservices.go
@@ -36,20 +36,18 @@ type TCPServicesConverter interface {
 // NewTCPServicesConverter ...
 func NewTCPServicesConverter(options *convtypes.ConverterOptions, haproxy haproxy.Config, changed *convtypes.ChangedObjects) TCPServicesConverter {
 	return &tcpSvcConverter{
-		logger:                  options.Logger,
-		cache:                   options.Cache,
-		haproxy:                 haproxy,
-		changed:                 changed,
-		enableEndpointSlicesAPI: options.EnableEPSlices,
+		logger:  options.Logger,
+		cache:   options.Cache,
+		haproxy: haproxy,
+		changed: changed,
 	}
 }
 
 type tcpSvcConverter struct {
-	logger                  types.Logger
-	cache                   convtypes.Cache
-	haproxy                 haproxy.Config
-	changed                 *convtypes.ChangedObjects
-	enableEndpointSlicesAPI bool
+	logger  types.Logger
+	cache   convtypes.Cache
+	haproxy haproxy.Config
+	changed *convtypes.ChangedObjects
 }
 
 var regexValidTime = regexp.MustCompile(`^[0-9]+(us|ms|s|m|h|d)$`)
@@ -92,7 +90,7 @@ func (c *tcpSvcConverter) Sync() {
 			c.logger.Warn("skipping TCP service on public port %d: port not found: %s:%s", publicport, svc.name, svc.port)
 			continue
 		}
-		addrs, _, err := convutils.CreateEndpoints(c.cache, service, svcport, c.enableEndpointSlicesAPI)
+		addrs, _, err := convutils.CreateEndpoints(c.cache, service, svcport)
 		if err != nil {
 			c.logger.Warn("skipping TCP service on public port %d: %v", svc.port, err)
 			continue

--- a/pkg/converters/configmap/tcpservices_test.go
+++ b/pkg/converters/configmap/tcpservices_test.go
@@ -290,9 +290,9 @@ func TestTCPSvcSync(t *testing.T) {
 		c := setup(t)
 		for svckey, endpoints := range test.svcmock {
 			svcport := strings.Split(svckey, ":")
-			svc, ep, _ := conv_helper.CreateService(svcport[0], svcport[1], endpoints)
+			svc, eps := conv_helper.CreateService(svcport[0], svcport[1], endpoints)
 			c.cache.SvcList = append(c.cache.SvcList, svc)
-			c.cache.EpList[svcport[0]] = ep
+			c.cache.EpsList[svcport[0]] = eps
 		}
 		c.cache.SecretTLSPath = test.secretCertMock
 		c.cache.SecretCAPath = test.secretCAMock

--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -457,7 +457,7 @@ func (c *converter) createBackend(routeSource *source, index string, backendRefs
 			c.logger.Warn("skipping service '%s' on %s: port '%s' not found", back.Name, routeSource, portStr)
 			continue
 		}
-		epready, _, err := convutils.CreateEndpoints(c.cache, svc, svcport, c.options.EnableEPSlices)
+		epready, _, err := convutils.CreateEndpoints(c.cache, svc, svcport)
 		if err != nil {
 			c.logger.Warn("skipping service '%s' on %s: %v", back.Name, routeSource, err)
 			continue

--- a/pkg/converters/gateway/gateway_test.go
+++ b/pkg/converters/gateway/gateway_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/kylelemons/godebug/diff"
 	api "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
@@ -1059,11 +1060,11 @@ func (c *testConfig) createSecret1(secretName string) *api.Secret {
 	return s
 }
 
-func (c *testConfig) createService1(name, port, ip string) (*api.Service, *api.Endpoints) {
-	svc, ep, _ := conv_helper.CreateService(name, port, ip)
+func (c *testConfig) createService1(name, port, ip string) (*api.Service, []*discoveryv1.EndpointSlice) {
+	svc, eps := conv_helper.CreateService(name, port, ip)
 	c.cache.SvcList = append(c.cache.SvcList, svc)
-	c.cache.EpList[name] = ep
-	return svc, ep
+	c.cache.EpsList[name] = eps
+	return svc, eps
 }
 
 func (c *testConfig) createGateway0(name string) *gatewayv1.Gateway {

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -54,7 +54,6 @@ type CacheMock struct {
 	//
 	NsList        map[string]*api.Namespace
 	LookupList    map[string][]net.IP
-	EpList        map[string]*api.Endpoints
 	EpsList       map[string][]*discoveryv1.EndpointSlice
 	ConfigMapList map[string]*api.ConfigMap
 	TermPodList   map[string][]*api.Pod
@@ -75,7 +74,7 @@ func NewCacheMock(tracker convtypes.Tracker) *CacheMock {
 		GatewayList: []*gatewayv1.Gateway{},
 		NsList:      map[string]*api.Namespace{},
 		LookupList:  map[string][]net.IP{},
-		EpList:      map[string]*api.Endpoints{},
+		EpsList:     map[string][]*discoveryv1.EndpointSlice{},
 		TermPodList: map[string][]*api.Pod{},
 		SecretTLSPath: map[string]string{
 			"system/ingress-default": "/tls/tls-default.pem",
@@ -179,13 +178,13 @@ func (c *CacheMock) GetService(defaultNamespace, serviceName string) (*api.Servi
 	return nil, fmt.Errorf("service not found: '%s'", serviceName)
 }
 
-// GetEndpoints ...
-func (c *CacheMock) GetEndpoints(service *api.Service) (*api.Endpoints, error) {
+// GetEndpointSlices ...
+func (c *CacheMock) GetEndpointSlices(service *api.Service) ([]*discoveryv1.EndpointSlice, error) {
 	serviceName := service.Namespace + "/" + service.Name
-	if ep, found := c.EpList[serviceName]; found {
-		return ep, nil
+	if eps, found := c.EpsList[serviceName]; found {
+		return eps, nil
 	}
-	return nil, fmt.Errorf("could not find endpoints for service '%s'", serviceName)
+	return nil, fmt.Errorf("could not find endpointslices for service '%s'", serviceName)
 }
 
 // GetConfigMap ...
@@ -333,12 +332,4 @@ func (c *CacheMock) SwapChangedObjects() *convtypes.ChangedObjects {
 // NeedFullSync ...
 func (c *CacheMock) NeedFullSync() bool {
 	return false
-}
-
-func (c *CacheMock) GetEndpointSlices(service *api.Service) ([]*discoveryv1.EndpointSlice, error) {
-	serviceName := service.Namespace + "/" + service.Name
-	if ep, found := c.EpsList[serviceName]; found {
-		return ep, nil
-	}
-	return nil, fmt.Errorf("could not find endpointslices for service '%s'", serviceName)
 }

--- a/pkg/converters/helper_test/k8sobjects.go
+++ b/pkg/converters/helper_test/k8sobjects.go
@@ -27,7 +27,7 @@ import (
 )
 
 // CreateService ...
-func CreateService(name, port, endpoints string) (*api.Service, *api.Endpoints, []*discoveryv1.EndpointSlice) {
+func CreateService(name, port, endpoints string) (*api.Service, []*discoveryv1.EndpointSlice) {
 	sname := strings.Split(name, "/") // namespace/name of the service
 	sport := strings.Split(port, ":") // numeric-port -or- name:numeric-port -or- name:numeric-port:named-port
 	if len(sport) < 2 {
@@ -54,38 +54,12 @@ spec:
     port: ` + portNumber + `
     targetPort: ` + targetRef).(*api.Service)
 
-	ep := CreateObject(`
-apiVersion: v1
-kind: Endpoints
-metadata:
-  name: ` + metaName + `
-  namespace: ` + namespace + `
-subsets:
-- addresses: []
-  ports:
-  - name: ` + portName + `
-    port: ` + portNumber + `
-    protocol: TCP`).(*api.Endpoints)
-
-	addr := []api.EndpointAddress{}
-	for _, e := range strings.Split(endpoints, ",") {
-		if e != "" {
-			target := &api.ObjectReference{
-				Kind:      "Pod",
-				Name:      metaName + "-xxxxx",
-				Namespace: namespace,
-			}
-			addr = append(addr, api.EndpointAddress{IP: e, TargetRef: target})
-		}
-	}
-	ep.Subsets[0].Addresses = addr
-
 	eps := []*discoveryv1.EndpointSlice{}
 	if len(endpoints) > 0 {
 		eps = createEndpointSlices(metaName, namespace, portName, portNumber, endpoints)
 	}
 
-	return svc, ep, eps
+	return svc, eps
 }
 
 // CreateSecret ...

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -979,7 +979,7 @@ func (c *converter) addTLS(source *annotations.Source, secretName string) convty
 }
 
 func (c *converter) addEndpoints(svc *api.Service, svcPort *api.ServicePort, backend *hatypes.Backend) error {
-	ready, notReady, err := convutils.CreateEndpoints(c.cache, svc, svcPort, c.options.EnableEPSlices)
+	ready, notReady, err := convutils.CreateEndpoints(c.cache, svc, svcPort)
 	if err != nil {
 		return err
 	}

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -45,7 +45,6 @@ type Cache interface {
 	GetHTTPRouteList() ([]*gatewayv1.HTTPRoute, error)
 	GetTCPRouteList() ([]*gatewayv1alpha2.TCPRoute, error)
 	GetService(defaultNamespace, serviceName string) (*api.Service, error)
-	GetEndpoints(service *api.Service) (*api.Endpoints, error)
 	GetConfigMap(configMapName string) (*api.ConfigMap, error)
 	GetNamespace(name string) (*api.Namespace, error)
 	GetTerminatingPods(service *api.Service, track []TrackingRef) ([]*api.Pod, error)

--- a/pkg/converters/types/options.go
+++ b/pkg/converters/types/options.go
@@ -44,7 +44,6 @@ type ConverterOptions struct {
 	HasGatewayB1     bool
 	HasGatewayV1     bool
 	HasTCPRouteA2    bool
-	EnableEPSlices   bool
 }
 
 // DynamicConfig ...

--- a/pkg/converters/utils/services_test.go
+++ b/pkg/converters/utils/services_test.go
@@ -31,13 +31,13 @@ func TestCreateEndpointsExternalName(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()
 
-	svc, _, _ := helper_test.CreateService("default/echo", "8080", "")
+	svc, _ := helper_test.CreateService("default/echo", "8080", "")
 	svc.Spec.Type = api.ServiceTypeExternalName
 	svc.Spec.ExternalName = "domain.local"
 	cache := helper_test.NewCacheMock(nil)
 	cache.LookupList["domain.local"] = []net.IP{net.ParseIP("10.0.1.10"), net.ParseIP("10.0.1.11")}
 	svcPort := FindServicePort(svc, "8080")
-	ready, notReady, err := CreateEndpoints(cache, svc, svcPort, true)
+	ready, notReady, err := CreateEndpoints(cache, svc, svcPort)
 	expected := []*Endpoint{
 		{
 			IP:     "10.0.1.10",
@@ -99,33 +99,15 @@ func TestCreateEndpoints(t *testing.T) {
 	}
 	for _, test := range testCases {
 		c := setup(t)
-		svc, ep, eps := helper_test.CreateService("default/echo", test.declarePort, test.endpoints)
-		for _, ss := range ep.Subsets {
-			for i := range ss.Addresses {
-				ss.Addresses[i].TargetRef = nil
-			}
-			for i := range ss.NotReadyAddresses {
-				ss.NotReadyAddresses[i].TargetRef = nil
-			}
-		}
+		svc, eps := helper_test.CreateService("default/echo", test.declarePort, test.endpoints)
 		cache := &helper_test.CacheMock{
 			SvcList: []*api.Service{svc},
-			EpList:  map[string]*api.Endpoints{"default/echo": ep},
 			EpsList: map[string][]*discoveryv1.EndpointSlice{"default/echo": eps},
 		}
 		port := FindServicePort(svc, test.findPort)
 
-		// Test with Endpoints API
 		var endpoints []*Endpoint
-		if port != nil {
-			endpoints, _, _ = CreateEndpoints(cache, svc, port, false)
-		}
-		if !reflect.DeepEqual(endpoints, test.expected) {
-			t.Errorf("endpoints differ: expected=%+v actual=%+v", test.expected, endpoints)
-		}
-
-		// Test with EndpointSlice API
-		endpoints, _, _ = CreateEndpoints(cache, svc, port, true)
+		endpoints, _, _ = CreateEndpoints(cache, svc, port)
 		if !reflect.DeepEqual(endpoints, test.expected) {
 			t.Errorf("endpoints differ: expected=%+v actual=%+v", test.expected, endpoints)
 		}


### PR DESCRIPTION
remove all references to v1.Endpoints api, since it is deprecated on Kubernetes 1.33. `--enable-endpointslices-api` command-line option now is deprecated as well and noop.