### PR TITLE
fix label selector from daemonset

### DIFF
--- a/pkg/controller/services/svcstatusing.go
+++ b/pkg/controller/services/svcstatusing.go
@@ -256,6 +256,8 @@ func (s *svcStatusIng) getControllerPodList(ctx context.Context) ([]api.Pod, err
 	delete(podLabels, "controller-revision-hash")
 	delete(podLabels, "pod-template-generation")
 	delete(podLabels, "pod-template-hash")
+	delete(podLabels, "apps.kubernetes.io/pod-index")
+	delete(podLabels, "statefulset.kubernetes.io/pod-name")
 
 	// read all controller's pod
 	podList := api.PodList{}


### PR DESCRIPTION
Label selector is used to filter pods and find all the replicas of an ingress cluster. DaemonSet could add other labels that uniquely identify a pod, making the returned list inaccurate.

Should be merged to v0.15.