### PR TITLE
fix status update during shutdown

### DIFF
--- a/pkg/controller/services/cache.go
+++ b/pkg/controller/services/cache.go
@@ -592,16 +592,31 @@ func (c *c) GetPasswdSecretContent(defaultNamespace, secretName string, track []
 	return data, nil
 }
 
-func (c *c) UpdateStatus(namedObj client.Object, apply func() bool) error {
-	if !c.leader {
+func (c *c) UpdateStatus(namedObj client.Object, apply func() bool, opts ...convtypes.CacheOptions) error {
+	var opt convtypes.CacheOptions
+	if len(opts) > 0 {
+		opt = opts[0]
+	}
+	// should proceed only if this controller is the leader, or in the case it is not, caller asked to skip this check
+	proceed := c.leader || opt.SkipLeaderCheck
+	if !proceed {
 		return nil
 	}
+	ctx := c.ctx
+	if ctx.Err() != nil {
+		// Controller is shutting down, need a new context to write the status.
+		// Read comes from the cache, so it does not use context.
+		// TODO: Cache refactor should consider dropping the internal context, asking one from the caller.
+		var cancel func()
+		ctx, cancel = context.WithTimeout(context.Background(), *c.config.ShutdownTimeout/5) // 5s in the default config
+		defer cancel()
+	}
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		if err := c.client.Get(c.ctx, client.ObjectKeyFromObject(namedObj), namedObj); err != nil {
+		if err := c.client.Get(ctx, client.ObjectKeyFromObject(namedObj), namedObj); err != nil {
 			return err
 		}
 		if apply() {
-			return c.client.Status().Update(c.ctx, namedObj)
+			return c.client.Status().Update(ctx, namedObj)
 		}
 		return nil
 	})

--- a/pkg/controller/services/svcaddress.go
+++ b/pkg/controller/services/svcaddress.go
@@ -111,6 +111,7 @@ func (s *svcAddress) update(_ context.Context, lb []networking.IngressLoadBalanc
 	if err != nil {
 		return err
 	}
+	s.log.Info("checking address status", "ingress-count", len(ingList))
 	var errs []error
 	for _, ing := range ingList {
 		if err := s.updateIngressStatus(ing.Namespace, ing.Name, lb); err != nil {
@@ -143,7 +144,7 @@ func (s *svcAddress) updateIngressStatus(namespace, name string, lb []networking
 		ing.Status.LoadBalancer.Ingress = lb
 		changed = true
 		return true
-	})
+	}, convtypes.CacheOptions{SkipLeaderCheck: true})
 	if err != nil {
 		return err
 	}

--- a/pkg/converters/helper_test/cachemock.go
+++ b/pkg/converters/helper_test/cachemock.go
@@ -277,7 +277,9 @@ func (c *CacheMock) GetPasswdSecretContent(defaultNamespace, secretName string, 
 }
 
 // UpdateStatus ...
-func (c *CacheMock) UpdateStatus(namedObj client.Object, apply func() bool) error { return nil }
+func (c *CacheMock) UpdateStatus(namedObj client.Object, apply func() bool, opt ...convtypes.CacheOptions) error {
+	return nil
+}
 
 // LegacySwapObjects ...
 func (c *CacheMock) LegacySwapObjects() *convtypes.ChangedObjects {

--- a/pkg/converters/types/interfaces.go
+++ b/pkg/converters/types/interfaces.go
@@ -52,8 +52,12 @@ type Cache interface {
 	GetCASecretPath(defaultNamespace, secretName string, track []TrackingRef) (ca, crl File, err error)
 	GetDHSecretPath(defaultNamespace, secretName string) (File, error)
 	GetPasswdSecretContent(defaultNamespace, secretName string, track []TrackingRef) ([]byte, error)
-	UpdateStatus(namedObj client.Object, apply func() bool) error
+	UpdateStatus(namedObj client.Object, apply func() bool, opt ...CacheOptions) error
 	GetEndpointSlices(service *api.Service) ([]*discoveryv1.EndpointSlice, error)
+}
+
+type CacheOptions struct {
+	SkipLeaderCheck bool
 }
 
 // ChangedObjects ...


### PR DESCRIPTION
Address status are removed from ingress resources in the case controller detects it is the last instance running. This behavior is configurable. The status update during the shutdown is not working because:

* Controller is not the leader anymore, and status updates only happen in the leader;
* Internal context is already cancelled, making the status not to be updated.

This change is parameterizing status update so it ignores the leader state during the shutdown event. A new context is also being used.

This fix should be merged up to v0.15.