### PR TITLE
move gateway api version check to the cache

### DIFF
--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -213,7 +213,7 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		configLog.Info("watching for Gateway API resources - --watch-gateway is true")
 	}
 
-	var hasGatewayV1, hasGatewayB1, hasTCPRouteA2, hasTLSRouteA2 bool
+	var hasGateway, hasGatewayV1, hasGatewayB1, hasTCPRouteA2, hasTLSRouteA2 bool
 	if opt.WatchGateway {
 		gwapis := []string{"gatewayclass", "gateway", "httproute"}
 		tcpapis := []string{"tcproute"}
@@ -233,6 +233,7 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		gw := gwV1 || gwB1
 		hasGatewayV1 = gwV1
 		hasGatewayB1 = gwB1 && !hasGatewayV1
+		hasGateway = hasGatewayV1 || hasGatewayB1
 
 		tcpA2 := configHasAPI(clientGateway.Discovery(), gatewayv1alpha2.GroupVersion, tcpapis...)
 		if tcpA2 {
@@ -506,6 +507,7 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		ElectionID:               electionID,
 		ElectionNamespace:        controllerPod.Namespace,
 		ForceNamespaceIsolation:  opt.ForceIsolation,
+		HasGateway:               hasGateway,
 		HasGatewayB1:             hasGatewayB1,
 		HasGatewayV1:             hasGatewayV1,
 		HasTCPRouteA2:            hasTCPRouteA2,
@@ -762,6 +764,7 @@ type Config struct {
 	ElectionID               string
 	ElectionNamespace        string
 	ForceNamespaceIsolation  bool
+	HasGateway               bool
 	HasGatewayB1             bool
 	HasGatewayV1             bool
 	HasTCPRouteA2            bool

--- a/pkg/controller/reconciler/watchers.go
+++ b/pkg/controller/reconciler/watchers.go
@@ -295,14 +295,14 @@ func (w *watchers) handlersGatewayv1beta1() []*hdlr {
 				predicate.GenerationChangedPredicate{},
 				predicate.Funcs{
 					CreateFunc: func(ce event.CreateEvent) bool {
-						return w.val.IsValidGatewayClassB1(ce.Object.(*gatewayv1beta1.GatewayClass))
+						return w.val.IsValidGatewayClass((*gatewayv1.GatewayClass)(ce.Object.(*gatewayv1beta1.GatewayClass)))
 					},
 					DeleteFunc: func(de event.DeleteEvent) bool {
-						return w.val.IsValidGatewayClassB1(de.Object.(*gatewayv1beta1.GatewayClass))
+						return w.val.IsValidGatewayClass((*gatewayv1.GatewayClass)(de.Object.(*gatewayv1beta1.GatewayClass)))
 					},
 					UpdateFunc: func(ue event.UpdateEvent) bool {
-						return w.val.IsValidGatewayClassB1(ue.ObjectOld.(*gatewayv1beta1.GatewayClass)) ||
-							w.val.IsValidGatewayClassB1(ue.ObjectNew.(*gatewayv1beta1.GatewayClass))
+						return w.val.IsValidGatewayClass((*gatewayv1.GatewayClass)(ue.ObjectOld.(*gatewayv1beta1.GatewayClass))) ||
+							w.val.IsValidGatewayClass((*gatewayv1.GatewayClass)(ue.ObjectNew.(*gatewayv1beta1.GatewayClass)))
 					},
 				},
 			},

--- a/pkg/controller/services/services.go
+++ b/pkg/controller/services/services.go
@@ -164,10 +164,7 @@ func (s *Services) setup(ctx context.Context) error {
 		DisableKeywords:  cfg.DisableKeywords,
 		AcmeTrackTLSAnn:  cfg.AcmeTrackTLSAnn,
 		TrackInstances:   cfg.TrackOldInstances,
-		HasGatewayB1:     cfg.HasGatewayB1,
-		HasGatewayV1:     cfg.HasGatewayV1,
-		HasTCPRouteA2:    cfg.HasTCPRouteA2,
-		HasTLSRouteA2:    cfg.HasTLSRouteA2,
+		HasGateway:       cfg.HasGateway,
 	}
 	instance := haproxy.CreateInstance(s.legacylogger.new("haproxy"), instanceOptions)
 	if err := instance.ParseTemplates(); err != nil {

--- a/pkg/controller/services/types.go
+++ b/pkg/controller/services/types.go
@@ -19,13 +19,10 @@ package services
 import (
 	networking "k8s.io/api/networking/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // IsValidResource ...
 type IsValidResource interface {
-	IsValidGatewayB1(gw *gatewayv1beta1.Gateway) bool
-	IsValidGatewayClassB1(gwcls *gatewayv1beta1.GatewayClass) bool
 	IsValidGateway(gw *gatewayv1.Gateway) bool
 	IsValidGatewayClass(gwcls *gatewayv1.GatewayClass) bool
 	IsValidIngress(ing *networking.Ingress) bool

--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -23,9 +23,6 @@ import (
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
-
-	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 // Config ...
@@ -74,13 +71,8 @@ func (c *converters) Sync() {
 	//
 	// gateway converter
 	//
-	if c.options.HasGatewayV1 {
-		gatewayConverter.Sync(needFullSync, &gatewayv1.Gateway{})
-	}
-	if c.options.HasGatewayB1 {
-		gatewayConverter.Sync(needFullSync, &gatewayv1beta1.Gateway{})
-	}
-	if c.options.HasGatewayB1 || c.options.HasGatewayV1 {
+	if c.options.HasGateway && needFullSync {
+		gatewayConverter.SyncFull()
 		c.timer.Tick("parse_gateway")
 	}
 

--- a/pkg/converters/gateway/gateway_test.go
+++ b/pkg/converters/gateway/gateway_test.go
@@ -863,7 +863,7 @@ func runTestSync(t *testing.T, testCases []testCaseSync) {
 			// ch.Links reflects changes made by the watcher
 			hasChanges := len(c.cache.Changed.Links) > 0
 			conv := c.createConverter()
-			conv.Sync(true, &gatewayv1.Gateway{})
+			conv.SyncFull()
 
 			if hasChanges {
 				c.hconfig.Commit()
@@ -922,11 +922,10 @@ func setup(t *testing.T) *testConfig {
 func (c *testConfig) createConverter() gateway.Config {
 	return gateway.NewGatewayConverter(
 		&convtypes.ConverterOptions{
-			Cache:         c.cache,
-			Logger:        c.logger,
-			Tracker:       c.tracker,
-			HasTLSRouteA2: true,
-			HasTCPRouteA2: true,
+			Cache:      c.cache,
+			Logger:     c.logger,
+			Tracker:    c.tracker,
+			HasGateway: true,
 		},
 		c.hconfig,
 		c.cache.LegacySwapObjects(),

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/tracker"
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
@@ -125,11 +124,6 @@ func (c *CacheMock) GetIngressClass(className string) (*networking.IngressClass,
 }
 
 // GetHTTPRouteList ...
-func (c *CacheMock) GetHTTPRouteB1List() ([]*gatewayv1beta1.HTTPRoute, error) {
-	return nil, fmt.Errorf("missing implementation")
-}
-
-// GetHTTPRouteList ...
 func (c *CacheMock) GetHTTPRouteList() ([]*gatewayv1.HTTPRoute, error) {
 	return c.HTTPRouteList, nil
 }
@@ -140,11 +134,6 @@ func (c *CacheMock) GetTCPRouteList() ([]*gatewayv1alpha2.TCPRoute, error) {
 
 func (c *CacheMock) GetTLSRouteList() ([]*gatewayv1alpha2.TLSRoute, error) {
 	return c.TLSRouteList, nil
-}
-
-// GetGatewayB1 ...
-func (c *CacheMock) GetGatewayB1(namespace, name string) (*gatewayv1beta1.Gateway, error) {
-	return nil, fmt.Errorf("missing implementation")
 }
 
 // GetGateway ...

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 )
@@ -38,9 +37,7 @@ type Cache interface {
 	GetIngress(ingressName string) (*networking.Ingress, error)
 	GetIngressList() ([]*networking.Ingress, error)
 	GetIngressClass(className string) (*networking.IngressClass, error)
-	GetGatewayB1(namespace, name string) (*gatewayv1beta1.Gateway, error)
 	GetGateway(namespace, name string) (*gatewayv1.Gateway, error)
-	GetHTTPRouteB1List() ([]*gatewayv1beta1.HTTPRoute, error)
 	GetHTTPRouteList() ([]*gatewayv1.HTTPRoute, error)
 	GetTCPRouteList() ([]*gatewayv1alpha2.TCPRoute, error)
 	GetTLSRouteList() ([]*gatewayv1alpha2.TLSRoute, error)

--- a/pkg/converters/types/options.go
+++ b/pkg/converters/types/options.go
@@ -40,10 +40,7 @@ type ConverterOptions struct {
 	DisableKeywords  []string
 	AcmeTrackTLSAnn  bool
 	TrackInstances   bool
-	HasGatewayB1     bool
-	HasGatewayV1     bool
-	HasTCPRouteA2    bool
-	HasTLSRouteA2    bool
+	HasGateway       bool
 }
 
 // DynamicConfig ...


### PR DESCRIPTION
Simplifies the Cache facade by moving the Gateway version check from the converter to the cache. Instead of making the converter to identify which cache method should be called, the cache method itself checks the version and converts the api version if needed.

Gateway converter implementation has also a huge improvement: since the code needs to deal with a single version per API, code could be refactored in a way it has a better reuse.

An internal behavior was changed as well: whenever an undeployed/ unsupported api version endpoint is used, getlist() will return an empty list and get() will return a 404 compatible error, so converters just need to make their ordinary calls and handle the same errors as usual without the need to check supported api versions.