### PR TITLE
load lua script per thread instead

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         haproxy-version:
-        - "2.2" # minimum supported
+        - "2.4" # minimum supported
         - "2.6" # embedded version
         - "3.2" # latest
         envtest-version:

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1309,9 +1309,9 @@ global
     maxconn 2000
     hard-stop-after 15m
     lua-prepend-path /etc/haproxy/lua/?.lua
-    lua-load /etc/haproxy/lua/auth-request.lua
-    lua-load /etc/haproxy/lua/services.lua
-    lua-load /etc/haproxy/lua/responses.lua
+    lua-load-per-thread /etc/haproxy/lua/auth-request.lua
+    lua-load-per-thread /etc/haproxy/lua/services.lua
+    lua-load-per-thread /etc/haproxy/lua/responses.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256
@@ -1368,9 +1368,9 @@ global
     maxconn 2000
     hard-stop-after 15m
     lua-prepend-path /etc/haproxy/lua/?.lua
-    lua-load /etc/haproxy/lua/auth-request.lua
-    lua-load /etc/haproxy/lua/services.lua
-    lua-load /etc/haproxy/lua/responses.lua
+    lua-load-per-thread /etc/haproxy/lua/auth-request.lua
+    lua-load-per-thread /etc/haproxy/lua/services.lua
+    lua-load-per-thread /etc/haproxy/lua/responses.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256
@@ -1434,8 +1434,8 @@ global
     maxconn 2000
     hard-stop-after 15m
     mworker-max-reloads 20
-    lua-load /etc/haproxy/lua/services.lua
-    lua-load /etc/haproxy/lua/responses.lua
+    lua-load-per-thread /etc/haproxy/lua/services.lua
+    lua-load-per-thread /etc/haproxy/lua/responses.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256
@@ -1565,9 +1565,9 @@ global
     maxconn 2000
     hard-stop-after 15m
     lua-prepend-path /etc/haproxy/lua/?.lua
-    lua-load /etc/haproxy/lua/auth-request.lua
-    lua-load /etc/haproxy/lua/services.lua
-    lua-load /etc/haproxy/lua/responses.lua
+    lua-load-per-thread /etc/haproxy/lua/auth-request.lua
+    lua-load-per-thread /etc/haproxy/lua/services.lua
+    lua-load-per-thread /etc/haproxy/lua/responses.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256
@@ -4608,9 +4608,9 @@ global
     log 127.0.0.1:1514 len 2048 format rfc3164 local0
     log-tag ingress
     lua-prepend-path /etc/haproxy/lua/?.lua
-    lua-load /etc/haproxy/lua/auth-request.lua
-    lua-load /etc/haproxy/lua/services.lua
-    lua-load /etc/haproxy/lua/responses.lua
+    lua-load-per-thread /etc/haproxy/lua/auth-request.lua
+    lua-load-per-thread /etc/haproxy/lua/services.lua
+    lua-load-per-thread /etc/haproxy/lua/responses.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256
@@ -5691,9 +5691,9 @@ func (c *testConfig) checkConfigFile(expected, fileName string) {
     maxconn 2000
     hard-stop-after 15m
     lua-prepend-path /etc/haproxy/lua/?.lua
-    lua-load /etc/haproxy/lua/auth-request.lua
-    lua-load /etc/haproxy/lua/services.lua
-    lua-load /etc/haproxy/lua/responses.lua
+    lua-load-per-thread /etc/haproxy/lua/auth-request.lua
+    lua-load-per-thread /etc/haproxy/lua/services.lua
+    lua-load-per-thread /etc/haproxy/lua/responses.lua
     ssl-dh-param-file /var/haproxy/tls/dhparam.pem
     ssl-default-bind-ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256
     ssl-default-bind-ciphersuites TLS_AES_128_GCM_SHA256

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -106,10 +106,10 @@ global
 {{- end }}
 {{- if or (not $global.External.IsExternal) $global.External.HasLua }}
     lua-prepend-path {{ $global.LocalFSPrefix }}/etc/haproxy/lua/?.lua
-    lua-load {{ $global.LocalFSPrefix }}/etc/haproxy/lua/auth-request.lua
+    lua-load-per-thread {{ $global.LocalFSPrefix }}/etc/haproxy/lua/auth-request.lua
 {{- end }}
-    lua-load {{ $global.LocalFSPrefix }}/etc/haproxy/lua/services.lua
-    lua-load {{ $global.LocalFSPrefix }}/etc/haproxy/lua/responses.lua
+    lua-load-per-thread {{ $global.LocalFSPrefix }}/etc/haproxy/lua/services.lua
+    lua-load-per-thread {{ $global.LocalFSPrefix }}/etc/haproxy/lua/responses.lua
 {{- if $global.SSL.DHParam.Filename }}
     ssl-dh-param-file {{ $global.SSL.DHParam.Filename }}
 {{- else }}

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -70,8 +70,8 @@ func NewFramework(ctx context.Context, t *testing.T, o ...options.Framework) *fr
 	require.NoError(t, err)
 
 	major, minor, full := haproxyVersion(t)
-	if major < 2 || (major == 2 && minor < 2) {
-		require.Fail(t, "unsupported haproxy version", "need haproxy 2.2 or newer, found %s", full)
+	if major < 2 || (major == 2 && minor < 4) {
+		require.Fail(t, "unsupported haproxy version", "need haproxy 2.4 or newer, found %s", full)
 	}
 	t.Logf("using haproxy %s\n", full)
 


### PR DESCRIPTION
Changes from `lua-load` to `lua-load-per-thread` in order to load Lua scripts per thread, improving performance. This can be done since none of the scripts use global variables.

Using `lua-load-per-thread` changes minimum haproxy version to 2.4.