### PR TITLE
configure more than one http/s ports

### DIFF
--- a/pkg/converters/gateway/gateway_test.go
+++ b/pkg/converters/gateway/gateway_test.go
@@ -1253,7 +1253,7 @@ func (c *testConfig) compareText(id string, actual, expected string) {
 }
 
 func (c *testConfig) compareConfigDefaultHost(id string, expected string) {
-	host := c.hconfig.Hosts().DefaultHost()
+	host := c.hconfig.Frontends().Default().DefaultHost()
 	if host != nil {
 		c.compareText(id, conv_helper.MarshalHost(host), expected)
 	} else {
@@ -1262,7 +1262,7 @@ func (c *testConfig) compareConfigDefaultHost(id string, expected string) {
 }
 
 func (c *testConfig) compareConfigHosts(id string, expected string) {
-	c.compareText(id, conv_helper.MarshalHosts(c.hconfig.Hosts().BuildSortedItems()...), expected)
+	c.compareText(id, conv_helper.MarshalHosts(c.hconfig.Frontends().Default().BuildSortedHosts()...), expected)
 }
 
 func (c *testConfig) compareConfigTCPServices(id string, expected string) {

--- a/pkg/converters/helper_test/marshal.go
+++ b/pkg/converters/helper_test/marshal.go
@@ -154,7 +154,7 @@ func marshalHosts(hafronts ...*hatypes.Host) []hostMock {
 			Paths:        paths,
 			RootRedirect: f.RootRedirect,
 			TLS:          tlsMock{TLSFilename: f.TLS.TLSFilename},
-			Passthrough:  f.SSLPassthrough(),
+			Passthrough:  f.SSLPassthrough,
 			HTTPPassBack: f.HTTPPassthroughBackend,
 		})
 	}

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -195,12 +195,13 @@ func (c *updater) setAuthExternal(config ConfigValueGetter, auth *hatypes.AuthEx
 		return
 	}
 	// TODO track
-	authBackendName, err := c.haproxy.Frontend().AcquireAuthBackendName(backend.BackendID())
+	df := c.haproxy.Frontends().Default()
+	authBackendName, err := df.AcquireAuthBackendName(backend.BackendID())
 	if err != nil {
 		// clean up and try again
 		used := c.haproxy.Backends().BuildUsedAuthBackends()
-		c.haproxy.Frontend().RemoveAuthBackendExcept(used)
-		authBackendName, err = c.haproxy.Frontend().AcquireAuthBackendName(backend.BackendID())
+		df.RemoveAuthBackendExcept(used)
+		authBackendName, err = df.AcquireAuthBackendName(backend.BackendID())
 		if err != nil {
 			// TODO remove backend if not used elsewhere
 			c.logger.Warn("ignoring auth URL on %s: %v", url.Source.String(), err)
@@ -791,7 +792,7 @@ func (c *updater) buildBackendOAuth(d *backData) {
 }
 
 func (c *updater) findBackend(namespace, uriPrefix string) *hatypes.HostBackend {
-	for _, host := range c.haproxy.Hosts().Items() {
+	for _, host := range c.haproxy.Frontends().Default().Hosts() {
 		for _, path := range host.Paths {
 			if strings.TrimRight(path.Path(), "/") == uriPrefix && path.Backend.Namespace == namespace {
 				return &path.Backend

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -525,8 +525,9 @@ func TestAuthExternal(t *testing.T) {
 	for i, test := range testCase {
 		c := setup(t)
 		u := c.createUpdater()
-		c.haproxy.Frontend().AuthProxy.RangeStart = 4001
-		c.haproxy.Frontend().AuthProxy.RangeEnd = 4009
+		df := c.haproxy.Frontends().Default()
+		df.AuthProxy.RangeStart = 4001
+		df.AuthProxy.RangeEnd = 4009
 		if test.isExternal {
 			c.haproxy.Global().External.IsExternal = true
 		}
@@ -567,7 +568,7 @@ func TestAuthExternal(t *testing.T) {
 		u.buildBackendAuthExternal(d)
 		back := d.backend.Paths[0].AuthExternal
 		var iplist []string
-		bindList := c.haproxy.Frontend().AuthProxy.BindList
+		bindList := df.AuthProxy.BindList
 		if len(bindList) > 0 {
 			auth := c.haproxy.Backends().FindBackendID(bindList[0].Backend)
 			for _, ep := range auth.Endpoints {
@@ -2055,7 +2056,7 @@ WARN oauth2_proxy on ingress 'default/ing1' needs Lua json module, install lua-j
 		if test.backend != "" {
 			b := strings.Split(test.backend, ":")
 			backend := c.haproxy.Backends().AcquireBackend(b[0], b[1], "8080")
-			c.haproxy.Hosts().AcquireHost("app.local").AddPath(backend, b[2], hatypes.MatchBegin)
+			c.haproxy.Frontends().Default().AcquireHost("app.local").AddPath(backend, b[2], hatypes.MatchBegin)
 		}
 		c.createUpdater().buildBackendOAuth(d)
 		actual := map[string]hatypes.AuthExternal{}
@@ -2114,8 +2115,8 @@ func TestRewriteURL(t *testing.T) {
 			ann = map[string]string{ingtypes.BackRewriteTarget: test.input}
 		}
 		d := c.createBackendData("default/app", &test.source, map[string]string{}, map[string]string{})
-		d.backend.AddBackendPath(hatypes.CreateHostPathLink("d1.local", "/", hatypes.MatchBegin))
-		d.mapper.AddAnnotations(&test.source, hatypes.CreateHostPathLink("d1.local", "/", hatypes.MatchBegin), ann)
+		d.backend.AddBackendPath(hatypes.CreatePathLink("/", hatypes.MatchBegin))
+		d.mapper.AddAnnotations(&test.source, hatypes.CreatePathLink("/", hatypes.MatchBegin), ann)
 		c.createUpdater().buildBackendRewriteURL(d)
 		actual := d.backend.Paths[0].RewriteURL
 		c.compareObjects("rewrite", i, actual, test.expected)

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -60,7 +60,7 @@ var authProxyRegex = regexp.MustCompile(`^([A-Za-z_-]+):([0-9]{1,5})-([0-9]{1,5}
 func (c *updater) buildGlobalAuthProxy(d *globalData) {
 	proxystr := d.mapper.Get(ingtypes.GlobalAuthProxy).Value
 	proxy := authProxyRegex.FindStringSubmatch(proxystr)
-	authproxy := &c.haproxy.Frontend().AuthProxy
+	authproxy := &c.haproxy.Frontends().Default().AuthProxy
 	if len(proxy) < 4 {
 		c.logger.Warn("invalid auth proxy configuration: %s", proxystr)
 		// start>end ensures that trying to create a frontend bind will fail

--- a/pkg/converters/ingress/annotations/global_test.go
+++ b/pkg/converters/ingress/annotations/global_test.go
@@ -79,7 +79,7 @@ func TestAuthProxy(t *testing.T) {
 			ingtypes.GlobalAuthProxy: test.input,
 		})
 		c.createUpdater().buildGlobalAuthProxy(d)
-		c.compareObjects("bind", i, c.haproxy.Frontend().AuthProxy, test.expected)
+		c.compareObjects("bind", i, c.haproxy.Frontends().Default().AuthProxy, test.expected)
 		c.logger.CompareLogging(test.logging)
 		c.teardown()
 	}
@@ -147,7 +147,7 @@ func TestBind(t *testing.T) {
 			ingtypes.GlobalHTTPSPort:      "443",
 			ingtypes.GlobalBindIPAddrHTTP: "*",
 		})
-		d.mapper.AddAnnotations(nil, hatypes.CreateHostPathLink("-", "-", hatypes.MatchBegin), test.ann)
+		d.mapper.AddAnnotations(nil, hatypes.CreatePathLink("-", hatypes.MatchBegin), test.ann)
 		c.createUpdater().buildGlobalBind(d)
 		c.compareObjects("bind", i, d.global.Bind, test.expected)
 		c.teardown()

--- a/pkg/converters/ingress/annotations/host.go
+++ b/pkg/converters/ingress/annotations/host.go
@@ -111,15 +111,16 @@ func (c *updater) buildHostCertSigner(d *hostData) {
 
 func (c *updater) buildHostRedirect(d *hostData) {
 	// TODO need a host<->host tracking if a target is found
+	df := c.haproxy.Frontends().Default()
 	redir := d.mapper.Get(ingtypes.HostRedirectFrom)
-	if target := c.haproxy.Hosts().FindTargetRedirect(redir.Value, false); target != nil {
+	if target := df.FindTargetRedirect(redir.Value, false); target != nil {
 		c.logger.Warn("ignoring redirect from '%s' on %v, it's already targeting to '%s'",
 			redir.Value, redir.Source, target.Hostname)
 	} else if len(d.host.Paths) > 0 {
 		d.host.Redirect.RedirectHost = redir.Value
 	}
 	redirRegex := d.mapper.Get(ingtypes.HostRedirectFromRegex)
-	if target := c.haproxy.Hosts().FindTargetRedirect(redirRegex.Value, true); target != nil {
+	if target := df.FindTargetRedirect(redirRegex.Value, true); target != nil {
 		c.logger.Warn("ignoring regex redirect from '%s' on %v, it's already targeting to '%s'",
 			redirRegex.Value, redirRegex.Source, target.Hostname)
 	} else if len(d.host.Paths) > 0 {
@@ -147,7 +148,7 @@ func (c *updater) buildHostSSLPassthrough(d *hostData) {
 	}
 	backend := c.haproxy.Backends().AcquireBackend(hostBackend.Namespace, hostBackend.Name, hostBackend.Port)
 	backend.ModeTCP = true
-	d.host.SetSSLPassthrough(true)
+	d.host.SSLPassthrough = true
 }
 
 func (c *updater) buildHostTLSConfig(d *hostData) {

--- a/pkg/converters/ingress/annotations/host_test.go
+++ b/pkg/converters/ingress/annotations/host_test.go
@@ -115,8 +115,9 @@ func TestBuildHostRedirect(t *testing.T) {
 		b := c.haproxy.Backends().AcquireBackend("default", "d", "8080")
 		dprev := c.createHostData(sprev, test.annPrev, test.annDefault)
 		d := c.createHostData(source, test.ann, test.annDefault)
-		dprev.host = c.haproxy.Hosts().AcquireHost("dprev.local")
-		d.host = c.haproxy.Hosts().AcquireHost("d.local")
+		df := c.haproxy.Frontends().Default()
+		dprev.host = df.AcquireHost("dprev.local")
+		d.host = df.AcquireHost("d.local")
 		if !test.nopath {
 			dprev.host.AddPath(b, "/", hatypes.MatchPrefix)
 			d.host.AddPath(b, "/", hatypes.MatchPrefix)

--- a/pkg/converters/ingress/annotations/mapper_test.go
+++ b/pkg/converters/ingress/annotations/mapper_test.go
@@ -55,10 +55,10 @@ var (
 )
 
 func TestAddAnnotation(t *testing.T) {
-	pathRoot := hatypes.CreateHostPathLink("domain.local", "/", hatypes.MatchBegin)
-	pathApp := hatypes.CreateHostPathLink("domain.local", "/app", hatypes.MatchBegin)
-	pathPath := hatypes.CreateHostPathLink("domain.local", "/path", hatypes.MatchBegin)
-	pathURL := hatypes.CreateHostPathLink("domain.local", "/url", hatypes.MatchBegin)
+	pathRoot := hatypes.CreatePathLink("/", hatypes.MatchBegin)
+	pathApp := hatypes.CreatePathLink("/app", hatypes.MatchBegin)
+	pathPath := hatypes.CreatePathLink("/path", hatypes.MatchBegin)
+	pathURL := hatypes.CreatePathLink("/url", hatypes.MatchBegin)
 	testCases := []struct {
 		ann     []ann
 		getKey  string
@@ -150,8 +150,8 @@ func TestAddAnnotation(t *testing.T) {
 }
 
 func TestGetAnnotation(t *testing.T) {
-	pathRoot := hatypes.CreateHostPathLink("domain.local", "/", hatypes.MatchBegin)
-	pathURL := hatypes.CreateHostPathLink("domain.local", "/url", hatypes.MatchBegin)
+	pathRoot := hatypes.CreatePathLink("/", hatypes.MatchBegin)
+	pathURL := hatypes.CreatePathLink("/url", hatypes.MatchBegin)
 	testCases := []struct {
 		ann       []ann
 		getKey    string
@@ -282,7 +282,7 @@ func TestGetDefault(t *testing.T) {
 			},
 		},
 	}
-	pathRoot := hatypes.CreateHostPathLink("domain.local", "/", hatypes.MatchBegin)
+	pathRoot := hatypes.CreatePathLink("/", hatypes.MatchBegin)
 	for i, test := range testCases {
 		c := setup(t)
 		mapper := NewMapBuilder(c.logger, test.annDefaults).NewMapper()

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -173,8 +173,9 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
 	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()
 	//
-	c.haproxy.Frontend().RedirectFromCode = mapper.Get(ingtypes.GlobalRedirectFromCode).Int()
-	c.haproxy.Frontend().RedirectToCode = mapper.Get(ingtypes.GlobalRedirectToCode).Int()
+	df := c.haproxy.Frontends().Default()
+	df.RedirectFromCode = mapper.Get(ingtypes.GlobalRedirectFromCode).Int()
+	df.RedirectToCode = mapper.Get(ingtypes.GlobalRedirectToCode).Int()
 	//
 	c.buildGlobalAcme(d)
 	c.buildGlobalAuthProxy(d)

--- a/pkg/converters/ingress/annotations/updater_test.go
+++ b/pkg/converters/ingress/annotations/updater_test.go
@@ -152,7 +152,7 @@ func (c *testConfig) createUpdater() *updater {
 
 func (c *testConfig) createBackendData(svcFullName string, source *Source, ann, annDefault map[string]string) *backData {
 	mapper := NewMapBuilder(c.logger, annDefault).NewMapper()
-	mapper.AddAnnotations(source, hatypes.CreateHostPathLink("domain.local", "/", hatypes.MatchBegin), ann)
+	mapper.AddAnnotations(source, hatypes.CreatePathLink("/", hatypes.MatchBegin), ann)
 	svcName := strings.Split(svcFullName, "/")
 	namespace := svcName[0]
 	name := svcName[1]
@@ -165,8 +165,6 @@ func (c *testConfig) createBackendData(svcFullName string, source *Source, ann, 
 		mapper: mapper,
 	}
 }
-
-const testingHostname = "host.local"
 
 type hostResolver struct{}
 
@@ -190,21 +188,21 @@ func (c *testConfig) createBackendMappingData(
 		paths[path] = struct{}{}
 	}
 	for path := range paths {
-		b := d.backend.AddBackendPath(hatypes.CreateHostPathLink(testingHostname, path, hatypes.MatchBegin))
+		b := d.backend.AddBackendPath(hatypes.CreatePathLink(path, hatypes.MatchBegin))
 		// ignoring ID which isn't the focus of the test
 		// removing on createBackendPaths() as well
 		b.ID = ""
 		b.Host = &hostResolver{}
 	}
 	for uri, ann := range urlAnnValue {
-		d.mapper.AddAnnotations(source, hatypes.CreateHostPathLink(testingHostname, uri, hatypes.MatchBegin), ann)
+		d.mapper.AddAnnotations(source, hatypes.CreatePathLink(uri, hatypes.MatchBegin), ann)
 	}
 	return d
 }
 
 func (c *testConfig) createHostData(source *Source, ann, annDefault map[string]string) *hostData {
 	mapper := NewMapBuilder(c.logger, annDefault).NewMapper()
-	mapper.AddAnnotations(source, hatypes.CreateHostPathLink("domain.local", "/", hatypes.MatchBegin), ann)
+	mapper.AddAnnotations(source, hatypes.CreatePathLink("/", hatypes.MatchBegin), ann)
 	return &hostData{
 		host:   &hatypes.Host{},
 		mapper: mapper,

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -144,9 +144,9 @@ func (c *converter) Sync(full bool) {
 }
 
 func (c *converter) defaultCrtNeedFullSync() bool {
-	frontend := c.haproxy.Frontend()
-	return frontend.DefaultCrtFile != c.defaultCrt.Filename ||
-		frontend.DefaultCrtHash != c.defaultCrt.SHA1Hash
+	df := c.haproxy.Frontends().Default()
+	return df.DefaultCrtFile != c.defaultCrt.Filename ||
+		df.DefaultCrtHash != c.defaultCrt.SHA1Hash
 }
 
 func (c *converter) globalConfigNeedFullSync() bool {
@@ -181,15 +181,17 @@ func (c *converter) readDefaultCertificate() {
 }
 
 func (c *converter) syncDefaultCrt() {
-	frontend := c.haproxy.Frontend()
-	frontend.DefaultCrtFile = c.defaultCrt.Filename
-	frontend.DefaultCrtHash = c.defaultCrt.SHA1Hash
+	df := c.haproxy.Frontends().Default()
+	df.DefaultCrtFile = c.defaultCrt.Filename
+	df.DefaultCrtHash = c.defaultCrt.SHA1Hash
 }
+
+// bareLink creates a pathlink with default path and match type params, used to create generic, TCP, or hostname based pathlinks.
+func bareLink() *hatypes.PathLink { return hatypes.CreatePathLink("/", hatypes.MatchExact) }
 
 func (c *converter) syncDefaultBackend() {
 	if c.options.DefaultBackend != "" {
-		pathLink := hatypes.CreateHostPathLink(hatypes.DefaultHost, "/", hatypes.MatchBegin)
-		if backend, err := c.addBackend(&c.defaultBackSource, pathLink, c.options.DefaultBackend, "", map[string]string{}); err == nil {
+		if backend, err := c.addBackend(&c.defaultBackSource, bareLink(), c.options.DefaultBackend, "", map[string]string{}); err == nil {
 			c.haproxy.Backends().DefaultBackend = backend
 			c.tracker.TrackNames(c.defaultBackSource.Type, c.defaultBackSource.FullName(), convtypes.ResourceHAHostname, hatypes.DefaultHost)
 		} else {
@@ -226,8 +228,8 @@ func (c *converter) syncPartial() {
 	dirtyStorages := trackedLinks[convtypes.ResourceAcmeData]
 
 	c.haproxy.TCPServices().RemoveAll(dirtyTCPServices)
-	c.haproxy.Hosts().RemoveAll(dirtyHosts)
-	c.haproxy.Frontend().RemoveAuthBackendByTarget(dirtyBacks)
+	c.haproxy.Frontends().RemoveAllHosts(dirtyHosts)
+	c.haproxy.Frontends().RemoveAuthBackendByTarget(dirtyBacks)
 	c.haproxy.Backends().RemoveAll(dirtyBacks)
 	c.haproxy.Userlists().RemoveAll(dirtyUsers)
 	c.haproxy.AcmeData().Storages().RemoveAll(dirtyStorages)
@@ -407,7 +409,7 @@ func (c *converter) syncIngressHTTP(source *annotations.Source, ing *networking.
 				uri = "/"
 			}
 			match := c.readPathType(path, annBack[ingtypes.BackPathType])
-			pathLink := hatypes.CreateHostPathLink(hostname, uri, match)
+			pathLink := hatypes.CreatePathLink(uri, match).WithHTTPHost(host)
 			if headerMatch := annBack[ingtypes.BackHTTPHeaderMatch]; headerMatch != "" {
 				c.addHeaderMatch(source, pathLink, headerMatch, false)
 			}
@@ -518,7 +520,7 @@ func (c *converter) syncIngressHTTP(source *annotations.Source, ing *networking.
 func (c *converter) syncIngressTCP(source *annotations.Source, ing *networking.Ingress, tcpServicePort int, annTCP, annBack map[string]string) {
 	addIngressBackend := func(rawHostname string, ingressBackend *networking.IngressBackend) error {
 		hostname := normalizeHostname(rawHostname, tcpServicePort)
-		tcpService, err := c.addTCPService(source, hostname, annTCP)
+		tcpService, tcpLink, err := c.addTCPService(source, hostname, annTCP)
 		if err != nil {
 			return err
 		}
@@ -535,9 +537,8 @@ func (c *converter) syncIngressTCP(source *annotations.Source, ing *networking.I
 			return fmt.Errorf("service '%s' on %v: backend for port '%d' was already assigned", svcName, source, tcpServicePort)
 		}
 		fullSvcName := ing.Namespace + "/" + svcName
-		pathLink := hatypes.CreateHostPathLink(hostname, "/", hatypes.MatchExact)
 		ingressClass := c.readIngressClass(source, ing.Spec.IngressClassName)
-		backend, err := c.addBackendWithClass(source, pathLink, fullSvcName, svcPort, annBack, ingressClass)
+		backend, err := c.addBackendWithClass(source, tcpLink, fullSvcName, svcPort, annBack, ingressClass)
 		if err != nil {
 			return err
 		}
@@ -633,7 +634,7 @@ func (c *converter) fullSyncTCP() {
 
 func (c *converter) fullSyncAnnotations() {
 	c.fullSyncTCP()
-	for _, host := range c.haproxy.Hosts().Items() {
+	for _, host := range c.haproxy.Frontends().Default().Hosts() {
 		if ann, found := c.hostAnnotations[host]; found {
 			c.updater.UpdateHostConfig(host, ann)
 		}
@@ -647,7 +648,7 @@ func (c *converter) fullSyncAnnotations() {
 
 func (c *converter) partialSyncAnnotations() {
 	c.fullSyncTCP()
-	for _, host := range c.haproxy.Hosts().ItemsAdd() {
+	for _, host := range c.haproxy.Frontends().Default().HostsAdd() {
 		if ann, found := c.hostAnnotations[host]; found {
 			c.updater.UpdateHostConfig(host, ann)
 		}
@@ -708,27 +709,39 @@ func (c *converter) addDefaultHostBackend(source *annotations.Source, fullSvcNam
 	hostname := hatypes.DefaultHost
 	uri := "/"
 	match := hatypes.MatchBegin
-	if fr := c.haproxy.Hosts().FindHost(hostname); fr != nil {
-		if fr.FindPath(uri, match) != nil {
+	df := c.haproxy.Frontends().Default()
+
+	// existing stores if the host already existed before calling this func
+	var existing bool
+	if host := df.FindHost(hostname); host != nil {
+		if host.FindPath(uri, match) != nil {
 			return fmt.Errorf("path %s was already defined on default host", uri)
 		}
+		existing = true
 	}
-	pathLink := hatypes.CreateHostPathLink(hostname, uri, match)
+
+	host := df.AcquireHost(hostname)
+	pathLink := hatypes.CreatePathLink(uri, match).WithHTTPHost(host)
 	backend, err := c.addBackend(source, pathLink, fullSvcName, svcPort, annBack)
 	if err != nil {
 		c.tracker.TrackNames(source.Type, source.FullName(), convtypes.ResourceService, fullSvcName)
+		if !existing {
+			// we needed to create it in order to configure a pathLink,
+			// so reverting the creation since we are not going to use it.
+			df.RemoveAllHosts([]string{hostname})
+		}
 		return err
 	}
-	host := c.addHost(hostname, source, annHost)
+	host = c.addHost(hostname, source, annHost)
 	host.AddPath(backend, uri, match)
 	return nil
 }
 
-func (c *converter) addTCPService(source *annotations.Source, hostname string, ann map[string]string) (*hatypes.TCPServiceHost, error) {
+func (c *converter) addTCPService(source *annotations.Source, hostname string, ann map[string]string) (*hatypes.TCPServiceHost, *hatypes.PathLink, error) {
 	tcpPort, tcpHost := c.haproxy.TCPServices().AcquireTCPService(hostname)
 	if !tcpHost.Backend.IsEmpty() {
 		tcpservice := strings.TrimPrefix(hostname, hatypes.DefaultHost)
-		return nil, fmt.Errorf("tcp service %s was already assigned to %s", tcpservice, tcpHost.Backend)
+		return nil, nil, fmt.Errorf("tcp service %s was already assigned to %s", tcpservice, tcpHost.Backend)
 	}
 	c.tracker.TrackNames(source.Type, source.FullName(), convtypes.ResourceHATCPService, hostname)
 	mapper, found := c.tcpsvcAnnotations[tcpPort]
@@ -736,23 +749,24 @@ func (c *converter) addTCPService(source *annotations.Source, hostname string, a
 		mapper = c.mapBuilder.NewMapper()
 		c.tcpsvcAnnotations[tcpPort] = mapper
 	}
-	conflict := mapper.AddAnnotations(source, hatypes.CreateHostPathLink(hostname, "/", hatypes.MatchExact), ann)
+	tcpLink := bareLink().WithTCPHost(tcpHost)
+	conflict := mapper.AddAnnotations(source, tcpLink, ann)
 	if len(conflict) > 0 {
 		c.logger.Warn("skipping tcp service annotation(s) from %v due to conflict: %v", source, conflict)
 	}
-	return tcpHost, nil
+	return tcpHost, tcpLink, nil
 }
 
 func (c *converter) addHost(hostname string, source *annotations.Source, ann map[string]string) *hatypes.Host {
 	// TODO build a stronger tracking
-	host := c.haproxy.Hosts().AcquireHost(hostname)
+	host := c.haproxy.Frontends().Default().AcquireHost(hostname)
 	c.tracker.TrackNames(source.Type, source.FullName(), convtypes.ResourceHAHostname, hostname)
 	mapper, found := c.hostAnnotations[host]
 	if !found {
 		mapper = c.mapBuilder.NewMapper()
 		c.hostAnnotations[host] = mapper
 	}
-	conflict := mapper.AddAnnotations(source, hatypes.CreateHostPathLink(hostname, "/", hatypes.MatchExact), ann)
+	conflict := mapper.AddAnnotations(source, bareLink().WithHTTPHost(host), ann)
 	if len(conflict) > 0 {
 		c.logger.Warn("skipping host annotation(s) from %v due to conflict: %v", source, conflict)
 	}

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -29,7 +29,7 @@ import (
 
 // Config ...
 type Config interface {
-	Frontend() *hatypes.Frontend
+	Frontends() *hatypes.Frontends
 	SyncConfig()
 	WriteTCPServicesMaps() error
 	WriteFrontendMaps() error
@@ -38,7 +38,6 @@ type Config interface {
 	Global() *hatypes.Global
 	TCPBackends() *hatypes.TCPBackends
 	TCPServices() *hatypes.TCPServices
-	Hosts() *hatypes.Hosts
 	Backends() *hatypes.Backends
 	Userlists() *hatypes.Userlists
 	Clear()
@@ -53,8 +52,7 @@ type config struct {
 	// haproxy internal state
 	globalOld   *hatypes.Global
 	global      *hatypes.Global
-	frontend    *hatypes.Frontend
-	hosts       *hatypes.Hosts
+	frontends   *hatypes.Frontends
 	backends    *hatypes.Backends
 	tcpbackends *hatypes.TCPBackends
 	tcpservices *hatypes.TCPServices
@@ -75,8 +73,7 @@ func createConfig(options options) *config {
 		options:     options,
 		acmeData:    &hatypes.AcmeData{},
 		global:      &hatypes.Global{},
-		frontend:    &hatypes.Frontend{},
-		hosts:       hatypes.CreateHosts(),
+		frontends:   hatypes.CreateFrontends(),
 		backends:    hatypes.CreateBackends(options.shardCount),
 		tcpbackends: hatypes.CreateTCPBackends(),
 		tcpservices: hatypes.CreateTCPServices(),
@@ -84,8 +81,8 @@ func createConfig(options options) *config {
 	}
 }
 
-func (c *config) Frontend() *hatypes.Frontend {
-	return c.frontend
+func (c *config) Frontends() *hatypes.Frontends {
+	return c.frontends
 }
 
 // SyncConfig does final synchronization, just before write
@@ -93,23 +90,24 @@ func (c *config) Frontend() *hatypes.Frontend {
 // during ingress, services and endpoint parsing, but most of
 // them need to start after all objects are parsed.
 func (c *config) SyncConfig() {
-	if c.hosts.HasSSLPassthrough() {
+	df := c.frontends.Default()
+	if df.HasSSLPassthrough() {
 		// using ssl-passthrough config, so need a `mode tcp`
 		// frontend with `inspect-delay` and `req.ssl_sni`
 		bindName := "_https_socket"
-		c.frontend.Name = "_front_https__local"
-		c.frontend.BindName = bindName
-		c.frontend.BindSocket = fmt.Sprintf("unix@%s/var/run/haproxy/%s.sock", c.global.LocalFSPrefix, bindName)
-		c.frontend.AcceptProxy = true
+		df.Name = "_front_https__local"
+		df.BindName = bindName
+		df.BindSocket = fmt.Sprintf("unix@%s/var/run/haproxy/%s.sock", c.global.LocalFSPrefix, bindName)
+		df.AcceptProxy = true
 	} else {
 		// One single HAProxy's frontend and bind
-		c.frontend.Name = "_front_https"
-		c.frontend.BindName = "_public"
-		c.frontend.BindSocket = c.global.Bind.HTTPSBind
-		c.frontend.AcceptProxy = c.global.Bind.AcceptProxy
+		df.Name = "_front_https"
+		df.BindName = "_public"
+		df.BindSocket = c.global.Bind.HTTPSBind
+		df.AcceptProxy = c.global.Bind.AcceptProxy
 	}
-	for _, host := range c.hosts.ItemsAdd() {
-		if host.SSLPassthrough() {
+	for _, host := range df.HostsAdd() {
+		if host.SSLPassthrough {
 			// no action if ssl-passthrough
 			continue
 		}
@@ -123,7 +121,7 @@ func (c *config) SyncConfig() {
 		}
 		if c.global.StrictHost && host.FindPath("/", hatypes.MatchBegin) == nil {
 			var back *hatypes.Backend
-			defaultHost := c.hosts.DefaultHost()
+			defaultHost := df.DefaultHost()
 			if defaultHost != nil {
 				if path := defaultHost.FindPath("/"); len(path) > 0 {
 					hback := path[0].Backend
@@ -166,7 +164,8 @@ func (c *config) WriteTCPServicesMaps() error {
 // config file. This func doesn't change model state, except the
 // link to the frontend maps.
 func (c *config) WriteFrontendMaps() error {
-	if c.frontend.Maps != nil && !c.hosts.Changed() {
+	df := c.frontends.Default()
+	if df.Maps != nil && !df.HostsChanged() {
 		// TODO Maps!=nil just to preserve the current behavior. Check if this can be removed.
 		// hosts are clean, maps are updated
 		return nil
@@ -192,23 +191,23 @@ func (c *config) WriteFrontendMaps() error {
 		DefaultHostMap: mapBuilder.AddMap(mapsDir + "/_front_defaulthost.map"),
 	}
 	// TODO crtList* to be removed after implement a template to the crt list
-	c.frontend.CrtListFile = mapsDir + "/_front_bind_crt.list"
+	df.CrtListFile = mapsDir + "/_front_bind_crt.list"
 	var crtListItems []*hatypes.HostsMapEntry
-	crtListItems = append(crtListItems, &hatypes.HostsMapEntry{Key: c.frontend.DefaultCrtFile + " !*"})
-	hasVarNamespace := c.hosts.HasVarNamespace()
-	defaultHost := c.hosts.DefaultHost()
-	if defaultHost != nil && !defaultHost.SSLPassthrough() {
+	crtListItems = append(crtListItems, &hatypes.HostsMapEntry{Key: df.DefaultCrtFile + " !*"})
+	hasVarNamespace := df.HasVarNamespace()
+	defaultHost := df.DefaultHost()
+	if defaultHost != nil && !defaultHost.SSLPassthrough {
 		for _, path := range defaultHost.Paths {
 			// using DefaultHost ID as hostname, see types.maps.go/buildMapKey()
 			fmaps.DefaultHostMap.AddHostnamePathMapping(hatypes.DefaultHost, path, path.Backend.ID)
 		}
 	}
-	for _, host := range c.hosts.BuildSortedItems() {
+	for _, host := range df.BuildSortedHosts() {
 		for _, path := range host.Paths {
 			backendID := path.Backend.ID
 			// IMPLEMENT check if host.Alias.AliasName was already used as a hostname
 			if backendID != "" {
-				if host.SSLPassthrough() {
+				if host.SSLPassthrough {
 					// no ssl offload, cannot inspect incoming path, so tracking root only
 					if path.Path() == "/" {
 						fmaps.SSLPassthroughMap.AddHostnameMapping(host.Hostname, backendID)
@@ -242,7 +241,7 @@ func (c *config) WriteFrontendMaps() error {
 				fmaps.VarNamespaceMap.AddHostnamePathMapping(host.Hostname, path, ns)
 			}
 		}
-		if host.SSLPassthrough() {
+		if host.SSLPassthrough {
 			continue
 		}
 		if host.Redirect.RedirectHost != "" {
@@ -277,7 +276,7 @@ func (c *config) WriteFrontendMaps() error {
 					if backend := c.backends.Items()[path.Backend.ID]; backend != nil {
 						if bpath := backend.FindBackendPath(path.Link); bpath != nil {
 							redir = bpath.SSLRedirect
-							if !path.Link.ComposeMatch() {
+							if !path.Link.IsComposeMatch() {
 								// give precedence for root path without method, header or cookie matching
 								return redir
 							}
@@ -295,9 +294,9 @@ func (c *config) WriteFrontendMaps() error {
 		tls := host.TLS
 		crtFile := tls.TLSFilename
 		if crtFile == "" {
-			crtFile = c.frontend.DefaultCrtFile
+			crtFile = df.DefaultCrtFile
 		}
-		if crtFile != c.frontend.DefaultCrtFile ||
+		if crtFile != df.DefaultCrtFile ||
 			tls.ALPN != "" ||
 			tls.CAFilename != "" ||
 			tls.Ciphers != "" ||
@@ -337,13 +336,13 @@ func (c *config) WriteFrontendMaps() error {
 			crtListItems = append(crtListItems, &hatypes.HostsMapEntry{Key: crtListEntry})
 		}
 	}
-	if err := c.options.mapsTemplate.WriteOutput(crtListItems, c.frontend.CrtListFile); err != nil {
+	if err := c.options.mapsTemplate.WriteOutput(crtListItems, df.CrtListFile); err != nil {
 		return err
 	}
 	if err := writeMaps(mapBuilder, c.options.mapsTemplate); err != nil {
 		return err
 	}
-	c.frontend.Maps = fmaps
+	df.Maps = fmaps
 	return nil
 }
 
@@ -358,6 +357,7 @@ func (c *config) WriteBackendMaps() error {
 		return nil
 	}
 	mapBuilder := hatypes.CreateMaps(c.global.MatchOrder)
+	df := c.frontends.Default()
 	for _, backend := range c.backends.ItemsAdd() {
 		if backend.NeedACL() {
 			mapsPrefix := c.options.mapsDir + "/_back_" + backend.ID
@@ -365,7 +365,7 @@ func (c *config) WriteBackendMaps() error {
 			pathsDefaultHostMap := mapBuilder.AddMap(mapsPrefix + "_idpathdef.map")
 			for _, path := range backend.Paths {
 				// IMPLEMENT add HostPath link into the backend path
-				h := c.hosts.FindHost(path.Hostname())
+				h := df.FindHost(path.Hostname())
 				if h == nil {
 					continue
 				}
@@ -374,7 +374,7 @@ func (c *config) WriteBackendMaps() error {
 					continue
 				}
 				if path.IsDefaultHost() {
-					// using DefaultHost ID as hostname, see types.maps.go/buildMapKey()
+					// using DefaultHost ID as hostname, see types/maps.go/buildMapKey()
 					pathsDefaultHostMap.AddHostnamePathMapping(hatypes.DefaultHost, p, path.ID)
 				} else {
 					pathsMap.AddHostnamePathMapping(path.Hostname(), p, path.ID)
@@ -415,10 +415,6 @@ func (c *config) TCPServices() *hatypes.TCPServices {
 	return c.tcpservices
 }
 
-func (c *config) Hosts() *hatypes.Hosts {
-	return c.hosts
-}
-
 func (c *config) Backends() *hatypes.Backends {
 	return c.backends
 }
@@ -439,7 +435,7 @@ func (c *config) Clear() {
 }
 
 func (c *config) Shrink() {
-	c.hosts.Shrink()
+	c.frontends.Default().ShrinkHosts()
 	c.backends.Shrink()
 }
 
@@ -452,8 +448,7 @@ func (c *config) Commit() {
 		}
 		c.globalOld = &globalOld
 	}
-	c.frontend.Commit()
-	c.hosts.Commit()
+	c.frontends.Commit()
 	c.backends.Commit()
 	c.tcpbackends.Commit()
 	c.tcpservices.Commit()

--- a/pkg/haproxy/config_test.go
+++ b/pkg/haproxy/config_test.go
@@ -25,14 +25,15 @@ func TestEmptyFrontend(t *testing.T) {
 	if err := c.WriteFrontendMaps(); err != nil {
 		t.Errorf("error creating frontends: %v", err)
 	}
-	if maps := c.frontend.Maps; maps == nil {
+	df := c.frontends.Default()
+	if maps := df.Maps; maps == nil {
 		t.Error("expected frontend.Maps != nil")
 	}
-	c.hosts.AcquireHost("empty")
+	df.AcquireHost("empty")
 	if err := c.WriteFrontendMaps(); err != nil {
 		t.Errorf("error creating frontends: %v", err)
 	}
-	maps := c.frontend.Maps
+	maps := df.Maps
 	if maps == nil {
 		t.Error("expected frontend.Maps != nil")
 	}
@@ -40,8 +41,9 @@ func TestEmptyFrontend(t *testing.T) {
 
 func TestAcquireHostDiff(t *testing.T) {
 	c := createConfig(options{})
-	f1 := c.hosts.AcquireHost("h1")
-	f2 := c.hosts.AcquireHost("h2")
+	df := c.frontends.Default()
+	f1 := df.AcquireHost("h1")
+	f2 := df.AcquireHost("h2")
 	if f1.Hostname != "h1" {
 		t.Errorf("expected %v but was %v", "h1", f1.Hostname)
 	}
@@ -52,8 +54,9 @@ func TestAcquireHostDiff(t *testing.T) {
 
 func TestAcquireHostSame(t *testing.T) {
 	c := createConfig(options{})
-	f1 := c.hosts.AcquireHost("h1")
-	f2 := c.hosts.AcquireHost("h1")
+	df := c.frontends.Default()
+	f1 := df.AcquireHost("h1")
+	f2 := df.AcquireHost("h1")
 	if f1 != f2 {
 		t.Errorf("expected same host but was different")
 	}
@@ -63,22 +66,24 @@ func TestClear(t *testing.T) {
 	c := createConfig(options{
 		mapsDir: "/tmp/maps",
 	})
-	c.Hosts().AcquireHost("app.local")
+	df := c.frontends.Default()
+	df.AcquireHost("app.local")
 	c.Backends().AcquireBackend("default", "app", "8080")
 	if c.options.mapsDir != "/tmp/maps" {
 		t.Error("expected mapsDir == /tmp/maps")
 	}
-	if len(c.Hosts().Items()) != 1 {
+	if len(df.Hosts()) != 1 {
 		t.Error("expected len(hosts) == 1")
 	}
 	if len(c.Backends().Items()) != 1 {
 		t.Error("expected len(backends) == 1")
 	}
 	c.Clear()
+	df = c.frontends.Default() // `c` itself is updated after `Clear()`, updating df reference.
 	if c.options.mapsDir != "/tmp/maps" {
 		t.Error("expected mapsDir == /tmp/maps")
 	}
-	if len(c.Hosts().Items()) != 0 {
+	if len(df.Hosts()) != 0 {
 		t.Error("expected len(hosts) == 0")
 	}
 	if len(c.Backends().Items()) != 0 {

--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -88,7 +88,7 @@ func (d *dynUpdater) checkConfigChange() bool {
 	if d.config.tcpservices.Changed() {
 		diff = append(diff, "tcp-services")
 	}
-	if d.config.frontend.Changed() {
+	if d.config.frontends.FrontendsChanged() {
 		diff = append(diff, "frontend")
 	}
 	if d.config.userlists.Changed() {
@@ -110,11 +110,12 @@ func (d *dynUpdater) checkConfigChange() bool {
 func (d *dynUpdater) frontendUpdated() bool {
 	updated := true
 
-	hosts := make(map[string]*hostPair, len(d.config.hosts.ItemsDel()))
-	for _, host := range d.config.hosts.ItemsDel() {
+	df := d.config.frontends.Default()
+	hosts := make(map[string]*hostPair, len(df.HostsDel()))
+	for _, host := range df.HostsDel() {
 		hosts[host.Hostname] = &hostPair{old: host}
 	}
-	for _, host := range d.config.hosts.ItemsAdd() {
+	for _, host := range df.HostsAdd() {
 		id := host.Hostname
 		h, found := hosts[id]
 		if !found {

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -862,19 +862,19 @@ WARN unrecognized response disabling endpoint default_app_8080/srv003: No such s
 INFO-V(2) need to reload due to config changes: [backends]
 `,
 		},
-		// 28
+		// 30
 		{
 			doconfig1: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
-				h2 := c.config.Hosts().AcquireHost("domain2.local")
+				h1 := c.df.AcquireHost("domain1.local")
+				h2 := c.df.AcquireHost("domain2.local")
 				h1.TLS.TLSFilename = "/tmp/domain1.pem"
 				h2.TLS.TLSFilename = "/tmp/domain2.pem"
 				h1.TLS.TLSHash = "1"
 				h2.TLS.TLSHash = "2"
 			},
 			doconfig2: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
-				h2 := c.config.Hosts().AcquireHost("domain2.local")
+				h1 := c.df.AcquireHost("domain1.local")
+				h2 := c.df.AcquireHost("domain2.local")
 				h1.TLS.TLSFilename = "/tmp/domain1.pem"
 				h2.TLS.TLSFilename = "/tmp/domain2.pem"
 				h1.TLS.TLSHash = "1"
@@ -897,15 +897,15 @@ INFO-V(2) response from server: Committing /tmp/domain2.pem. \\ Success!
 INFO certificate updated for domain2.local
 `,
 		},
-		// 29
+		// 31
 		{
 			doconfig1: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
+				h1 := c.df.AcquireHost("domain1.local")
 				h1.TLS.TLSFilename = "/tmp/domain1.pem"
 				h1.TLS.TLSHash = "1"
 			},
 			doconfig2: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
+				h1 := c.df.AcquireHost("domain1.local")
 				h1.TLS.TLSFilename = "/tmp/domain2.pem"
 				h1.TLS.TLSHash = "2"
 			},
@@ -915,19 +915,19 @@ INFO-V(2) diff outside server certificate of host 'domain1.local'
 INFO-V(2) need to reload due to config changes: [hosts]
 `,
 		},
-		// 30
+		// 32
 		{
 			doconfig1: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
-				h2 := c.config.Hosts().AcquireHost("domain2.local")
+				h1 := c.df.AcquireHost("domain1.local")
+				h2 := c.df.AcquireHost("domain2.local")
 				h1.TLS.TLSFilename = "/tmp/domain1.pem"
 				h2.TLS.TLSFilename = ""
 				h1.TLS.TLSHash = "1"
 				h2.TLS.TLSHash = "2"
 			},
 			doconfig2: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
-				h2 := c.config.Hosts().AcquireHost("domain2.local")
+				h1 := c.df.AcquireHost("domain1.local")
+				h2 := c.df.AcquireHost("domain2.local")
 				h1.TLS.TLSFilename = "/tmp/domain1.pem"
 				h2.TLS.TLSFilename = ""
 				h1.TLS.TLSHash = "3"
@@ -950,15 +950,15 @@ INFO-V(2) response from server: Committing /tmp/domain1.pem. \\ Success!
 INFO certificate updated for domain1.local
 `,
 		},
-		// 31
+		// 33
 		{
 			doconfig1: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
+				h1 := c.df.AcquireHost("domain1.local")
 				h1.TLS.TLSFilename = "/tmp/domain1.pem"
 				h1.TLS.TLSHash = "1"
 			},
 			doconfig2: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
+				h1 := c.df.AcquireHost("domain1.local")
 				h1.TLS.TLSFilename = "/tmp/domain1.pem"
 				h1.TLS.TLSHash = "2"
 			},
@@ -980,16 +980,16 @@ WARN cannot update certificate for domain1.local
 INFO-V(2) need to reload due to config changes: [hosts]
 `,
 		},
-		// 32
+		// 34
 		{
 			doconfig1: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
+				h1 := c.df.AcquireHost("domain1.local")
 				h1.TLS.TLSFilename = "/tmp/domain1.pem"
 				h1.TLS.TLSHash = "1"
-				c.config.Hosts().AcquireHost("domain2.local")
+				c.df.AcquireHost("domain2.local")
 			},
 			doconfig2: func(c *testConfig) {
-				h1 := c.config.Hosts().AcquireHost("domain1.local")
+				h1 := c.df.AcquireHost("domain1.local")
 				h1.TLS.TLSFilename = "/tmp/domain1.pem"
 				h1.TLS.TLSHash = "1"
 			},
@@ -1010,10 +1010,10 @@ INFO-V(2) need to reload due to config changes: [hosts]
 		}
 		c.instance.config.Commit()
 		hostnames := []string{}
-		for hostname := range c.config.hosts.Items() {
+		for hostname := range c.df.Hosts() {
 			hostnames = append(hostnames, hostname)
 		}
-		c.config.Hosts().RemoveAll(hostnames)
+		c.df.RemoveAllHosts(hostnames)
 		backendIDs := []string{}
 		for _, backend := range c.config.Backends().Items() {
 			backendIDs = append(backendIDs, backend.ID)

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -441,9 +441,10 @@ func (i *instance) Shutdown() {
 }
 
 func (i *instance) logChanged() {
-	hostsAdd := i.config.Hosts().ItemsAdd()
+	df := i.config.Frontends().Default()
+	hostsAdd := df.HostsAdd()
 	if len(hostsAdd) < 100 {
-		hostsDel := i.config.Hosts().ItemsDel()
+		hostsDel := df.HostsDel()
 		hosts := make([]string, 0, len(hostsAdd))
 		for host := range hostsAdd {
 			hosts = append(hosts, host)
@@ -615,7 +616,7 @@ func (i *instance) buildCustomHTTPResponses() (responsesList []httpResponseOverr
 	for _, beResponse := range i.config.Backends().BuildHTTPResponses() {
 		addAll(&beResponse)
 	}
-	for _, hostResponse := range i.config.Hosts().BuildHTTPResponses() {
+	for _, hostResponse := range i.config.Frontends().Default().BuildHTTPResponses() {
 		addAll(&hostResponse)
 	}
 	addAll(&i.config.Global().CustomHTTPResponses)
@@ -640,9 +641,10 @@ func (i *instance) updateSuccessful(success bool) {
 }
 
 func (i *instance) updateCertExpiring() {
-	hostsAdd := i.config.Hosts().ItemsAdd()
-	hostsDel := i.config.Hosts().ItemsDel()
-	if !i.config.Hosts().HasCommit() {
+	df := i.config.Frontends().Default()
+	hostsAdd := df.HostsAdd()
+	hostsDel := df.HostsDel()
+	if !df.HasCommit() {
 		// TODO the time between this reset and finishing to repopulate the gauge would lead
 		// to incomplete data scraped by Prometheus. This however happens only when a full parsing
 		// happens - edit globals, edit default crt, invalid data coming from lister events

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1028,17 +1028,18 @@ d1.local#/ path01`,
 		},
 		{
 			doconfig: func(c *config, h *hatypes.Host, b *hatypes.Backend) {
+				df := c.frontends.Default()
 				link1 := hatypes.CreatePathLink("/app1", hatypes.MatchPrefix).
 					WithHeadersMatch(hatypes.HTTPHeaderMatch{{Name: "x-user", Value: "myusr1"}})
 				link2 := hatypes.CreatePathLink("/app2", hatypes.MatchPrefix).
 					WithHeadersMatch(hatypes.HTTPHeaderMatch{{Name: "x-user", Value: "myusr2"}})
 
-				hdef := c.hosts.AcquireHost(hatypes.DefaultHost)
-				b.FindBackendPath(hdef.AddLink(b, link1)).MaxBodySize = 1048576
-				b.FindBackendPath(hdef.AddLink(b, link2)).MaxBodySize = 2097152
+				hdef := df.AcquireHost(hatypes.DefaultHost)
+				b.FindBackendPath(hdef.AddLink(b, link1).Link).MaxBodySize = 1048576
+				b.FindBackendPath(hdef.AddLink(b, link2).Link).MaxBodySize = 2097152
 
-				b.FindBackendPath(h.AddLink(b, link1)).MaxBodySize = 1048576
-				b.FindBackendPath(h.AddLink(b, link2)).MaxBodySize = 2097152
+				b.FindBackendPath(h.AddLink(b, link1).Link).MaxBodySize = 1048576
+				b.FindBackendPath(h.AddLink(b, link2).Link).MaxBodySize = 2097152
 			},
 			expected: `
     # path02 = <default>/app1
@@ -1121,7 +1122,7 @@ frontend _front_https
 		var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 		ep := *endpointS1
 		b.Endpoints = []*hatypes.Endpoint{&ep}
-		h = c.config.Hosts().AcquireHost("d1.local")
+		h = c.df.AcquireHost("d1.local")
 		for j, p := range test.path {
 			match := hatypes.MatchBegin
 			if test.match != nil {
@@ -1198,7 +1199,7 @@ func TestInstanceBare(t *testing.T) {
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	c.Update()
@@ -1222,7 +1223,7 @@ func TestInstanceBareHTTP(t *testing.T) {
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.TLS.UseDefaultCrt = false
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
@@ -1276,7 +1277,7 @@ func TestInstanceGlobalBind(t *testing.T) {
 		var h *hatypes.Host
 		var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.Hosts().AcquireHost("d1.local")
+		h = c.df.AcquireHost("d1.local")
 		h.AddPath(b, "/", hatypes.MatchBegin)
 
 		c.config.Global().Bind = test.bind
@@ -1320,7 +1321,7 @@ func TestInstanceEmpty(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()
 
-	c.config.Hosts().AcquireHost("empty").AddPath(c.config.Backends().AcquireBackend("default", "empty", "8080"), "/", hatypes.MatchBegin)
+	c.df.AcquireHost("empty").AddPath(c.config.Backends().AcquireBackend("default", "empty", "8080"), "/", hatypes.MatchBegin)
 	c.Update()
 
 	c.checkConfig(`
@@ -1378,7 +1379,7 @@ func TestDefaultBackendRedir(t *testing.T) {
 	defer c.teardown()
 
 	c.config.Global().DefaultBackendRedir = "https://example.tld"
-	c.config.Hosts().AcquireHost("empty").AddPath(c.config.Backends().AcquireBackend("default", "empty", "8080"), "/", hatypes.MatchBegin)
+	c.df.AcquireHost("empty").AddPath(c.config.Backends().AcquireBackend("default", "empty", "8080"), "/", hatypes.MatchBegin)
 
 	c.Update()
 
@@ -1443,7 +1444,7 @@ func TestInstanceEmptyExternal(t *testing.T) {
 	c.config.global.Security.Username = "external"
 	c.config.global.Security.Groupname = "external"
 
-	c.config.Hosts().AcquireHost("empty").AddPath(c.config.Backends().AcquireBackend("default", "empty", "8080"), "/", hatypes.MatchBegin)
+	c.df.AcquireHost("empty").AddPath(c.config.Backends().AcquireBackend("default", "empty", "8080"), "/", hatypes.MatchBegin)
 	c.Update()
 
 	c.checkConfig(`
@@ -1487,7 +1488,7 @@ func TestPathIDsSplit(t *testing.T) {
 
 	max := 32
 	for i := 1; i <= max; i++ {
-		h := c.config.Hosts().AcquireHost(fmt.Sprintf("h%02d.local", i))
+		h := c.df.AcquireHost(fmt.Sprintf("h%02d.local", i))
 		h.AddPath(b, "/", hatypes.MatchBegin)
 		path := b.FindBackendPath(h.FindPath("/")[0].Link)
 		path.SSLRedirect = true
@@ -1574,7 +1575,7 @@ func TestInstanceSecurity(t *testing.T) {
 	c.config.global.Security.Username = "haproxy"
 	c.config.global.Security.Groupname = "haproxy"
 
-	c.config.Hosts().AcquireHost("empty").AddPath(c.config.Backends().AcquireBackend("default", "empty", "8080"), "/", hatypes.MatchBegin)
+	c.df.AcquireHost("empty").AddPath(c.config.Backends().AcquireBackend("default", "empty", "8080"), "/", hatypes.MatchBegin)
 	c.Update()
 
 	c.checkConfig(`
@@ -1614,7 +1615,7 @@ func TestInstanceMatch(t *testing.T) {
 
 	b := c.config.Backends().AcquireBackend("default", "d1", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h := c.config.Hosts().AcquireHost("d1.local")
+	h := c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/app", hatypes.MatchPrefix)
 	h.AddPath(b, "/api/v[0-9]+/", hatypes.MatchRegex)
 	c.Update()
@@ -1927,7 +1928,7 @@ func TestInstanceFrontingProxy(t *testing.T) {
 
 		var h *hatypes.Host
 		var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
-		h = c.config.Hosts().AcquireHost(test.domain)
+		h = c.df.AcquireHost(test.domain)
 		h.AddPath(b, "/", hatypes.MatchBegin)
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
 		b.FindBackendPath(h.FindPath("/")[0].Link).SSLRedirect = test.sslRedirect
@@ -1994,7 +1995,7 @@ func TestInstanceTCPServices(t *testing.T) {
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.ModeTCP = true
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	b2 := c.config.Backends().AcquireBackend("d2", "app", "8080")
@@ -2428,11 +2429,11 @@ func TestInstanceDefaultHost(t *testing.T) {
 
 	var h *hatypes.Host
 	var b *hatypes.Backend
-	hdef := c.config.Hosts().AcquireHost(hatypes.DefaultHost)
+	hdef := c.df.AcquireHost(hatypes.DefaultHost)
 
 	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.VarNamespace = true
@@ -2445,7 +2446,7 @@ func TestInstanceDefaultHost(t *testing.T) {
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d2.local")
+	h = c.df.AcquireHost("d2.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.VarNamespace = true
@@ -2565,13 +2566,13 @@ func TestInstanceUseDefaultCrt(t *testing.T) {
 
 	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.TLS.UseDefaultCrt = false
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h = c.config.Hosts().AcquireHost("d2.local")
+	h = c.df.AcquireHost("d2.local")
 	h.TLS.UseDefaultCrt = true
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
@@ -2605,7 +2606,7 @@ func TestInstanceStrictHost(t *testing.T) {
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/path", hatypes.MatchBegin)
 	c.config.Global().StrictHost = true
 
@@ -2640,12 +2641,12 @@ func TestInstanceStrictHostDefaultHost(t *testing.T) {
 
 	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/path", hatypes.MatchBegin)
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h = c.config.Hosts().AcquireHost(hatypes.DefaultHost)
+	h = c.df.AcquireHost(hatypes.DefaultHost)
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	c.config.Global().StrictHost = true
@@ -2716,7 +2717,7 @@ func TestInstanceFrontend(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	b.FindBackendPath(h.FindPath("/")[0].Link).SSLRedirect = true
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
@@ -2725,7 +2726,7 @@ func TestInstanceFrontend(t *testing.T) {
 	h.TLS.TLSHash = "1"
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
-	h = c.config.Hosts().AcquireHost("d2.local")
+	h = c.df.AcquireHost("d2.local")
 	h.AddPath(b, "/app", hatypes.MatchPrefix)
 	b.FindBackendPath(h.FindPath("/app")[0].Link).SSLRedirect = true
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
@@ -2816,7 +2817,7 @@ func TestInstanceFrontendMatchHeader(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()
 
-	c.config.frontend.RedirectToCode = 302
+	c.df.RedirectToCode = 302
 
 	def := c.config.Backends().AcquireBackend("default", "default-backend", "8080")
 	def.Endpoints = []*hatypes.Endpoint{endpointS0}
@@ -2881,15 +2882,15 @@ func TestInstanceFrontendMatchHeader(t *testing.T) {
 	b21 = c.config.Backends().AcquireBackend("b21", "app", "8080")
 	b1.Endpoints = []*hatypes.Endpoint{endpointS1}
 	b21.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h1 = c.config.Hosts().AcquireHost(hatypes.DefaultHost)
-	h2 = c.config.Hosts().AcquireHost("h2.local")
+	h1 = c.df.AcquireHost(hatypes.DefaultHost)
+	h2 = c.df.AcquireHost("h2.local")
 	h2.TLS.TLSFilename = "/var/haproxy/ssl/certs/h2.pem"
-	h3 = c.config.hosts.AcquireHost("h3.local")
-	h4 = c.config.hosts.AcquireHost("h4.local")
+	h3 = c.df.AcquireHost("h3.local")
+	h4 = c.df.AcquireHost("h4.local")
 	h4.TLS.TLSFilename = "/var/haproxy/ssl/certs/h4.pem"
 	h4.TLS.CAFilename = "/var/haproxy/ssl/cacerts/h4.pem"
 	h4.TLS.CAHash = "1"
-	h5 = c.config.hosts.AcquireHost("h5.local")
+	h5 = c.df.AcquireHost("h5.local")
 	h5.VarNamespace = true
 
 	h1.AddPath(b1, "/", hatypes.MatchBegin)
@@ -3093,7 +3094,7 @@ func TestInstanceFrontendCA(t *testing.T) {
 
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d", "app", "8080")
-	h = c.config.Hosts().AcquireHost("*.d1.local")
+	h = c.df.AcquireHost("*.d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
@@ -3101,7 +3102,7 @@ func TestInstanceFrontendCA(t *testing.T) {
 	h.TLS.CAHash = "1"
 	h.TLS.CAErrorPage = "http://d1.local/error.html"
 
-	h = c.config.Hosts().AcquireHost("d2.local")
+	h = c.df.AcquireHost("d2.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
@@ -3111,25 +3112,25 @@ func TestInstanceFrontendCA(t *testing.T) {
 	h.TLS.CRLHash = "2"
 	h.TLS.CAErrorPage = "http://d2.local/error.html"
 
-	h = c.config.Hosts().AcquireHost("d3.local")
+	h = c.df.AcquireHost("d3.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.TLS.Ciphers = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384"
 
-	h = c.config.Hosts().AcquireHost("d4.local")
+	h = c.df.AcquireHost("d4.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.TLS.CipherSuites = "TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
 
-	h = c.config.Hosts().AcquireHost("d5.local")
+	h = c.df.AcquireHost("d5.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.TLS.ALPN = "h2"
 
-	h = c.config.Hosts().AcquireHost("d6.local")
+	h = c.df.AcquireHost("d6.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
@@ -3325,17 +3326,17 @@ frontend _front__auth
 		var h *hatypes.Host
 		var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.Hosts().AcquireHost("d1.local")
+		h = c.df.AcquireHost("d1.local")
 		h.AddPath(b, "/", hatypes.MatchBegin)
 
-		auth := &c.config.Frontend().AuthProxy
+		auth := &c.df.AuthProxy
 		auth.Name = "_front__auth"
 		auth.RangeStart = 4001
 		auth.RangeEnd = 4010
 
 		for _, back := range test.backs {
 			backend := c.config.Backends().AcquireAuthBackend(back.iplist, back.port, back.hostname)
-			_, _ = c.config.Frontend().AcquireAuthBackendName(backend.BackendID())
+			_, _ = c.df.AcquireAuthBackendName(backend.BackendID())
 		}
 
 		c.Update()
@@ -3444,7 +3445,7 @@ func TestInstanceFrontendAuthExternal(t *testing.T) {
 		c := setup(t)
 		defer c.teardown()
 
-		h := c.config.Hosts().AcquireHost("d.local")
+		h := c.df.AcquireHost("d.local")
 		b := c.config.Backends().AcquireBackend("d", "app1", "8080")
 
 		path := h.AddPath(b, "/", hatypes.MatchBegin)
@@ -3496,7 +3497,7 @@ func TestInstanceSomePaths(t *testing.T) {
 	var b *hatypes.Backend
 
 	b = c.config.Backends().AcquireBackend("d", "app0", "8080")
-	h = c.config.Hosts().AcquireHost("d.local")
+	h = c.df.AcquireHost("d.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/", hatypes.MatchBegin)
@@ -3572,7 +3573,7 @@ func TestInstanceCustomFrontend(t *testing.T) {
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	c.config.Global().CustomFrontendEarly = []string{
 		"# dummy tcp-request",
@@ -3632,7 +3633,7 @@ func TestInstanceCustomSections(t *testing.T) {
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	c.config.Global().CustomSections = []string{
@@ -3694,24 +3695,24 @@ func TestInstanceCustomProxy(t *testing.T) {
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
-	h.SetSSLPassthrough(true)
+	h.SSLPassthrough = true
 
 	var h2 *hatypes.Host
 	var b2 = c.config.Backends().AcquireBackend("d2", "app", "8080")
 	b2.Endpoints = []*hatypes.Endpoint{endpointS21}
 	b2.ModeTCP = true
-	h2 = c.config.Hosts().AcquireHost("d2.local")
+	h2 = c.df.AcquireHost("d2.local")
 	h2.AddPath(b, "/", hatypes.MatchBegin)
-	h2.SetSSLPassthrough(true)
+	h2.SSLPassthrough = true
 
-	auth := &c.config.Frontend().AuthProxy
+	auth := &c.df.AuthProxy
 	auth.Name = "_front__auth"
 	auth.RangeStart = 4001
 	auth.RangeEnd = 4010
 	authBackend := c.config.Backends().AcquireAuthBackend([]string{"172.17.100.11"}, 5000, "")
-	_, _ = c.config.Frontend().AcquireAuthBackendName(authBackend.BackendID())
+	_, _ = c.df.AcquireAuthBackendName(authBackend.BackendID())
 
 	tcp := c.config.tcpbackends.Acquire("default_pgsql", 5432)
 	tcp.AddEndpoint("172.17.0.21", 5432)
@@ -3875,7 +3876,7 @@ func TestCustomResponseLua(t *testing.T) {
 		},
 	}
 
-	host1 := c.config.hosts.AcquireHost("server1.local")
+	host1 := c.df.AcquireHost("server1.local")
 	host1.TLS.CAFilename = "/var/haproxy/ssl/ca/ca.pem" // adds mTLS, all host based lua services are being called from there
 	host1.CustomHTTPResponses.ID = host1.Hostname
 	host1.CustomHTTPResponses.Lua = []hatypes.HTTPResponse{
@@ -4172,20 +4173,20 @@ func TestInstanceSSLPassthrough(t *testing.T) {
 
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d2", "app", "8080")
-	h = c.config.Hosts().AcquireHost("d2.local")
+	h = c.df.AcquireHost("d2.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	b.FindBackendPath(h.FindPath("/")[0].Link).SSLRedirect = true
 	b.Endpoints = []*hatypes.Endpoint{endpointS31}
 	// TODO should ingress converter configure mode tcp?
 	b.ModeTCP = true
-	h.SetSSLPassthrough(true)
+	h.SSLPassthrough = true
 
 	b = c.config.Backends().AcquireBackend("d3", "app-ssl", "8443")
-	h = c.config.Hosts().AcquireHost("d3.local")
+	h = c.df.AcquireHost("d3.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	b.Endpoints = []*hatypes.Endpoint{endpointS41s}
 	b.ModeTCP = true
-	h.SetSSLPassthrough(true)
+	h.SSLPassthrough = true
 
 	b = c.config.Backends().AcquireBackend("d3", "app1-http", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS41h}
@@ -4196,11 +4197,11 @@ func TestInstanceSSLPassthrough(t *testing.T) {
 	h.AddPath(b, "/app", hatypes.MatchBegin)
 
 	b = c.config.Backends().AcquireBackend("d4", "app4-ssl", "8443")
-	h = c.config.Hosts().AcquireHost(hatypes.DefaultHost)
+	h = c.df.AcquireHost(hatypes.DefaultHost)
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	b.Endpoints = []*hatypes.Endpoint{endpointS41s}
 	b.ModeTCP = true
-	h.SetSSLPassthrough(true)
+	h.SSLPassthrough = true
 
 	b = c.config.Backends().AcquireBackend("d4", "app4-http", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS41h}
@@ -4278,7 +4279,7 @@ func TestInstanceRootRedirect(t *testing.T) {
 
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
-	h = c.config.Hosts().AcquireHost("*.d1.local")
+	h = c.df.AcquireHost("*.d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/", hatypes.MatchBegin)
@@ -4286,7 +4287,7 @@ func TestInstanceRootRedirect(t *testing.T) {
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
-	h = c.config.Hosts().AcquireHost("d2.local")
+	h = c.df.AcquireHost("d2.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/app1", hatypes.MatchBegin)
@@ -4376,20 +4377,20 @@ func TestInstanceAlias(t *testing.T) {
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.Alias.AliasName = "*.d1.local"
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h = c.config.Hosts().AcquireHost("d2.local")
+	h = c.df.AcquireHost("d2.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.Alias.AliasName = "sub.d2.local"
 	h.Alias.AliasRegex = "^[a-z]+\\.d2\\.local$"
 
 	b = c.config.Backends().AcquireBackend("d3", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS31}
-	h = c.config.Hosts().AcquireHost("d3.local")
+	h = c.df.AcquireHost("d3.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.Alias.AliasRegex = "d3\\.local$"
 
@@ -4531,26 +4532,26 @@ sub.d2.local d2.local
 		var h *hatypes.Host
 		var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.Hosts().AcquireHost("d1.local")
+		h = c.df.AcquireHost("d1.local")
 		h.AddPath(b, "/", hatypes.MatchBegin)
 		h.Redirect = test.data[0]
 
 		b = c.config.Backends().AcquireBackend("d2", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS21}
-		h = c.config.Hosts().AcquireHost("d2.local")
+		h = c.df.AcquireHost("d2.local")
 		h.AddPath(b, "/", hatypes.MatchBegin)
 		h.Redirect = test.data[1]
 
 		b = c.config.Backends().AcquireBackend("d3", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS31}
-		h = c.config.Hosts().AcquireHost("d3.local")
+		h = c.df.AcquireHost("d3.local")
 		h.AddPath(b, "/", hatypes.MatchBegin)
 		h.Redirect = test.data[2]
 
 		if test.code != 0 {
-			c.config.frontend.RedirectFromCode = test.code
+			c.df.RedirectFromCode = test.code
 		} else {
-			c.config.frontend.RedirectFromCode = 302
+			c.df.RedirectFromCode = 302
 		}
 
 		c.Update()
@@ -4687,7 +4688,7 @@ d1.local#/ https://app.local
 
 		c.config.global.NoRedirects = test.noredirs
 
-		var h = c.config.Hosts().AcquireHost("d1.local")
+		var h = c.df.AcquireHost("d1.local")
 		var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
 		if test.to[0] != "" {
@@ -4713,9 +4714,9 @@ d1.local#/ https://app.local
 		}
 
 		if test.code != 0 {
-			c.config.frontend.RedirectToCode = test.code
+			c.df.RedirectToCode = test.code
 		} else {
-			c.config.frontend.RedirectToCode = 302
+			c.df.RedirectToCode = 302
 		}
 
 		c.Update()
@@ -4778,7 +4779,7 @@ func TestInstanceSyslog(t *testing.T) {
 	var h *hatypes.Host
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	tcpPort1, tcpHost1 := c.config.tcpservices.AcquireTCPService("<default>:7001")
@@ -4975,20 +4976,20 @@ func TestDNS(t *testing.T) {
 	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21, endpointS22}
 	b.Resolver = "k8s"
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "http")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21, endpointS22}
 	b.Resolver = "k8s"
-	h = c.config.Hosts().AcquireHost("d2.local")
+	h = c.df.AcquireHost("d2.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	b = c.config.Backends().AcquireBackend("d3", "app", "http")
 	b.DNSPort = "named"
 	b.Endpoints = []*hatypes.Endpoint{endpointS21, endpointS22}
 	b.Resolver = "k8s"
-	h = c.config.Hosts().AcquireHost("d3.local")
+	h = c.df.AcquireHost("d3.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	c.Update()
@@ -5091,7 +5092,7 @@ userlist default_auth2
 		var h *hatypes.Host
 		var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.Hosts().AcquireHost("d1.local")
+		h = c.df.AcquireHost("d1.local")
 		h.AddPath(b, "/", hatypes.MatchBegin)
 		h.AddPath(b, "/admin", hatypes.MatchBegin)
 
@@ -5168,7 +5169,7 @@ frontend _front_http
 		var h *hatypes.Host
 		var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.Hosts().AcquireHost("d1.local")
+		h = c.df.AcquireHost("d1.local")
 		h.AddPath(b, "/", hatypes.MatchBegin)
 
 		acme := &c.config.Global().Acme
@@ -5442,7 +5443,7 @@ spoe-message coraza-req
 		var h *hatypes.Host
 		var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 		b.Endpoints = []*hatypes.Endpoint{endpointS1}
-		h = c.config.Hosts().AcquireHost("d1.local")
+		h = c.df.AcquireHost("d1.local")
 		if test.path == "" {
 			test.path = "/"
 		}
@@ -5511,15 +5512,15 @@ func TestInstanceWildcardHostname(t *testing.T) {
 	var h *hatypes.Host
 
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/", hatypes.MatchBegin)
-	h = c.config.Hosts().AcquireHost("*.app.d1.local")
+	h = c.df.AcquireHost("*.app.d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/", hatypes.MatchBegin)
-	h = c.config.Hosts().AcquireHost("*.sub.d1.local")
+	h = c.df.AcquireHost("*.sub.d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/", hatypes.MatchBegin)
@@ -5533,7 +5534,7 @@ func TestInstanceWildcardHostname(t *testing.T) {
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
-	h = c.config.Hosts().AcquireHost("*.d2.local")
+	h = c.df.AcquireHost("*.d2.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 	h.RootRedirect = "/app"
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
@@ -5629,7 +5630,7 @@ func TestCAVerifySkip(t *testing.T) {
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
 
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
 	h.TLS.TLSHash = "0"
 	h.AddPath(b, "/", hatypes.MatchBegin)
@@ -5697,17 +5698,17 @@ func TestShards(t *testing.T) {
 
 	var b = c.config.Backends().AcquireBackend("d1", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS1}
-	h = c.config.Hosts().AcquireHost("d1.local")
+	h = c.df.AcquireHost("d1.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	b = c.config.Backends().AcquireBackend("d2", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS21}
-	h = c.config.Hosts().AcquireHost("d2.local")
+	h = c.df.AcquireHost("d2.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	b = c.config.Backends().AcquireBackend("d3", "app", "8080")
 	b.Endpoints = []*hatypes.Endpoint{endpointS31}
-	h = c.config.Hosts().AcquireHost("d3.local")
+	h = c.df.AcquireHost("d3.local")
 	h.AddPath(b, "/", hatypes.MatchBegin)
 
 	c.Update()
@@ -5749,6 +5750,7 @@ type testConfig struct {
 	logger   *helper_test.LoggerMock
 	instance *instance
 	config   *config
+	df       *hatypes.Frontend
 	tempdir  string
 }
 
@@ -5844,12 +5846,14 @@ func setupOptions(options testOptions) *testConfig {
 		t.Errorf("error parsing modsecurity.tmpl: %v", err)
 	}
 	config := instance.Config().(*config)
-	config.frontend.DefaultCrtFile = "/var/haproxy/ssl/certs/default.pem"
+	df := config.frontends.Default()
+	df.DefaultCrtFile = "/var/haproxy/ssl/certs/default.pem"
 	c := &testConfig{
 		t:        t,
 		logger:   logger,
 		instance: instance,
 		config:   config,
+		df:       df,
 		tempdir:  tempdir,
 	}
 	c.configGlobal(c.config.Global())

--- a/pkg/haproxy/types/backend_test.go
+++ b/pkg/haproxy/types/backend_test.go
@@ -32,54 +32,54 @@ func TestAddBackendPath(t *testing.T) {
 		{
 			input: []string{"/"},
 			expected: []*BackendPath{
-				{ID: "path01", Link: CreateHostPathLink("d1.local", "/", MatchBegin)},
+				{ID: "path01", Link: CreatePathLink("/", MatchBegin)},
 			},
 		},
 		// 1
 		{
 			input: []string{"/app", "/app"},
 			expected: []*BackendPath{
-				{ID: "path01", Link: CreateHostPathLink("d1.local", "/app", MatchBegin)},
+				{ID: "path01", Link: CreatePathLink("/app", MatchBegin)},
 			},
 		},
 		// 2
 		{
 			input: []string{"/app", "/root"},
 			expected: []*BackendPath{
-				{ID: "path01", Link: CreateHostPathLink("d1.local", "/app", MatchBegin)},
-				{ID: "path02", Link: CreateHostPathLink("d1.local", "/root", MatchBegin)},
+				{ID: "path01", Link: CreatePathLink("/app", MatchBegin)},
+				{ID: "path02", Link: CreatePathLink("/root", MatchBegin)},
 			},
 		},
 		// 3
 		{
 			input: []string{"/app", "/root", "/root"},
 			expected: []*BackendPath{
-				{ID: "path01", Link: CreateHostPathLink("d1.local", "/app", MatchBegin)},
-				{ID: "path02", Link: CreateHostPathLink("d1.local", "/root", MatchBegin)},
+				{ID: "path01", Link: CreatePathLink("/app", MatchBegin)},
+				{ID: "path02", Link: CreatePathLink("/root", MatchBegin)},
 			},
 		},
 		// 4
 		{
 			input: []string{"/app", "/root", "/app"},
 			expected: []*BackendPath{
-				{ID: "path01", Link: CreateHostPathLink("d1.local", "/app", MatchBegin)},
-				{ID: "path02", Link: CreateHostPathLink("d1.local", "/root", MatchBegin)},
+				{ID: "path01", Link: CreatePathLink("/app", MatchBegin)},
+				{ID: "path02", Link: CreatePathLink("/root", MatchBegin)},
 			},
 		},
 		// 5
 		{
 			input: []string{"/", "/app", "/root"},
 			expected: []*BackendPath{
-				{ID: "path01", Link: CreateHostPathLink("d1.local", "/", MatchBegin)},
-				{ID: "path02", Link: CreateHostPathLink("d1.local", "/app", MatchBegin)},
-				{ID: "path03", Link: CreateHostPathLink("d1.local", "/root", MatchBegin)},
+				{ID: "path01", Link: CreatePathLink("/", MatchBegin)},
+				{ID: "path02", Link: CreatePathLink("/app", MatchBegin)},
+				{ID: "path03", Link: CreatePathLink("/root", MatchBegin)},
 			},
 		},
 	}
 	for i, test := range testCases {
 		b := &Backend{}
 		for _, p := range test.input {
-			b.AddBackendPath(CreateHostPathLink("d1.local", p, MatchBegin))
+			b.AddBackendPath(CreatePathLink(p, MatchBegin))
 		}
 		if !reflect.DeepEqual(b.Paths, test.expected) {
 			t.Errorf("backend.Paths differs on %d - actual: %v - expected: %v", i, b.Paths, test.expected)

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -18,8 +18,225 @@ package types
 
 import (
 	"fmt"
+	"reflect"
 	"sort"
 )
+
+func CreateFrontends() *Frontends {
+	return &Frontends{
+		items: []*Frontend{{
+			hosts:    map[string]*Host{},
+			hostsAdd: map[string]*Host{},
+			hostsDel: map[string]*Host{},
+		}},
+	}
+}
+
+func (f *Frontends) Default() *Frontend {
+	return f.items[0]
+}
+
+func (f *Frontends) Commit() {
+	f.items[0].Commit()
+}
+
+func (f *Frontends) FrontendsChanged() bool {
+	return f.items[0].FrontendChanged()
+}
+
+func (f *Frontends) RemoveAllHosts(hostnames []string) {
+	f.items[0].RemoveAllHosts(hostnames)
+}
+
+func (f *Frontends) RemoveAuthBackendByTarget(backends []string) {
+	f.items[0].RemoveAuthBackendByTarget(backends)
+}
+
+// AcquireHost ...
+func (f *Frontend) AcquireHost(hostname string) *Host {
+	if host := f.FindHost(hostname); host != nil {
+		return host
+	}
+	host := f.createHost(hostname)
+	f.hosts[hostname] = host
+	f.hostsAdd[hostname] = host
+	return host
+}
+
+// FindHost ...
+func (f *Frontend) FindHost(hostname string) *Host {
+	return f.hosts[hostname]
+}
+
+// RemoveAllHosts ...
+func (f *Frontend) RemoveAllHosts(hostnames []string) {
+	for _, hostname := range hostnames {
+		if item, found := f.hosts[hostname]; found {
+			f.hostsDel[hostname] = item
+			delete(f.hosts, hostname)
+		}
+	}
+}
+
+// FindTargetRedirect ...
+func (f *Frontend) FindTargetRedirect(redirfrom string, isRegex bool) *Host {
+	if redirfrom == "" {
+		return nil
+	}
+	// TODO this'd be somewhat expensive on full parsing,
+	// tens of thousands of ingress and most of them using redirect
+	if isRegex {
+		for _, host := range f.hosts {
+			if host.Redirect.RedirectHostRegex == redirfrom {
+				return host
+			}
+		}
+		return nil
+	}
+	for _, host := range f.hosts {
+		if host.Redirect.RedirectHost == redirfrom {
+			return host
+		}
+	}
+	return nil
+}
+
+// ShrinkHosts removes matching added and deleted hosts from the changing hashmap
+// tracker that has the same content. A matching added+deleted pair means
+// that a hostname was reparsed but its content wasn't changed.
+func (f *Frontend) ShrinkHosts() {
+	for name, del := range f.hostsDel {
+		if add, found := f.hostsAdd[name]; found {
+			if reflect.DeepEqual(add, del) {
+				f.hosts[name] = del
+				delete(f.hostsAdd, name)
+				delete(f.hostsDel, name)
+			}
+		}
+	}
+}
+
+// Commit ...
+func (f *Frontend) Commit() {
+	f.hostsAdd = map[string]*Host{}
+	f.hostsDel = map[string]*Host{}
+	f.hasCommit = true
+	f.changed = false
+}
+
+// HasCommit ...
+func (f *Frontend) HasCommit() bool {
+	return f.hasCommit
+}
+
+// FrontendChanged ...
+func (f *Frontend) FrontendChanged() bool {
+	return f.changed
+}
+
+// HostsChanged ...
+func (f *Frontend) HostsChanged() bool {
+	return len(f.hostsAdd) > 0 || len(f.hostsDel) > 0
+}
+
+func (f *Frontend) createHost(hostname string) *Host {
+	return &Host{
+		Hostname: hostname,
+		frontend: f,
+		TLS: HostTLSConfig{
+			// TODO revisit instance_test to allow change this default value to `false`
+			UseDefaultCrt: true,
+		},
+	}
+}
+
+// BuildSortedHosts ...
+func (f *Frontend) BuildSortedHosts() []*Host {
+	items := make([]*Host, len(f.hosts))
+	var i int
+	for hostname, item := range f.hosts {
+		if hostname != DefaultHost {
+			items[i] = item
+			i++
+		}
+	}
+	items = items[:i]
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].Hostname < items[j].Hostname
+	})
+	if len(items) == 0 {
+		return nil
+	}
+	return items
+}
+
+// Hosts ...
+func (f *Frontend) Hosts() map[string]*Host {
+	return f.hosts
+}
+
+// HostsAdd ...
+func (f *Frontend) HostsAdd() map[string]*Host {
+	return f.hostsAdd
+}
+
+// HostsDel ...
+func (f *Frontend) HostsDel() map[string]*Host {
+	return f.hostsDel
+}
+
+// DefaultHost ...
+func (f *Frontend) DefaultHost() *Host {
+	return f.hosts[DefaultHost]
+}
+
+// HasTLSAuth ...
+func (f *Frontend) HasTLSAuth() bool {
+	for _, host := range f.hosts {
+		if host.TLS.CAFilename != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// HasSSLPassthrough ...
+func (f *Frontend) HasSSLPassthrough() bool {
+	for _, host := range f.hosts {
+		if host.SSLPassthrough {
+			return true
+		}
+	}
+	return false
+}
+
+// HasVarNamespace ...
+func (f *Frontend) HasVarNamespace() bool {
+	for _, host := range f.hosts {
+		if host.VarNamespace {
+			return true
+		}
+	}
+	return false
+}
+
+func (f *Frontend) BuildHTTPResponses() (responses []HTTPResponses) {
+	for _, host := range f.hosts {
+		res := &host.CustomHTTPResponses
+		if len(res.HAProxy) > 0 || len(res.Lua) > 0 {
+			responses = append(responses, HTTPResponses{
+				ID:      res.ID,
+				HAProxy: res.HAProxy,
+				Lua:     res.Lua,
+			})
+		}
+	}
+	// predictable response
+	sort.Slice(responses, func(i, j int) bool {
+		return responses[i].ID < responses[j].ID
+	})
+	return responses
+}
 
 // AcquireAuthBackendName ...
 func (f *Frontend) AcquireAuthBackendName(backend BackendID) (authBackendName string, err error) {
@@ -84,16 +301,6 @@ func hasBackend(backends []string, backend string) bool {
 		}
 	}
 	return false
-}
-
-// Changed ...
-func (f *Frontend) Changed() bool {
-	return f.changed
-}
-
-// Commit ...
-func (f *Frontend) Commit() {
-	f.changed = false
 }
 
 // String ...

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -18,218 +18,10 @@ package types
 
 import (
 	"fmt"
-	"reflect"
 	"sort"
+
+	"k8s.io/utils/ptr"
 )
-
-// CreateHosts ...
-func CreateHosts() *Hosts {
-	return &Hosts{
-		items:    map[string]*Host{},
-		itemsAdd: map[string]*Host{},
-		itemsDel: map[string]*Host{},
-	}
-}
-
-// CreatePathLink ...
-func CreatePathLink(path string, match MatchType) *PathLink {
-	return CreateHostPathLink("", path, match)
-}
-
-// CreateHostPathLink ...
-func CreateHostPathLink(hostname, path string, match MatchType) *PathLink {
-	pathlink := &PathLink{
-		hostname: hostname,
-		path:     path,
-		match:    match,
-	}
-	pathlink.updatehash()
-	return pathlink
-}
-
-// AcquireHost ...
-func (h *Hosts) AcquireHost(hostname string) *Host {
-	if host := h.FindHost(hostname); host != nil {
-		return host
-	}
-	host := h.createHost(hostname)
-	h.items[hostname] = host
-	h.itemsAdd[hostname] = host
-	return host
-}
-
-// FindHost ...
-func (h *Hosts) FindHost(hostname string) *Host {
-	return h.items[hostname]
-}
-
-// RemoveAll ...
-func (h *Hosts) RemoveAll(hostnames []string) {
-	for _, hostname := range hostnames {
-		if item, found := h.items[hostname]; found {
-			h.releaseHost(item)
-			h.itemsDel[hostname] = item
-			delete(h.items, hostname)
-		}
-	}
-}
-
-// FindTargetRedirect ...
-func (h *Hosts) FindTargetRedirect(redirfrom string, isRegex bool) *Host {
-	if redirfrom == "" {
-		return nil
-	}
-	// TODO this'd be somewhat expensive on full parsing,
-	// tens of thousands of ingress and most of them using redirect
-	if isRegex {
-		for _, host := range h.items {
-			if host.Redirect.RedirectHostRegex == redirfrom {
-				return host
-			}
-		}
-		return nil
-	}
-	for _, host := range h.items {
-		if host.Redirect.RedirectHost == redirfrom {
-			return host
-		}
-	}
-	return nil
-}
-
-// Shrink removes matching added and deleted hosts from the changing hashmap
-// tracker that has the same content. A matching added+deleted pair means
-// that a hostname was reparsed but its content wasn't changed.
-func (h *Hosts) Shrink() {
-	for name, del := range h.itemsDel {
-		if add, found := h.itemsAdd[name]; found {
-			if reflect.DeepEqual(add, del) {
-				h.items[name] = del
-				delete(h.itemsAdd, name)
-				delete(h.itemsDel, name)
-			}
-		}
-	}
-}
-
-// Commit ...
-func (h *Hosts) Commit() {
-	h.itemsAdd = map[string]*Host{}
-	h.itemsDel = map[string]*Host{}
-	h.hasCommit = true
-}
-
-// HasCommit ...
-func (h *Hosts) HasCommit() bool {
-	return h.hasCommit
-}
-
-// Changed ...
-func (h *Hosts) Changed() bool {
-	return len(h.itemsAdd) > 0 || len(h.itemsDel) > 0
-}
-
-func (h *Hosts) createHost(hostname string) *Host {
-	return &Host{
-		Hostname: hostname,
-		hosts:    h,
-		TLS: HostTLSConfig{
-			// TODO revisit instance_test to allow change this default value to `false`
-			UseDefaultCrt: true,
-		},
-	}
-}
-
-// BuildSortedItems ...
-func (h *Hosts) BuildSortedItems() []*Host {
-	items := make([]*Host, len(h.items))
-	var i int
-	for hostname, item := range h.items {
-		if hostname != DefaultHost {
-			items[i] = item
-			i++
-		}
-	}
-	items = items[:i]
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].Hostname < items[j].Hostname
-	})
-	if len(items) == 0 {
-		return nil
-	}
-	return items
-}
-
-// Items ...
-func (h *Hosts) Items() map[string]*Host {
-	return h.items
-}
-
-// ItemsAdd ...
-func (h *Hosts) ItemsAdd() map[string]*Host {
-	return h.itemsAdd
-}
-
-// ItemsDel ...
-func (h *Hosts) ItemsDel() map[string]*Host {
-	return h.itemsDel
-}
-
-// DefaultHost ...
-func (h *Hosts) DefaultHost() *Host {
-	return h.items[DefaultHost]
-}
-
-// releaseHost does a reverse update on the Hosts state
-// due to the removal of a Host item
-func (h *Hosts) releaseHost(host *Host) {
-	if host.sslPassthrough {
-		h.sslPassthroughCount--
-	}
-}
-
-// HasTLSAuth ...
-func (h *Hosts) HasTLSAuth() bool {
-	for _, host := range h.items {
-		if host.TLS.CAFilename != "" {
-			return true
-		}
-	}
-	return false
-}
-
-// HasSSLPassthrough ...
-func (h *Hosts) HasSSLPassthrough() bool {
-	return h.sslPassthroughCount > 0
-}
-
-// HasVarNamespace ...
-func (h *Hosts) HasVarNamespace() bool {
-	for _, host := range h.items {
-		if host.VarNamespace {
-			return true
-		}
-	}
-	return false
-}
-
-func (h *Hosts) BuildHTTPResponses() (responses []HTTPResponses) {
-	for _, host := range h.items {
-		res := &host.CustomHTTPResponses
-		if len(res.HAProxy) > 0 || len(res.Lua) > 0 {
-			responses = append(responses, HTTPResponses{
-				ID:      res.ID,
-				HAProxy: res.HAProxy,
-				Lua:     res.Lua,
-			})
-		}
-	}
-	// predictable response
-	sort.Slice(responses, func(i, j int) bool {
-		return responses[i].ID < responses[j].ID
-	})
-	return responses
-}
 
 // FindPath ...
 func (h *Host) FindPath(path string, match ...MatchType) (paths []*HostPath) {
@@ -256,25 +48,19 @@ func (h *Host) AddPath(backend *Backend, path string, match MatchType) *HostPath
 	return h.addPath(path, match, backend, "")
 }
 
-// AddLink ...
-func (h *Host) AddLink(backend *Backend, link *PathLink) *PathLink {
-	newlink := *link
-	newlink.WithHostname(h.Hostname)
-	_ = h.addLink(backend, &newlink, "")
-	return &newlink
-}
-
-// AddLinkRedirect ...
-func (h *Host) AddLinkRedirect(link *PathLink, redirTo string) *PathLink {
-	newlink := *link
-	newlink.WithHostname(h.Hostname)
-	_ = h.addLink(nil, &newlink, redirTo)
-	return &newlink
-}
-
 // AddRedirect ...
 func (h *Host) AddRedirect(path string, match MatchType, redirTo string) {
 	_ = h.addPath(path, match, nil, redirTo)
+}
+
+// AddLink ...
+func (h *Host) AddLink(backend *Backend, link *PathLink) *HostPath {
+	return h.addLink(backend, link, "")
+}
+
+// AddLinkRedirect ...
+func (h *Host) AddLinkRedirect(link *PathLink, redirTo string) *HostPath {
+	return h.addLink(nil, link, redirTo)
 }
 
 type hostResolver struct {
@@ -284,11 +70,12 @@ type hostResolver struct {
 }
 
 func (h *Host) addPath(path string, match MatchType, backend *Backend, redirTo string) *HostPath {
-	link := CreateHostPathLink(h.Hostname, path, match)
+	link := CreatePathLink(path, match)
 	return h.addLink(backend, link, redirTo)
 }
 
 func (h *Host) addLink(backend *Backend, link *PathLink, redirTo string) *HostPath {
+	link = ptr.To(*link).WithHTTPHost(h)
 	var hback HostBackend
 	if backend != nil {
 		hback = HostBackend{
@@ -361,24 +148,6 @@ func (h *Host) HasTLSAuth() bool {
 	return h.TLS.CAHash != ""
 }
 
-// SSLPassthrough ...
-func (h *Host) SSLPassthrough() bool {
-	return h.sslPassthrough
-}
-
-// SetSSLPassthrough ...
-func (h *Host) SetSSLPassthrough(value bool) {
-	if h.sslPassthrough == value {
-		return
-	}
-	if value {
-		h.hosts.sslPassthroughCount++
-	} else {
-		h.hosts.sslPassthroughCount--
-	}
-	h.sslPassthrough = value
-}
-
 // Path ...
 func (h *HostPath) Path() string {
 	return h.Link.path
@@ -404,93 +173,6 @@ func (h *HostPath) hasMatch(match []MatchType) bool {
 		}
 	}
 	return false
-}
-
-func (l *PathLink) updatehash() {
-	hash := l.hostname + "\n" + l.path + "\n" + string(l.match)
-	for _, h := range l.headers {
-		hash += "\n" + "h:" + h.Name + ":" + h.Value
-		if h.Regex {
-			hash += "(regex)"
-		}
-	}
-	l.hash = PathLinkHash(hash)
-}
-
-// Hash ...
-func (l *PathLink) Hash() PathLinkHash {
-	return l.hash
-}
-
-// Equals ...
-func (l *PathLink) Equals(other *PathLink) bool {
-	if l == nil || other == nil {
-		return l == other
-	}
-	return l.hash == other.hash
-}
-
-// ComposeMatch returns true if the pathLink has composing match,
-// by adding method, header or cookie match.
-func (l *PathLink) ComposeMatch() bool {
-	return len(l.headers) > 0
-}
-
-// WithHostname ...
-func (l *PathLink) WithHostname(hostname string) *PathLink {
-	l.hostname = hostname
-	l.updatehash()
-	return l
-}
-
-// WithHeadersMatch ...
-func (l *PathLink) WithHeadersMatch(headers HTTPHeaderMatch) *PathLink {
-	l.headers = headers
-	l.updatehash()
-	return l
-}
-
-// AddHeadersMatch ...
-func (l *PathLink) AddHeadersMatch(headers HTTPHeaderMatch) *PathLink {
-	l.headers = append(l.headers, headers...)
-	l.updatehash()
-	return l
-}
-
-// Hostname ...
-func (l *PathLink) Hostname() string {
-	return l.hostname
-}
-
-// IsEmpty ...
-func (l *PathLink) IsEmpty() bool {
-	return l.hostname == "" && l.path == ""
-}
-
-// IsDefaultHost ...
-func (l *PathLink) IsDefaultHost() bool {
-	return l.hostname == DefaultHost
-}
-
-// Less ...
-func (l *PathLink) Less(other *PathLink, reversePath bool) bool {
-	if l.hostname == other.hostname {
-		if reversePath {
-			return l.path > other.path
-		}
-		return l.path < other.path
-	}
-	return l.hostname < other.hostname
-}
-
-// HAMatch ...
-func (l *PathLink) HAMatch() string {
-	return haMatchMethod(l.match)
-}
-
-// Key ...
-func (l *PathLink) Key() string {
-	return buildMapKey(l.match, l.hostname, l.path)
 }
 
 // String ...

--- a/pkg/haproxy/types/host_test.go
+++ b/pkg/haproxy/types/host_test.go
@@ -22,37 +22,41 @@ import (
 )
 
 func TestCreatePathLink(t *testing.T) {
-	l1 := CreateHostPathLink("domain.local", "/app", MatchBegin)
-	l2 := CreateHostPathLink("domain.local", "/app", MatchBegin)
+	df := CreateFrontends().Default()
+	host0 := df.AcquireHost("domain.local")
+	host1 := df.AcquireHost("domain1.local")
+	host2 := df.AcquireHost("domain2.local")
+	l1 := CreatePathLink("/app", MatchBegin).WithHTTPHost(host0)
+	l2 := CreatePathLink("/app", MatchBegin).WithHTTPHost(host0)
 	if !l1.Equals(l2) {
 		t.Errorf("two distinct path links with same host and path should match")
 	}
-	l3 := CreateHostPathLink("domain1.local", "/app", MatchBegin)
-	l4 := CreateHostPathLink("domain2.local", "/app", MatchBegin)
+	l3 := CreatePathLink("/app", MatchBegin).WithHTTPHost(host1)
+	l4 := CreatePathLink("/app", MatchBegin).WithHTTPHost(host2)
 	if l3.Equals(l4) {
 		t.Errorf("path links with distinct domains should not match")
 	}
-	l5 := CreateHostPathLink("domain.local", "/app1", MatchBegin)
-	l6 := CreateHostPathLink("domain.local", "/app2", MatchBegin)
+	l5 := CreatePathLink("/app1", MatchBegin).WithHTTPHost(host0)
+	l6 := CreatePathLink("/app2", MatchBegin).WithHTTPHost(host0)
 	if l5.Equals(l6) {
 		t.Errorf("path links with distinct paths should not match")
 	}
-	l7 := CreateHostPathLink("domain.local", "/app", MatchBegin)
+	l7 := CreatePathLink("/app", MatchBegin).WithHTTPHost(host0)
 	l7.WithHeadersMatch(HTTPHeaderMatch{
 		{Name: "h1", Value: "v1", Regex: true},
 	})
-	l8 := CreateHostPathLink("domain.local", "/app", MatchBegin)
+	l8 := CreatePathLink("/app", MatchBegin).WithHTTPHost(host0)
 	l8.WithHeadersMatch(HTTPHeaderMatch{
 		{Name: "h1", Value: "v1", Regex: true},
 	})
 	if !l7.Equals(l8) {
 		t.Errorf("path links with same headers should match")
 	}
-	l9 := CreateHostPathLink("domain.local", "/app", MatchBegin)
+	l9 := CreatePathLink("/app", MatchBegin).WithHTTPHost(host0)
 	l9.WithHeadersMatch(HTTPHeaderMatch{
 		{Name: "h1", Value: "v1", Regex: true},
 	})
-	l10 := CreateHostPathLink("domain.local", "/app", MatchBegin)
+	l10 := CreatePathLink("/app", MatchBegin).WithHTTPHost(host0)
 	l10.WithHeadersMatch(HTTPHeaderMatch{
 		{Name: "h1", Value: "v2", Regex: true},
 	})
@@ -95,12 +99,12 @@ func TestShrinkHosts(t *testing.T) {
 	}
 	for i, test := range testCases {
 		c := setup(t)
-		h := CreateHosts()
+		df := CreateFrontends().Default()
 		for _, add := range test.add {
-			h.itemsAdd[add.Hostname] = add
+			df.hostsAdd[add.Hostname] = add
 		}
 		for _, del := range test.del {
-			h.itemsDel[del.Hostname] = del
+			df.hostsDel[del.Hostname] = del
 		}
 		expAdd := map[string]*Host{}
 		for _, add := range test.expAdd {
@@ -110,9 +114,9 @@ func TestShrinkHosts(t *testing.T) {
 		for _, del := range test.expDel {
 			expDel[del.Hostname] = del
 		}
-		h.Shrink()
-		c.compareObjects("add", i, h.itemsAdd, expAdd)
-		c.compareObjects("del", i, h.itemsDel, expDel)
+		df.ShrinkHosts()
+		c.compareObjects("add", i, df.hostsAdd, expAdd)
+		c.compareObjects("del", i, df.hostsDel, expDel)
 		c.teardown()
 	}
 }
@@ -185,7 +189,8 @@ func TestAddFindPath(t *testing.T) {
 	}
 	for i, test := range testCases {
 		c := setup(t)
-		h := CreateHosts().AcquireHost("d1.local")
+		df := CreateFrontends().Default()
+		h := df.AcquireHost("d1.local")
 		for _, p := range test.paths {
 			h.AddPath(p.backend, p.path, p.match)
 		}
@@ -254,8 +259,9 @@ func TestRemovePath(t *testing.T) {
 	}
 	for i, test := range testCases {
 		c := setup(t)
+		df := CreateFrontends().Default()
 		b := CreateBackends(0).AcquireBackend("default", "b", "8080")
-		h := CreateHosts().AcquireHost("d1.local")
+		h := df.AcquireHost("d1.local")
 		for _, path := range strings.Split(test.addPaths, ",") {
 			h.AddPath(b, path, MatchPrefix)
 		}

--- a/pkg/haproxy/types/pathlink.go
+++ b/pkg/haproxy/types/pathlink.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2025 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"fmt"
+)
+
+func CreatePathLink(path string, match MatchType) *PathLink {
+	pathlink := &PathLink{
+		hostname: DefaultHost,
+		path:     path,
+		match:    match,
+	}
+	pathlink.updatehash()
+	return pathlink
+}
+
+func (l *PathLink) updatehash() {
+	hash := l.frontend + "\n" + l.hostname + "\n" + l.path + "\n" + string(l.match)
+	for _, h := range l.headers {
+		hash += "\n" + "h:" + h.Name + ":" + h.Value
+		if h.Regex {
+			hash += "(regex)"
+		}
+	}
+	l.hash = PathLinkHash(hash)
+}
+
+// Hash ...
+func (l *PathLink) Hash() PathLinkHash {
+	return l.hash
+}
+
+// Equals ...
+func (l *PathLink) Equals(other *PathLink) bool {
+	if l == nil || other == nil {
+		return l == other
+	}
+	return l.hash == other.hash
+}
+
+// IsComposeMatch returns true if the pathLink has composing match,
+// by adding method, header or cookie match.
+func (l *PathLink) IsComposeMatch() bool {
+	return len(l.headers) > 0
+}
+
+// WithHTTPHost ...
+func (l *PathLink) WithHTTPHost(host *Host) *PathLink {
+	l.frontend = "_http"
+	l.hostname = host.Hostname
+	l.updatehash()
+	return l
+}
+
+// WithTCPHost ...
+func (l *PathLink) WithTCPHost(tcphost *TCPServiceHost) *PathLink {
+	l.frontend = fmt.Sprintf("_tcp_%d", tcphost.tcpport.port)
+	l.hostname = fmt.Sprintf("%s:%d", tcphost.hostname, tcphost.tcpport.port)
+	l.updatehash()
+	return l
+}
+
+// WithHeadersMatch ...
+func (l *PathLink) WithHeadersMatch(headers HTTPHeaderMatch) *PathLink {
+	l.headers = headers
+	l.updatehash()
+	return l
+}
+
+// AddHeadersMatch ...
+func (l *PathLink) AddHeadersMatch(headers HTTPHeaderMatch) *PathLink {
+	l.headers = append(l.headers, headers...)
+	l.updatehash()
+	return l
+}
+
+// Hostname ...
+func (l *PathLink) Hostname() string {
+	return l.hostname
+}
+
+// IsEmpty ...
+func (l *PathLink) IsEmpty() bool {
+	return l.hostname == "" && l.path == ""
+}
+
+// IsDefaultHost ...
+func (l *PathLink) IsDefaultHost() bool {
+	return l.hostname == DefaultHost
+}
+
+// Less ...
+func (l *PathLink) Less(other *PathLink, reversePath bool) bool {
+	if l.hostname == other.hostname {
+		if reversePath {
+			return l.path > other.path
+		}
+		return l.path < other.path
+	}
+	return l.hostname < other.hostname
+}
+
+// HAMatch ...
+func (l *PathLink) HAMatch() string {
+	return haMatchMethod(l.match)
+}
+
+// Key ...
+func (l *PathLink) Key() string {
+	return buildMapKey(l.match, l.hostname, l.path)
+}

--- a/pkg/haproxy/types/tcpservices.go
+++ b/pkg/haproxy/types/tcpservices.go
@@ -33,7 +33,7 @@ func CreateTCPServices() *TCPServices {
 func (s *TCPServices) AcquireTCPService(service string) (*TCPServicePort, *TCPServiceHost) {
 	hostname, port := splitService(service)
 	tcpPort := s.acquireTCPPort(port)
-	tcpHost, found := tcpPort.acquireHost(hostname)
+	tcpHost, found := tcpPort.acquireHost(tcpPort, hostname)
 	if !found {
 		s.changed = true
 	}
@@ -134,13 +134,13 @@ func (s *TCPServicePort) isEmpty() bool {
 	return s.defaultHost == nil && len(s.hosts) == 0
 }
 
-func (s *TCPServicePort) acquireHost(hostname string) (tcpHost *TCPServiceHost, found bool) {
+func (s *TCPServicePort) acquireHost(tcpport *TCPServicePort, hostname string) (tcpHost *TCPServiceHost, found bool) {
 	if hostname == DefaultHost && s.defaultHost != nil {
 		return s.defaultHost, true
 	}
 	tcpHost, found = s.hosts[hostname]
 	if !found {
-		tcpHost = &TCPServiceHost{hostname: hostname}
+		tcpHost = &TCPServiceHost{tcpport: tcpport, hostname: hostname}
 		if hostname == DefaultHost {
 			s.defaultHost = tcpHost
 		} else {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -318,6 +318,7 @@ type TCPServicePort struct {
 
 // TCPServiceHost ...
 type TCPServiceHost struct {
+	tcpport  *TCPServicePort
 	hostname string
 	Backend  BackendID
 }
@@ -469,6 +470,11 @@ type AuthProxyBind struct {
 	SocketID        int
 }
 
+// Frontends ...
+type Frontends struct {
+	items []*Frontend
+}
+
 // Frontend ...
 type Frontend struct {
 	changed     bool
@@ -486,18 +492,16 @@ type Frontend struct {
 	//
 	RedirectFromCode int
 	RedirectToCode   int
+	//
+	// hosts
+	hosts,
+	hostsAdd,
+	hostsDel map[string]*Host
+	hasCommit bool
 }
 
 // DefaultHost ...
 const DefaultHost = "<default>"
-
-// Hosts ...
-type Hosts struct {
-	items, itemsAdd, itemsDel map[string]*Host
-	//
-	sslPassthroughCount int
-	hasCommit           bool
-}
 
 // Host ...
 //
@@ -514,11 +518,11 @@ type Host struct {
 	Redirect               HostRedirectConfig
 	HTTPPassthroughBackend string
 	RootRedirect           string
+	SSLPassthrough         bool
 	TLS                    HostTLSConfig
 	VarNamespace           bool
 	//
-	hosts          *Hosts
-	sslPassthrough bool
+	frontend *Frontend
 }
 
 // MatchType ...
@@ -561,6 +565,7 @@ type PathLinkHash string
 // or should not be applied.
 type PathLink struct {
 	hash     PathLinkHash
+	frontend string
 	hostname string
 	path     string
 	match    MatchType

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -24,9 +24,8 @@
     {{- $tcpservices := $cfg.TCPServices.BuildSortedItems }}
     {{- $backends := $cfg.Backends }}
     {{- $backendItems := $backends.BuildSortedItems }}
-    {{- $frontend := $cfg.Frontend }}
+    {{- $frontend := $cfg.Frontends.Default }}
     {{- $fmaps := $frontend.Maps }}
-    {{- $hosts := $cfg.Hosts }}
     {{- template "global" map $global }}
     {{- if $global.Peers.Servers }}
         {{- template "peers" map $global }}
@@ -46,8 +45,8 @@
     {{- if $backendItems }}
         {{- template "backends" map $global $backendItems true }}
     {{- end }}
-    {{- template "backend-support" map $global $hosts $backends }}
-    {{- template "frontends" map $global $frontend $hosts $fmaps $backends.DefaultBackend $tcpservices }}
+    {{- template "backend-support" map $global $frontend $backends }}
+    {{- template "frontends" map $global $frontend $fmaps $backends.DefaultBackend $tcpservices }}
     {{- template "frontend-support" map $global }}
 {{- else if and .Global .Backends }}
     {{- $global := .Global }}
@@ -902,10 +901,10 @@ backend {{ $backend.ID }}
 
 {{- define "backend-support" }}
 {{- $global := .p1 }}
-{{- $hosts := .p2 }}
+{{- $frontend := .p2 }}
 {{- $backends := .p3 }}
 
-{{- if $hosts.HasSSLPassthrough }}
+{{- if $frontend.HasSSLPassthrough }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -958,10 +957,9 @@ backend _error404
 {{- define "frontends" }}
 {{- $global := .p1 }}
 {{- $frontend := .p2 }}
-{{- $hosts := .p3 }}
-{{- $fmaps := .p4 }}
-{{- $defaultbackend := .p5 }}
-{{- $tcpservices := .p6 }}
+{{- $fmaps := .p3 }}
+{{- $defaultbackend := .p4 }}
+{{- $tcpservices := .p5 }}
 
 
   # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -1090,7 +1088,7 @@ frontend {{ $proxy_name }}
 {{- end }}{{/* range $tcpservices */}}
 {{- end }}{{/* has $tcpservices */}}
 
-{{- if $hosts.HasSSLPassthrough }}
+{{- if $frontend.HasSSLPassthrough }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -1132,7 +1130,7 @@ listen {{ $proxy__front__tls }}
 
 {{- /*------------------------------------*/}}
     use_backend %[var(req.sslpassback)] if { var(req.sslpassback) -m found }
-{{- $defaultHost := $hosts.DefaultHost }}
+{{- $defaultHost := $frontend.DefaultHost }}
 {{- if $defaultHost }}
 {{- if $defaultHost.SSLPassthrough }}
 {{- range $path := $defaultHost.Paths }}
@@ -1257,7 +1255,7 @@ frontend {{ $proxy__front_http }}
 {{- template "redirectTo" map $global $frontend $fmaps }}
 
 {{- /*------------------------------------*/}}
-{{- template "authExternalFrontend" map $hosts }}
+{{- template "authExternalFrontend" map $frontend }}
 
 {{- /*------------------------------------*/}}
 {{- range $match := $fmaps.HTTPHostMap.MatchFiles }}
@@ -1297,12 +1295,12 @@ frontend {{ $proxy__front_http }}
     use_backend _acme_challenge if acme-challenge
 {{- end }}
 
-{{- if $hosts.DefaultHost }}
-{{- if $hosts.DefaultHost.HTTPPassthroughBackend }}
-    use_backend {{ $hosts.DefaultHost.HTTPPassthroughBackend }}
+{{- if $frontend.DefaultHost }}
+{{- if $frontend.DefaultHost.HTTPPassthroughBackend }}
+    use_backend {{ $frontend.DefaultHost.HTTPPassthroughBackend }}
 {{- end }}
 {{- end }}
-{{- template "defaultbackend" map $hosts $defaultbackend }}
+{{- template "defaultbackend" map $frontend $defaultbackend }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -1344,7 +1342,7 @@ frontend {{ $frontend.Name }}
 {{- template "redirectTo" map $global $frontend $fmaps }}
 
 {{- /*------------------------------------*/}}
-{{- template "authExternalFrontend" map $hosts }}
+{{- template "authExternalFrontend" map $frontend }}
 
 {{- /*------------------------------------*/}}
 {{- range $match := $fmaps.HTTPSHostMap.MatchFiles }}
@@ -1398,7 +1396,7 @@ frontend {{ $frontend.Name }}
 {{- template "sourceIP" map $global }}
 
 {{- /*------------------------------------*/}}
-{{- $hasTLSAuth := or $hosts.HasTLSAuth  }}
+{{- $hasTLSAuth := or $frontend.HasTLSAuth  }}
 {{- if $hasTLSAuth }}
 {{- $mandatory := $fmaps.TLSNeedCrtList.HasHost }}
     acl tls-has-crt ssl_c_used
@@ -1461,7 +1459,7 @@ frontend {{ $frontend.Name }}
 
 {{- /*------------------------------------*/}}
 {{- if $hasTLSAuth }}
-{{- if $hosts.BuildHTTPResponses }}
+{{- if $frontend.BuildHTTPResponses }}
     http-request set-var(txn.lua_scope) var(req.host)
 {{- end }}
     http-request use-service lua.send-421 if
@@ -1487,7 +1485,7 @@ frontend {{ $frontend.Name }}
     use_backend %[var(req.snibackend)]
         {{- "" }} if { var(req.snibackend) -m found }
 {{- end }}
-{{- template "defaultbackend" map $hosts $defaultbackend }}
+{{- template "defaultbackend" map $frontend $defaultbackend }}
 
 {{- end }}{{/* has $fmaps */}}
 {{- end }}{{/* define "frontends" */}}
@@ -1594,8 +1592,8 @@ frontend {{ $frontend.Name }}
 {{- /*------------------------------------*/}}
 {{- /*------------------------------------*/}}
 {{- define "authExternalFrontend" }}
-{{- $hosts := .p1 }}
-{{- range $host := $hosts.Items }}
+{{- $frontend := .p1 }}
+{{- range $host := $frontend.Hosts }}
 {{- range $path := $host.Paths }}
 {{- if $path.AuthExt }}
 {{- template "authExternal" map $path.AuthExt (printf "{ var(req.base) -m str %s '%s' }" $path.Link.HAMatch $path.Link.Key) }}
@@ -1624,9 +1622,9 @@ frontend {{ $frontend.Name }}
 {{- /*------------------------------------*/}}
 {{- /*------------------------------------*/}}
 {{- define "defaultbackend" }}
-{{- $hosts := .p1 }}
+{{- $frontend := .p1 }}
 {{- $defaultbackend := .p2 }}
-{{- $defaultHost := $hosts.DefaultHost }}
+{{- $defaultHost := $frontend.DefaultHost }}
 {{- if $defaultHost }}
 {{- if not $defaultHost.SSLPassthrough }}
     use_backend %[var(req.defaultbackend)]


### PR DESCRIPTION
Adds the ability to configure the HTTP/s frontends with more than one HTTP port, allowing to multiplex distinct groups of hostnames without colliding each other. This is a pre-requisite to improve Gateway API support.

Several places of HAProxy Ingress code uses the dual and plain HTTP/s model as a premise, so this is a non trivial refactor. Starting the refactor from the top of the internal HAProxy model representation.

TODO list includes:

* [x] Move Hosts and Frontend types under a new Frontends type
* [x] Improve PathLink type to support distinct Frontends
* [ ] Move Bind configurations specific to frontends under the Frontend type
* [ ] Split the single HTTP/s frontend representation into two separated HTTP and HTTPs entries
* [ ] Support a list of HTTP/s frontends
* [ ] Add frontends support into Ingress API
* [ ] Add listener.Port support into Gateway API