### PR TITLE
add reload with websocket connection test

### DIFF
--- a/tests/framework/options/request.go
+++ b/tests/framework/options/request.go
@@ -16,6 +16,15 @@ func ExpectError(msg string) Request {
 	}
 }
 
+func SetHeader(key, value string) Request {
+	return func(o *requestOpt) {
+		if o.ReqHeaders == nil {
+			o.ReqHeaders = make(map[string]string)
+		}
+		o.ReqHeaders[key] = value
+	}
+}
+
 func Body(body string) Request {
 	return func(o *requestOpt) {
 		o.Body = body
@@ -76,6 +85,7 @@ type CustomRequestCallback func(req *http.Request)
 type requestOpt struct {
 	ExpectResponseCode int
 	ExpectError        string
+	ReqHeaders         map[string]string
 	Body               string
 	TLS                bool
 	TLSSkipVerify      bool

--- a/tests/framework/options/server.go
+++ b/tests/framework/options/server.go
@@ -19,9 +19,16 @@ func ClientCACertificate(ca *x509.Certificate) Server {
 	}
 }
 
+func WebsocketMessages(ch chan<- string) Server {
+	return func(o *serverOpt) {
+		o.WSMessage = ch
+	}
+}
+
 type serverOpt struct {
-	Certs    []tls.Certificate
-	ClientCA *x509.Certificate
+	Certs     []tls.Certificate
+	ClientCA  *x509.Certificate
+	WSMessage chan<- string
 }
 
 func ParseServerOptions(opts ...Server) (opt serverOpt) {


### PR DESCRIPTION
Add an integration test checking if websocket connections continue available after haproxy reload. Old haproxy instances should continue running and allowing data from/to already established connections.