### PR TITLE
check if process is the same waiting for reload

### DIFF
--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -737,13 +737,13 @@ func (i *instance) reloadEmbeddedMasterWorker() error {
 		if err := i.waitMaster(); err != nil {
 			return err
 		}
-		return i.waitWorker(-1) // very first check, current reload count is 0, so "previous" is "-1"
+		return i.waitWorker(socket.Proc{Reloads: -1}) // very first check, current reload count is 0, so "previous" is "-1"
 	}
-	prevReloads, err := i.reloadWorker()
+	prevProc, err := i.reloadWorker()
 	if err != nil {
 		return err
 	}
-	return i.waitWorker(prevReloads)
+	return i.waitWorker(prevProc)
 }
 
 func (i *instance) startHAProxySync(ctx context.Context) {
@@ -799,11 +799,11 @@ func (i *instance) reloadExternal() error {
 			return err
 		}
 	}
-	prevReloads, err := i.reloadWorker()
+	prevProc, err := i.reloadWorker()
 	if err != nil {
 		return err
 	}
-	return i.waitWorker(prevReloads)
+	return i.waitWorker(prevProc)
 }
 
 func (i *instance) waitMaster() error {
@@ -830,7 +830,7 @@ func (i *instance) waitMaster() error {
 	}
 }
 
-func (i *instance) reloadWorker() (int, error) {
+func (i *instance) reloadWorker() (socket.Proc, error) {
 	if i.config.Global().LoadServerState {
 		if err := i.persistServersState(); err != nil {
 			i.logger.Warn("failed to persist servers state before worker reload: %w", err)
@@ -838,25 +838,25 @@ func (i *instance) reloadWorker() (int, error) {
 	}
 	procs, err := socket.HAProxyProcs(i.options.StopCtx, i.conns.Master())
 	if err != nil {
-		return 0, fmt.Errorf("error reading haproxy procs: %w", err)
+		return socket.Proc{}, fmt.Errorf("error reading haproxy procs: %w", err)
 	}
 	out, err := i.conns.Master().Send(nil, "reload")
 	if err != nil {
-		return 0, fmt.Errorf("error sending reload to master socket: %w", err)
+		return socket.Proc{}, fmt.Errorf("error sending reload to master socket: %w", err)
 	}
 	if len(out) > 0 && strings.HasPrefix(out[0], "Success=0") {
 		// Taking advantage of the response on haproxy 2.7+
 		// Note that on 2.6 and older the response is empty, so we need to compare
 		// a failure output instead, since empty is also considered valid.
 		// `procs.Master.Reloads` checks for proper reload on 2.6 and older.
-		return 0, fmt.Errorf("error reloading haproxy: %s", strings.Join(out, "\n"))
+		return socket.Proc{}, fmt.Errorf("error reloading haproxy: %s", strings.Join(out, "\n"))
 	}
-	return procs.Master.Reloads, nil
+	return procs.Master, nil
 }
 
-func (i *instance) waitWorker(prevReloads int) error {
+func (i *instance) waitWorker(prevProc socket.Proc) error {
 	out, err := socket.HAProxyProcs(i.options.StopCtx, i.conns.Master())
-	for err == nil && out.Master.Reloads <= prevReloads {
+	for err == nil && out.Master.PID == prevProc.PID && out.Master.Reloads <= prevProc.Reloads {
 		// Continues to wait until we can see `Reloads` greater than the previous one.
 		// This is needed on 2.6 and older, whose `reload` command runs async.
 		select {
@@ -864,7 +864,7 @@ func (i *instance) waitWorker(prevReloads int) error {
 		case <-i.options.StopCtx.Done():
 			return fmt.Errorf("received sigterm")
 		}
-		i.logger.Info("reconnecting master socket. current-reloads=%d prev-reloads=%d", out.Master.Reloads, prevReloads)
+		i.logger.Info("reconnecting master socket. pid=%d current-reloads=%d prev-reloads=%d", out.Master.PID, out.Master.Reloads, prevProc.Reloads)
 		out, err = socket.HAProxyProcs(i.options.StopCtx, i.conns.Master())
 	}
 	if err != nil {


### PR DESCRIPTION
HAProxy up to 2.6 runs the reload command async, so we need to wait until we identify that haproxy finished reloading, succeeding or not. This is done by checking if the number of reloads increased. We however does not check if the process continues to be the same, in that case we'd see the reload count decreasing. This update checks not only the number of reloads, but also the process ID of the previous and the current HAProxy instance.