### PR TITLE
fix reading backend ca certificate from file

### DIFF
--- a/pkg/converters/ingress/annotations/mapper.go
+++ b/pkg/converters/ingress/annotations/mapper.go
@@ -207,6 +207,18 @@ func (cv *ConfigValue) String() string {
 
 // NamespacedName ...
 func (cv *ConfigValue) NamespacedName() (namespace, name string, err error) {
+	// TODO this fixes updater.buildBackendProtocol() by allowing a proto://content approach, supported by the cache.
+	// This however seems to be wrongly implemented, since cache method signature does not match this behavior.
+	// Removing the proto parsing code from the cache seems to be a better approach, so callers have a better idea on
+	// what is happening under the hood.
+	if strings.Contains(cv.Value, "://") {
+		var ns string
+		if s := cv.Source; s != nil {
+			ns = s.Namespace
+		}
+		return ns, cv.Value, nil
+	}
+
 	value := strings.Split(cv.Value, "/")
 	if len(value) > 2 {
 		return "", "", fmt.Errorf("unpexpected format for resource name: %s", cv.Value)

--- a/tests/framework/options/server.go
+++ b/tests/framework/options/server.go
@@ -1,0 +1,32 @@
+package options
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+)
+
+type Server func(o *serverOpt)
+
+func ServerCertificates(certs []tls.Certificate) Server {
+	return func(o *serverOpt) {
+		o.Certs = certs
+	}
+}
+
+func ClientCACertificate(ca *x509.Certificate) Server {
+	return func(o *serverOpt) {
+		o.ClientCA = ca
+	}
+}
+
+type serverOpt struct {
+	Certs    []tls.Certificate
+	ClientCA *x509.Certificate
+}
+
+func ParseServerOptions(opts ...Server) (opt serverOpt) {
+	for _, o := range opts {
+		o(&opt)
+	}
+	return opt
+}


### PR DESCRIPTION
TLS backend can be configured by adding a CA secret (verify server's certificate) and/or a Crt secret (server verify client's certificate). A former controller version was reading the namespace of a secret from the ingress that configures the annotation, leading to nil dereference when the value is configured globally. This was fixed by adding a new step, that verifies if the config is global or an annotation, and if the provided name has already a name or just the name of the secret.

This new step however broke the proto://content approach added on the get secret code because it happens before getting the secret, and the proto://content syntax is incompatible with the ns/name one. This failed deployments that read ca or crt from the file system.

Should be merged as far as v0.13.