### PR TITLE
fix full-sync trigger

### DIFF
--- a/pkg/controller/reconciler/reconciler.go
+++ b/pkg/controller/reconciler/reconciler.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	k8sworkqueue "k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,13 +39,10 @@ type IngressReconciler struct {
 	//
 	log      logr.Logger
 	watchers *watchers
-	queue    k8sworkqueue.TypedRateLimitingInterface[rparam]
 }
 
 // rparam defines reconciliation parameters
 type rparam struct {
-	// fullsync defines if fullsync reconciliation should be enabled
-	fullsync bool
 }
 
 // Reconcile ...
@@ -55,7 +51,6 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req rparam) (ctrl.Res
 		return ctrl.Result{}, err
 	}
 	changed := r.watchers.getChangedObjects()
-	changed.NeedFullSync = req.fullsync
 	err := r.Services.ReconcileIngress(ctx, changed)
 	if err != nil {
 		r.log.Error(err, fmt.Sprintf("error reconciling ingress, retrying in %s", r.Config.ReloadRetry.String()))
@@ -67,7 +62,7 @@ func (r *IngressReconciler) Reconcile(ctx context.Context, req rparam) (ctrl.Res
 func (r *IngressReconciler) leaderChanged(ctx context.Context, isLeader bool) {
 	if isLeader && r.watchers.running() {
 		r.log.Info("enqueue reconciliation due to leader acquired")
-		r.queue.AddRateLimited(rparam{fullsync: true})
+		r.watchers.addRateLimited(true)
 	}
 }
 
@@ -76,13 +71,7 @@ func (r *IngressReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manag
 	r.log = logr.FromContextOrDiscard(ctx).WithName("ingress")
 	r.watchers = createWatchers(ctx, r.Config, r.Services.GetIsValidResource())
 	opt := controller.TypedOptions[rparam]{
-		LogConstructor: func(*rparam) logr.Logger { return logr.FromContextOrDiscard(ctx).WithName("reconciler") },
-		NewQueue: func(controllerName string, rateLimiter k8sworkqueue.TypedRateLimiter[rparam]) k8sworkqueue.TypedRateLimitingInterface[rparam] {
-			r.queue = k8sworkqueue.NewTypedRateLimitingQueueWithConfig(rateLimiter, k8sworkqueue.TypedRateLimitingQueueConfig[rparam]{
-				Name: controllerName,
-			})
-			return r.queue
-		},
+		LogConstructor:     func(*rparam) logr.Logger { return logr.FromContextOrDiscard(ctx).WithName("reconciler") },
 		RateLimiter:        workqueue.IngressReconcilerRateLimiter[rparam](r.Config.RateLimitUpdate, r.Config.WaitBeforeUpdate),
 		Reconciler:         r,
 		RecoverPanic:       ptr.To(true),

--- a/pkg/controller/reconciler/watchers.go
+++ b/pkg/controller/reconciler/watchers.go
@@ -45,6 +45,7 @@ import (
 
 func createWatchers(ctx context.Context, cfg *config.Config, val services.IsValidResource) *watchers {
 	w := &watchers{
+		q:   make(chan event.GenericEvent),
 		log: logr.FromContextOrDiscard(ctx).WithName("watchers"),
 		cfg: cfg,
 		val: val,
@@ -55,6 +56,7 @@ func createWatchers(ctx context.Context, cfg *config.Config, val services.IsVali
 
 type watchers struct {
 	mu  sync.Mutex
+	q   chan event.GenericEvent
 	ch  *types.ChangedObjects
 	log logr.Logger
 	cfg *config.Config
@@ -116,6 +118,15 @@ func (w *watchers) running() bool {
 	return w.run
 }
 
+func (w *watchers) addRateLimited(fullsync bool) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if fullsync {
+		w.ch.NeedFullSync = true
+	}
+	w.q <- event.GenericEvent{}
+}
+
 func (w *watchers) handlersCore() []*hdlr {
 	cmChange := func(o client.Object) {
 		cm := o.(*api.ConfigMap)
@@ -128,6 +139,9 @@ func (w *watchers) handlersCore() []*hdlr {
 		}
 	}
 	return []*hdlr{
+		{
+			q: w.q,
+		},
 		{
 			typ: &api.ConfigMap{},
 			res: types.ResourceConfigMap,
@@ -387,6 +401,7 @@ func (w *watchers) handlersTLSRoutev1alpha2() []*hdlr {
 
 type hdlr struct {
 	w   *watchers
+	q   <-chan event.GenericEvent
 	typ client.Object
 	res types.ResourceType
 	pr  []predicate.Predicate
@@ -398,7 +413,13 @@ type hdlr struct {
 }
 
 func (h *hdlr) getSource(c cache.Cache) source.TypedSource[rparam] {
-	return source.TypedKind(c, h.typ, h, h.pr...)
+	switch {
+	case h.q != nil:
+		return source.TypedChannel(h.q, h)
+	case h.typ != nil:
+		return source.TypedKind(c, h.typ, h, h.pr...)
+	}
+	panic(fmt.Errorf("either queue channel or resource type should be configured in controller handler"))
 }
 
 func (h *hdlr) Create(ctx context.Context, e event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[rparam]) {
@@ -434,7 +455,6 @@ func (h *hdlr) Delete(ctx context.Context, e event.TypedDeleteEvent[client.Objec
 func (h *hdlr) Generic(ctx context.Context, e event.TypedGenericEvent[client.Object], q workqueue.TypedRateLimitingInterface[rparam]) {
 	h.w.mu.Lock()
 	defer h.w.mu.Unlock()
-	h.w.ch.NeedFullSync = true
 	h.notify("generic", e.Object, q)
 }
 
@@ -459,8 +479,12 @@ func (h *hdlr) notify(event string, o client.Object, q workqueue.TypedRateLimiti
 	if h.full {
 		h.w.ch.NeedFullSync = true
 	}
-	q.AddRateLimited(rparam{fullsync: h.full})
+	q.AddRateLimited(rparam{})
 	if h.w.run {
-		h.w.log.Info("notify", "event", event, "kind", reflect.TypeOf(o), "namespace", o.GetNamespace(), "name", o.GetName())
+		log := h.w.log.WithValues("event", event)
+		if o != nil {
+			log = log.WithValues("kind", reflect.TypeOf(o).String(), "namespace", o.GetNamespace(), "name", o.GetName())
+		}
+		log.Info("notify")
 	}
 }


### PR DESCRIPTION
Full sync is used whenever controller needs to parse all the Ingress and Gateway API resources, e.g. when a global is changed. Some internal events like acquire leader also leads to a full sync, but in this case there is no changed object.

Our previous approach to run full-sync without object being changed was parameterize a full-sync flag in the request object, but this might misbehave in the case there is also a non full-sync event in the queue, and converter needs to deal with the changed objects on the full-sync event.

So instead of hacking the internal work queue from the controller-runtime's controller, we're now using the generic event that can be triggered via a channel.

This fix should be merged up to v0.15.