### PR TITLE
makes controller pod namespace and name mandatory

### DIFF
--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -269,15 +270,20 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		}
 	}
 
-	podNamespace := os.Getenv("POD_NAMESPACE")
-	podName := os.Getenv("POD_NAME")
+	controllerPod := types.NamespacedName{
+		Namespace: os.Getenv("POD_NAMESPACE"),
+		Name:      os.Getenv("POD_NAME"),
+	}
+	if controllerPod.Namespace == "" {
+		return nil, fmt.Errorf("POD_NAMESPACE envvar is a mandatory configuration")
+	}
+	if controllerPod.Name == "" {
+		return nil, fmt.Errorf("POD_NAME envvar is a mandatory configuration")
+	}
 
 	// we could `|| hasGateway[version...]` instead of `|| opt.WatchGateway` here,
 	// but we're choosing a consistent startup behavior despite of the cluster configuration.
 	election := opt.UpdateStatus || opt.AcmeServer || opt.WatchGateway
-	if election && podNamespace == "" {
-		return nil, fmt.Errorf("POD_NAMESPACE envvar should be configured when --update-status=true, --acme-server=true, or --watch-gateway=true")
-	}
 	if election && opt.IngressClass == "" {
 		return nil, fmt.Errorf("--ingress-class should not be empty when --update-status=true, --acme-server=true, or --watch-gateway=true")
 	}
@@ -291,17 +297,13 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		}
 	}
 
-	if opt.UpdateStatus && podName == "" && opt.PublishService == "" && len(publishAddressHostnames)+len(publishAddressIPs) == 0 {
-		return nil, fmt.Errorf("one of --publish-service, --publish-address or POD_NAME envvar should be configured when --update-status=true")
-	}
-
 	acmeSecretKeyNamespaceName := opt.AcmeSecretKeyName
 	if !strings.Contains(acmeSecretKeyNamespaceName, "/") {
-		acmeSecretKeyNamespaceName = podNamespace + "/" + acmeSecretKeyNamespaceName
+		acmeSecretKeyNamespaceName = controllerPod.Namespace + "/" + acmeSecretKeyNamespaceName
 	}
 	acmeTokenConfigMapNamespaceName := opt.AcmeTokenConfigMapName
 	if !strings.Contains(acmeTokenConfigMapNamespaceName, "/") {
-		acmeTokenConfigMapNamespaceName = podNamespace + "/" + acmeTokenConfigMapNamespaceName
+		acmeTokenConfigMapNamespaceName = controllerPod.Namespace + "/" + acmeTokenConfigMapNamespaceName
 	}
 
 	masterWorkerCfg := opt.MasterWorker
@@ -478,6 +480,7 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		BucketsResponseTime:      opt.BucketsResponseTime,
 		ConfigMapName:            opt.ConfigMap,
 		ControllerName:           controllerName,
+		ControllerPod:            controllerPod,
 		DefaultDirCACerts:        defaultDirCACerts,
 		DefaultDirCerts:          defaultDirCerts,
 		DefaultDirCrl:            defaultDirCrl,
@@ -490,7 +493,7 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		DisableKeywords:          disableKeywords,
 		Election:                 election,
 		ElectionID:               electionID,
-		ElectionNamespace:        podNamespace,
+		ElectionNamespace:        controllerPod.Namespace,
 		ForceNamespaceIsolation:  opt.ForceIsolation,
 		HasGatewayA2:             hasGatewayA2,
 		HasGatewayB1:             hasGatewayB1,
@@ -505,8 +508,6 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		MasterSocket:             opt.MasterSocket,
 		MasterWorker:             masterWorkerCfg,
 		MaxOldConfigFiles:        opt.MaxOldConfigFiles,
-		PodName:                  podName,
-		PodNamespace:             podNamespace,
 		Profiling:                opt.Profiling,
 		PublishAddressHostnames:  publishAddressHostnames,
 		PublishAddressIPs:        publishAddressIPs,
@@ -662,6 +663,7 @@ type Config struct {
 	BucketsResponseTime      []float64
 	ConfigMapName            string
 	ControllerName           string
+	ControllerPod            types.NamespacedName
 	DefaultDirCerts          string
 	DefaultDirCACerts        string
 	DefaultDirCrl            string
@@ -689,8 +691,6 @@ type Config struct {
 	MasterSocket             string
 	MasterWorker             bool
 	MaxOldConfigFiles        int
-	PodName                  string
-	PodNamespace             string
 	Profiling                bool
 	PublishAddressHostnames  []string
 	PublishAddressIPs        []string

--- a/pkg/controller/services/svcleaderrecorder.go
+++ b/pkg/controller/services/svcleaderrecorder.go
@@ -43,7 +43,7 @@ func initRecorderProvider(cfg *config.Config) (*recorderProvider, error) {
 
 	return &recorderProvider{
 		cli:        cli,
-		namespace:  cfg.PodNamespace,
+		namespace:  cfg.ControllerPod.Namespace,
 		hostname:   hostname,
 		electionID: cfg.ElectionID,
 	}, nil

--- a/pkg/controller/services/svcstatusing.go
+++ b/pkg/controller/services/svcstatusing.go
@@ -242,12 +242,8 @@ func (s *svcStatusIng) getNodeIPs(ctx context.Context) []string {
 }
 
 func (s *svcStatusIng) getControllerPodList(ctx context.Context) ([]api.Pod, error) {
-	// read controller's pod - we need the pod's template labels to find all the other pods
-	if s.cfg.PodName == "" {
-		return nil, fmt.Errorf("POD_NAME envvar was not configured")
-	}
 	pod := api.Pod{}
-	if err := s.cli.Get(ctx, types.NamespacedName{Namespace: s.cfg.PodNamespace, Name: s.cfg.PodName}, &pod); err != nil {
+	if err := s.cli.Get(ctx, s.cfg.ControllerPod, &pod); err != nil {
 		return nil, err
 	}
 
@@ -261,7 +257,7 @@ func (s *svcStatusIng) getControllerPodList(ctx context.Context) ([]api.Pod, err
 	podList := api.PodList{}
 	if err := s.cli.List(ctx, &podList, &client.ListOptions{
 		LabelSelector: labels.SelectorFromSet(podLabels),
-		Namespace:     s.cfg.PodNamespace,
+		Namespace:     s.cfg.ControllerPod.Namespace,
 	}); err != nil {
 		return nil, err
 	}

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -203,6 +203,7 @@ func (f *framework) StartController(ctx context.Context, t *testing.T) {
 	opt.PublishService = PublishSvcName
 	opt.ConfigMap = "default/ingress-controller"
 	os.Setenv("POD_NAMESPACE", "default")
+	os.Setenv("POD_NAME", "haproxy-ingress")
 	ctx, cancel := context.WithCancel(ctx)
 	cfg, err := ctrlconfig.CreateWithConfig(ctx, f.config, opt)
 	require.NoError(t, err)


### PR DESCRIPTION
A number of configurations require controller pod name and/or namespace configured, starting to become harder to add and maintain all the validations. We're configuring it mandatory now, since it is easy to automate this configuration and default Helm chart already configures it by default.

Need to add to the breaking backward compatibility list of v0.16.