### PR TITLE
fixes wildcard match for gateway api

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -122,6 +122,7 @@ expfront
 explogging
 expmatch
 extfile
+extwild
 fcgiapp
 feb
 ffconf

--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -784,6 +784,7 @@ func (c *converter) createHTTPHosts(gatewaySource, routeSource *source, listener
 				hstr = hatypes.DefaultHost
 			}
 			h := frontend.AcquireHost(hstr)
+			h.ExtendedWildcard = true
 			pathlink := hatypes.CreatePathLink(path, haMatch).WithHTTPHost(h)
 			var haheaders hatypes.HTTPHeaderMatch
 			for _, header := range match.Headers {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -534,6 +534,7 @@ type Host struct {
 	//
 	Alias               HostAliasConfig
 	CustomHTTPResponses HTTPResponses
+	ExtendedWildcard    bool
 	Redirect            HostRedirectConfig
 	RootRedirect        string
 	SSLPassthrough      bool


### PR DESCRIPTION
Gateway API spec states that a hostname prefixed with wildcard should match one or more subdomains, instead of the single one implemented on HAProxy Ingress. This update add a parameter on the host level, so hostnames configured via Gateway API can change the wildcard match behavior on a backward compatible way.