### PR TITLE
fix lua http response having two or more options

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -3967,7 +3967,7 @@ large payload
 ]==]
         applet:set_status(413, "Payload Too Large")
         applet:add_header("content-length", "13")
-    elif scope == "default_server2_8080" then
+    elseif scope == "default_server2_8080" then
         response = [==[
 request to server2 has a large payload
 ]==]

--- a/rootfs/etc/templates/responses/responses.lua.tmpl
+++ b/rootfs/etc/templates/responses/responses.lua.tmpl
@@ -16,7 +16,7 @@ core.register_service("{{ $res.ResponseName }}", "http", function(applet)
     local scope = applet:get_var("txn.lua_scope")
     local response = ""
 {{- range $i, $lua := $res.Lua }}
-    {{ if gt $i 0 }}el{{ end }}if scope == "{{ $lua.ID }}" then
+    {{ if gt $i 0 }}else{{ end }}if scope == "{{ $lua.ID }}" then
         {{- template "lua_response" map $lua 8 }}
 {{- end }}
     else


### PR DESCRIPTION
Lua based HTTP responses are implemented via a chain of if/elseif. This update fixes the elseif token, which was incorrectly implemented as elif.