### PR TITLE
fix xfp header on fronting proxy shared port

### DIFF
--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -479,7 +479,7 @@ backend {{ $backend.ID }}
 {{- if $hasPlainHTTPSocket }}
     acl fronting-proxy so_id {{ $global.Bind.FrontingSockID }}
 {{- else }}
-    acl fronting-proxy hdr(X-Forwarded-Proto) -m found
+    acl fronting-proxy var(txn.proto) -m found
 {{- end }}
 {{- end }}
 {{- if and (not $frontingIgnoreProto) (or $backend.HasHSTS $backend.HasSSLRedirect) }}
@@ -490,11 +490,6 @@ backend {{ $backend.ID }}
 {{- end }}
 {{- if $backend.TLS.HasTLSAuth }}
     acl local-offload ssl_fc
-{{- end }}
-
-{{- /*------------------------------------*/}}
-{{- if and $frontingUseProto $backend.HasHSTS }}
-    http-request set-var(txn.proto) hdr(X-Forwarded-Proto)
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -534,7 +529,7 @@ backend {{ $backend.ID }}
 {{- if $frontingUseProto }}
     http-request redirect scheme https
         {{- if $global.SSL.RedirectCode }} code {{ $global.SSL.RedirectCode }}{{ end }}
-        {{- "" }} if fronting-proxy !{ hdr(X-Forwarded-Proto) https }
+        {{- "" }} if fronting-proxy !{ var(txn.proto) -m str https }
 {{- end }}
 
 {{- /*------------------------------------*/}}
@@ -1179,7 +1174,7 @@ frontend {{ $proxy__front_http }}
 {{- if $hasPlainHTTPSocket }}
     acl fronting-proxy so_id {{ $global.Bind.FrontingSockID }}
 {{- else }}
-    acl fronting-proxy hdr(X-Forwarded-Proto) -m found
+    acl fronting-proxy var(txn.proto) -m found
 {{- end }}
 {{- end }}
 
@@ -1206,6 +1201,9 @@ frontend {{ $proxy__front_http }}
     http-request set-var(req.path) path
     http-request set-var(req.host) hdr(host),field(1,:),lower
     http-request set-var(req.base) var(req.host),concat(\#,req.path)
+{{- if $frontingUseProto }}
+    http-request set-var(txn.proto) hdr(X-Forwarded-Proto)
+{{- end }}
 
 {{- $acmeexclusive := and $global.Acme.Enabled (not $global.Acme.Shared) }}
 

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -55,6 +55,7 @@ const (
 	PublishHostname = "ingress.local"
 
 	TestPortHTTP  = 28080
+	TestPortFront = 28081
 	TestPortHTTPS = 28443
 	TestPortStat  = 21936
 )
@@ -303,13 +304,13 @@ func (*framework) Request(ctx context.Context, t *testing.T, method, host, path 
 			}
 			assert.Equal(collect, opt.ExpectResponseCode, res.StatusCode)
 		}, 5*time.Second, time.Second)
-	case opt.ExpectX509Error != "":
+	case opt.ExpectError != "":
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_, err := cli.Do(req)
 			// better if matching some x509.<...>Error{} instead,
 			// but error.Is() does not render to true due to the server's
 			// x509 certificate attached to the error instance.
-			assert.ErrorContains(collect, err, opt.ExpectX509Error)
+			assert.ErrorContains(collect, err, opt.ExpectError)
 		}, 5*time.Second, time.Second)
 		return Response{EchoResponse: buildEchoResponse(t, "")}
 	default:

--- a/tests/framework/options/request.go
+++ b/tests/framework/options/request.go
@@ -10,9 +10,9 @@ func ExpectResponseCode(code int) Request {
 	}
 }
 
-func ExpectX509Error(msg string) Request {
+func ExpectError(msg string) Request {
 	return func(o *requestOpt) {
-		o.ExpectX509Error = msg
+		o.ExpectError = msg
 	}
 }
 
@@ -69,7 +69,7 @@ type CustomRequestCallback func(req *http.Request)
 
 type requestOpt struct {
 	ExpectResponseCode int
-	ExpectX509Error    string
+	ExpectError        string
 	Body               string
 	TLS                bool
 	TLSSkipVerify      bool

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -152,7 +153,7 @@ func TestIntegrationIngress(t *testing.T) {
 		res := f.Request(ctx, t, http.MethodGet, hostname, "/",
 			options.TLSRequest(),
 			options.SNI("localhost"), // fake certificate has `localhost` in certificates's SAN
-			options.ExpectX509Error("x509: certificate signed by unknown authority"),
+			options.ExpectError("x509: certificate signed by unknown authority"),
 		)
 		assert.False(t, res.EchoResponse.Parsed)
 	})
@@ -177,7 +178,7 @@ func TestIntegrationIngress(t *testing.T) {
 			options.TLSRequest(),
 			options.ClientCA(ca),
 			options.SNI(hostname),
-			options.ExpectX509Error("x509: certificate has expired or is not yet valid"),
+			options.ExpectError("x509: certificate has expired or is not yet valid"),
 		)
 		assert.False(t, res.EchoResponse.Parsed)
 	})
@@ -566,6 +567,122 @@ Request forbidden by administrative rules.
 			options.ExpectResponseCode(404),
 		)
 		assert.False(t, res.EchoResponse.Parsed)
+	})
+
+	t.Run("should handle proto header on fronting proxy", func(t *testing.T) {
+		// t.Parallel() // fronting proxy configuration changed, cannot run in parallel
+
+		svc := f.CreateService(ctx, t, httpServerPort)
+		_, hostname := f.CreateIngress(ctx, t, svc)
+
+		// global config to be changed
+		cm := corev1.ConfigMap{}
+		err := f.Client().Get(ctx, types.NamespacedName{Namespace: "default", Name: "ingress-controller"}, &cm)
+		require.NoError(t, err)
+
+		apply := func(t *testing.T, port int, useXFPHeader ...bool) {
+			if port > 0 {
+				cm.Data[ingtypes.GlobalFrontingProxyPort] = strconv.Itoa(port)
+				should := map[bool]string{false: "false", true: "true"}
+				cm.Data[ingtypes.GlobalUseForwardedProto] = should[useXFPHeader[0]]
+			} else {
+				delete(cm.Data, ingtypes.GlobalFrontingProxyPort)
+				delete(cm.Data, ingtypes.GlobalUseForwardedProto)
+			}
+			err = f.Client().Update(ctx, &cm)
+			require.NoError(t, err)
+			time.Sleep(3 * time.Second) // TODO need a better way to ensure the config was already applied
+		}
+
+		type reqtype string
+		const (
+			xfp = "X-Forwarded-Proto"
+
+			reqempty reqtype = ""
+			reqhttp  reqtype = "http"
+			reqhttps reqtype = "https"
+			reqredir reqtype = "<redir>"
+		)
+
+		req := func(t *testing.T, port int, xfpHeader string, expHeader reqtype) {
+			expcode := http.StatusOK
+			if expHeader == reqredir {
+				expcode = http.StatusFound
+			}
+			res := f.Request(ctx, t, http.MethodGet, hostname, "/",
+				options.CustomRequest(func(req *http.Request) {
+					if xfpHeader != "" {
+						req.Header.Set(xfp, xfpHeader)
+					}
+					req.URL.Host = fmt.Sprintf("127.0.0.1:%d", port)
+				}),
+				options.ExpectResponseCode(expcode),
+			)
+			if expHeader != reqredir {
+				assert.True(t, res.EchoResponse.Parsed)
+				assert.Equal(t, string(expHeader), res.EchoResponse.ReqHeaders[strings.ToLower(xfp)])
+			} else {
+				assert.False(t, res.EchoResponse.Parsed)
+			}
+		}
+
+		hport := framework.TestPortHTTP
+		fport := framework.TestPortFront
+		testCases := []struct {
+			frontingPort  int
+			useXFPHeader  bool
+			requestPort   int
+			expXFPMissing reqtype
+			expXFPHTTP    reqtype
+			expXFPHTTPS   reqtype
+		}{
+			// shared port
+			{frontingPort: hport, useXFPHeader: false, requestPort: hport, expXFPMissing: reqempty, expXFPHTTP: reqhttp, expXFPHTTPS: reqhttps},
+			{frontingPort: hport, useXFPHeader: true, requestPort: hport, expXFPMissing: reqhttp, expXFPHTTP: reqredir, expXFPHTTPS: reqhttps},
+
+			// dedicated port, calling `http` port
+			{frontingPort: fport, useXFPHeader: false, requestPort: hport, expXFPMissing: reqempty, expXFPHTTP: reqhttp, expXFPHTTPS: reqhttps},
+			{frontingPort: fport, useXFPHeader: true, requestPort: hport, expXFPMissing: reqhttp, expXFPHTTP: reqhttp, expXFPHTTPS: reqhttp},
+
+			// dedicated port, calling `fronting-proxy` port
+			{frontingPort: fport, useXFPHeader: false, requestPort: fport, expXFPMissing: reqempty, expXFPHTTP: reqhttp, expXFPHTTPS: reqhttps},
+			{frontingPort: fport, useXFPHeader: true, requestPort: fport, expXFPMissing: reqredir, expXFPHTTP: reqredir, expXFPHTTPS: reqhttps},
+		}
+		for _, test := range testCases {
+			nport := "shared"
+			if test.frontingPort != framework.TestPortHTTP {
+				nport = "dedicated"
+			}
+			rport := "http"
+			if test.requestPort != framework.TestPortHTTP {
+				rport = "fronting-proxy"
+			}
+			prefix := fmt.Sprintf("port=%s usexfp=%t reqport=%s reqxfp=", nport, test.useXFPHeader, rport)
+			apply(t, test.frontingPort, test.useXFPHeader)
+			t.Run(prefix+"missing", func(t *testing.T) {
+				req(t, test.requestPort, "", test.expXFPMissing)
+			})
+			t.Run(prefix+"http", func(t *testing.T) {
+				req(t, test.requestPort, "http", test.expXFPHTTP)
+			})
+			t.Run(prefix+"https", func(t *testing.T) {
+				req(t, test.requestPort, "https", test.expXFPHTTPS)
+			})
+		}
+
+		t.Run("restore global config", func(t *testing.T) {
+			apply(t, 0)
+			_ = f.Request(ctx, t, http.MethodGet, hostname, "/",
+				options.CustomRequest(func(req *http.Request) {
+					req.URL.Host = fmt.Sprintf("127.0.0.1:%d", framework.TestPortFront)
+				}),
+				options.ExpectError("connection refused"),
+			)
+
+			req(t, framework.TestPortHTTP, "", reqhttp)
+			req(t, framework.TestPortHTTP, "http", reqhttp)
+			req(t, framework.TestPortHTTP, "https", reqhttp)
+		})
 	})
 
 	t.Run("should take leader", func(t *testing.T) {


### PR DESCRIPTION
Fronting proxy configuration is incorrectly handling the X-Forwarded-Proto header sent to the backend if fronting proxy is configured in the same HTTP port: the frontend configuration overwrites the header value before its value is interpreted by the backend.

This update configures a txn var in the frontend before update the header value, so the value provided by the user is correctly handled.

Should be merged as far as the v0.13 branch.