### PR TITLE
consider http header filter when sorting paths

### DIFF
--- a/pkg/converters/helper_test/marshal.go
+++ b/pkg/converters/helper_test/marshal.go
@@ -151,6 +151,12 @@ func marshalHosts(hafronts ...*hatypes.Host) []hostMock {
 				})
 			}
 			paths = append(paths, pathMock{Path: p.Path(), Match: match, Headers: hmock, BackendID: p.Backend.ID})
+			// TODO: We used to sort on hosts.go/addLink(), but this ordering was moved deeper inside haproxy model.
+			// Lots of our converter tests consider sorted paths, but probably it is better to remove this sort from
+			// here and fix the tests instead.
+			sort.Slice(paths, func(i, j int) bool {
+				return paths[i].Path > paths[j].Path
+			})
 		}
 		hosts = append(hosts, hostMock{
 			Hostname:     f.Hostname,

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1058,11 +1058,11 @@ d1.local#/ path01`,
     # path01 = d1.local/
     # path04 = d1.local/app1
     # path05 = d1.local/app2
-    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_d1_app_8080_front_http_req__prefix_01.map) if { hdr(x-user) -- 'myusr2' }
-    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_d1_app_8080_front_http_req__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'myusr1' }
+    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_d1_app_8080_front_http_req__prefix_01.map) if { hdr(x-user) -- 'myusr1' }
+    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_d1_app_8080_front_http_req__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'myusr2' }
     http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_front_http_req__begin.map) if !{ var(txn.pathID) -m found }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_d1_app_8080_front_http_def__prefix_01.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'myusr2' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_d1_app_8080_front_http_def__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'myusr1' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_d1_app_8080_front_http_def__prefix_01.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'myusr1' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_d1_app_8080_front_http_def__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'myusr2' }
     http-request use-service lua.send-413 if { var(txn.pathID) -m str path02 path04 } { req.body_size,sub(1048576) gt 0 }
     http-request use-service lua.send-413 if { var(txn.pathID) -m str path03 path05 } { req.body_size,sub(2097152) gt 0 }`,
 			expFronts: `frontend _front_http
@@ -1079,11 +1079,11 @@ d1.local#/ path01`,
     use_backend %[var(req.defaultbackend)]
     default_backend _error404`,
 			expCheck: map[string]string{
-				"_back_d1_app_8080_front_http_req__prefix_01.map": "d1.local#/app2 path05",
-				"_back_d1_app_8080_front_http_req__prefix_02.map": "d1.local#/app1 path04",
+				"_back_d1_app_8080_front_http_req__prefix_01.map": "d1.local#/app1 path04",
+				"_back_d1_app_8080_front_http_req__prefix_02.map": "d1.local#/app2 path05",
 				"_back_d1_app_8080_front_http_req__begin.map":     "d1.local#/ path01",
-				"_back_d1_app_8080_front_http_def__prefix_01.map": "<default>#/app2 path03",
-				"_back_d1_app_8080_front_http_def__prefix_02.map": "<default>#/app1 path02",
+				"_back_d1_app_8080_front_http_def__prefix_01.map": "<default>#/app1 path02",
+				"_back_d1_app_8080_front_http_def__prefix_02.map": "<default>#/app2 path03",
 			},
 		},
 		"test68": {
@@ -2769,8 +2769,8 @@ func TestInstanceDefaultHostMultiFrontend(t *testing.T) {
 			hasHTTPFilter: true, hasReqHost: false, hasFrontACL: false,
 			expFront: frontHasFilterNoreq,
 			expBack: pathsNoreqNoacl + `
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_01.map) if { hdr(x-user) -- 'user2' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user1' }` +
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_01.map) if { hdr(x-user) -- 'user1' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user2' }` +
 				has2paths,
 		},
 		"test06": {
@@ -2778,20 +2778,20 @@ func TestInstanceDefaultHostMultiFrontend(t *testing.T) {
 			expFront: frontHasFilterNoreq,
 			expBack: pathsNoreqHasacl + `
     http-request set-var-fmt(req.fe) "%f"
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_01.map) if { var(req.fe) -m str _front_http_8001 } { hdr(x-user) -- 'user2' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_02.map) if { var(req.fe) -m str _front_http_8001 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user1' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_def__prefix_01.map) if { var(req.fe) -m str _front_http_8002 } { hdr(x-user) -- 'user2' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_def__prefix_02.map) if { var(req.fe) -m str _front_http_8002 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user1' }` +
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_01.map) if { var(req.fe) -m str _front_http_8001 } { hdr(x-user) -- 'user1' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_02.map) if { var(req.fe) -m str _front_http_8001 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user2' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_def__prefix_01.map) if { var(req.fe) -m str _front_http_8002 } { hdr(x-user) -- 'user1' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_def__prefix_02.map) if { var(req.fe) -m str _front_http_8002 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user2' }` +
 				has4pathsv2,
 		},
 		"test07": {
 			hasHTTPFilter: true, hasReqHost: true, hasFrontACL: false,
 			expFront: frontHasFilterHasreq,
 			expBack: pathsHasreqNoacl + `
-    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_req__prefix_01.map) if { hdr(x-user) -- 'user2' }
-    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_req__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user1' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_01.map) if { hdr(x-user) -- 'user2' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user1' }` +
+    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_req__prefix_01.map) if { hdr(x-user) -- 'user1' }
+    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_req__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user2' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_01.map) if { hdr(x-user) -- 'user1' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_02.map) if !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user2' }` +
 				has4pathsv1,
 		},
 		"test08": {
@@ -2799,14 +2799,14 @@ func TestInstanceDefaultHostMultiFrontend(t *testing.T) {
 			expFront: frontHasFilterHasreq,
 			expBack: pathsHasreqHasacl + `
     http-request set-var-fmt(req.fe) "%f"
-    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_req__prefix_01.map) if { var(req.fe) -m str _front_http_8001 } { hdr(x-user) -- 'user2' }
-    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_req__prefix_02.map) if { var(req.fe) -m str _front_http_8001 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user1' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_01.map) if { var(req.fe) -m str _front_http_8001 } { hdr(x-user) -- 'user2' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_02.map) if { var(req.fe) -m str _front_http_8001 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user1' }
-    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_req__prefix_01.map) if { var(req.fe) -m str _front_http_8002 } { hdr(x-user) -- 'user2' }
-    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_req__prefix_02.map) if { var(req.fe) -m str _front_http_8002 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user1' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_def__prefix_01.map) if { var(req.fe) -m str _front_http_8002 } { hdr(x-user) -- 'user2' }
-    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_def__prefix_02.map) if { var(req.fe) -m str _front_http_8002 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user1' }` +
+    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_req__prefix_01.map) if { var(req.fe) -m str _front_http_8001 } { hdr(x-user) -- 'user1' }
+    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_req__prefix_02.map) if { var(req.fe) -m str _front_http_8001 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user2' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_01.map) if { var(req.fe) -m str _front_http_8001 } { hdr(x-user) -- 'user1' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8001_def__prefix_02.map) if { var(req.fe) -m str _front_http_8001 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user2' }
+    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_req__prefix_01.map) if { var(req.fe) -m str _front_http_8002 } { hdr(x-user) -- 'user1' }
+    http-request set-var(txn.pathID) var(req.base),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_req__prefix_02.map) if { var(req.fe) -m str _front_http_8002 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user2' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_def__prefix_01.map) if { var(req.fe) -m str _front_http_8002 } { hdr(x-user) -- 'user1' }
+    http-request set-var(txn.pathID) str(<default>\#),concat(,req.path),map_dir(/etc/haproxy/maps/_back_default_app_8080_front_http_8002_def__prefix_02.map) if { var(req.fe) -m str _front_http_8002 } !{ var(txn.pathID) -m found } { hdr(x-user) -- 'user2' }` +
 				has8paths,
 		},
 	}

--- a/pkg/haproxy/types/host.go
+++ b/pkg/haproxy/types/host.go
@@ -18,7 +18,6 @@ package types
 
 import (
 	"fmt"
-	"sort"
 
 	"k8s.io/utils/ptr"
 )
@@ -76,15 +75,8 @@ func (h *Host) addLink(backend *Backend, link *PathLink, redirTo string) *Path {
 		path.Backend = backend
 	}
 	h.Paths = append(h.Paths, path)
-	// reverse order in order to avoid overlap of sub-paths
-	sort.Slice(h.Paths, func(i, j int) bool {
-		p1 := h.Paths[i]
-		p2 := h.Paths[j]
-		if p1.Link.path == p2.Link.path {
-			return p1.order < p2.order
-		}
-		return p1.Link.path > p2.Link.path
-	})
+	// paths must be sorted to avoid misbehavior due to overlap,
+	// this is happening later on maps.go/rebuildMatchFiles()
 	return path
 }
 

--- a/pkg/haproxy/types/host_test.go
+++ b/pkg/haproxy/types/host_test.go
@@ -133,7 +133,6 @@ func TestAddFindPath(t *testing.T) {
 	}
 	testCases := []struct {
 		paths     []path
-		order     []string
 		findPath  string
 		findMatch []MatchType
 		found     []string
@@ -145,7 +144,6 @@ func TestAddFindPath(t *testing.T) {
 				{backend: b2, path: "/app", match: MatchBegin},
 				{backend: b3, path: "/login", match: MatchBegin},
 			},
-			order:     []string{"b3", "b2", "b1"},
 			findPath:  "/",
 			findMatch: []MatchType{MatchExact},
 			found:     []string{},
@@ -157,7 +155,6 @@ func TestAddFindPath(t *testing.T) {
 				{backend: b2, path: "/", match: MatchExact},
 				{backend: b3, path: "/login", match: MatchExact},
 			},
-			order:     []string{"b3", "b1", "b2"},
 			findPath:  "/",
 			findMatch: []MatchType{MatchBegin},
 			found:     []string{"b1"},
@@ -169,7 +166,6 @@ func TestAddFindPath(t *testing.T) {
 				{backend: b2, path: "/", match: MatchExact},
 				{backend: b3, path: "/login", match: MatchExact},
 			},
-			order:     []string{"b3", "b1", "b2"},
 			findPath:  "/",
 			findMatch: []MatchType{},
 			found:     []string{"b1", "b2"},
@@ -181,7 +177,6 @@ func TestAddFindPath(t *testing.T) {
 				{backend: b2, path: "/", match: MatchBegin},
 				{backend: b3, path: "/login", match: MatchBegin},
 			},
-			order:     []string{"b3", "b1", "b2"},
 			findPath:  "/",
 			findMatch: []MatchType{MatchBegin},
 			found:     []string{"b1", "b2"},
@@ -194,15 +189,10 @@ func TestAddFindPath(t *testing.T) {
 		for _, p := range test.paths {
 			h.AddPath(p.backend, p.path, p.match)
 		}
-		actualOrder := []string{}
-		for _, p := range h.Paths {
-			actualOrder = append(actualOrder, p.Backend.Name)
-		}
 		actualFound := []string{}
 		for _, p := range h.FindPath(test.findPath, test.findMatch...) {
 			actualFound = append(actualFound, p.Backend.Name)
 		}
-		c.compareObjects("order", i, actualOrder, test.order)
 		c.compareObjects("find", i, actualFound, test.found)
 		c.teardown()
 	}
@@ -248,7 +238,7 @@ func TestRemovePath(t *testing.T) {
 		{
 			addPaths:    "/app1,/app2",
 			removePaths: "/app3",
-			expPaths:    "/app2,/app1",
+			expPaths:    "/app1,/app2",
 		},
 		// 6
 		{

--- a/pkg/haproxy/types/maps_test.go
+++ b/pkg/haproxy/types/maps_test.go
@@ -608,11 +608,11 @@ local1.tld /a1 exact
 				{hostname: "local1.tld", path: "/a0", match: MatchExact, headers: HTTPHeaderMatch{{Name: "x-user", Value: "myname2"}}},
 			},
 			expected: `
-hosts__exact_01.map first:true,lower:false,method:str headers=['x-user':'myname2',regex:false]
-local1.tld /a0 exact
-
-hosts__exact_02.map first:false,lower:false,method:str headers=['x-user':'myname1',regex:false]
+hosts__exact_01.map first:true,lower:false,method:str headers=['x-user':'myname1',regex:false]
 local1.tld /a1 exact
+
+hosts__exact_02.map first:false,lower:false,method:str headers=['x-user':'myname2',regex:false]
+local1.tld /a0 exact
 
 hosts__exact.map first:false,lower:false,method:str
 local1.tld /a2 exact
@@ -659,12 +659,30 @@ local1.tld /a0 prefix
 				{hostname: "local1.tld", path: "/a0", match: MatchPrefix, headers: HTTPHeaderMatch{{Name: "x-user", Value: "myname1"}}},
 			},
 			expected: `
-hosts__prefix_01.map first:true,lower:false,method:dir headers=['x-user':'myname1',regex:false]
+hosts__prefix_01.map first:true,lower:false,method:dir headers=['x-user':'myname2',regex:false]
+local1.tld /a2 prefix
+
+hosts__prefix_02.map first:false,lower:false,method:dir headers=['x-user':'myname1',regex:false]
 local1.tld /a1 prefix
+local1.tld /a0 prefix
+`,
+		},
+		// 18
+		{
+			data: []data{
+				{hostname: "local1.tld", path: "/a0", match: MatchPrefix, headers: HTTPHeaderMatch{{Name: "x-user", Value: "myname2"}}},
+				{hostname: "local1.tld", path: "/a0", match: MatchPrefix, headers: HTTPHeaderMatch{{Name: "x-user", Value: "myname1"}}},
+				{hostname: "local1.tld", path: "/a0", match: MatchPrefix, headers: HTTPHeaderMatch{{Name: "x-user", Value: "myname1"}, {Name: "x-env", Value: "staging"}}},
+			},
+			expected: `
+hosts__prefix_01.map first:true,lower:false,method:dir headers=['x-user':'myname1',regex:false;'x-env':'staging',regex:false]
 local1.tld /a0 prefix
 
 hosts__prefix_02.map first:false,lower:false,method:dir headers=['x-user':'myname2',regex:false]
-local1.tld /a2 prefix
+local1.tld /a0 prefix
+
+hosts__prefix_03.map first:false,lower:false,method:dir headers=['x-user':'myname1',regex:false]
+local1.tld /a0 prefix
 `,
 		},
 	}


### PR DESCRIPTION
Paths should always be in reverse order to avoid choosing the wrong backend in case of an overlap. This happens when declaring /api before /api/v1: a request to /api/v1 would be handled by the backend of /api.

This sort is now being deduplicated and removed from the path declaration, it is now implemented only in the map builder. Moreover, not only the paths are being compared, but also the number of headers being matched, so filters having more headers to match will be handled before on http requests.