### PR TITLE
turn envvars optional

### DIFF
--- a/pkg/controller/services/svcstatusing.go
+++ b/pkg/controller/services/svcstatusing.go
@@ -246,6 +246,10 @@ func (s *svcStatusIng) getNodeIPs(ctx context.Context) []string {
 }
 
 func (s *svcStatusIng) getControllerPodList(ctx context.Context) ([]api.Pod, error) {
+	// read controller's pod - we need the pod's template labels to find all the other pods
+	if s.cfg.ControllerPod.Name == "" {
+		return nil, fmt.Errorf("POD_NAME envvar was not configured")
+	}
 	pod := api.Pod{}
 	if err := s.cli.Get(ctx, s.cfg.ControllerPod, &pod); err != nil {
 		return nil, err

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -203,7 +203,6 @@ func (f *framework) StartController(ctx context.Context, t *testing.T) {
 	opt.PublishService = PublishSvcName
 	opt.ConfigMap = "default/ingress-controller"
 	os.Setenv("POD_NAMESPACE", "default")
-	os.Setenv("POD_NAME", "haproxy-ingress")
 	ctx, cancel := context.WithCancel(ctx)
 	cfg, err := ctrlconfig.CreateWithConfig(ctx, f.config, opt)
 	require.NoError(t, err)


### PR DESCRIPTION
HAProxy Ingress deployed outside a Kubernetes cluster does not have a pod name to provide. A missing pod name should be validated instead, and when missing, it should fail starting the controller only if using features that require its name. So we are changing pod name to optional again.