### PR TITLE
configure default backend per host

### DIFF
--- a/pkg/converters/helper_test/marshal.go
+++ b/pkg/converters/helper_test/marshal.go
@@ -53,6 +53,7 @@ type (
 	// host
 	hostMock struct {
 		Hostname     string
+		DefaultBack  string `yaml:",omitempty"`
 		Paths        []pathMock
 		RootRedirect string  `yaml:",omitempty"`
 		TLS          tlsMock `yaml:",omitempty"`
@@ -158,8 +159,13 @@ func marshalHosts(hafronts ...*hatypes.Host) []hostMock {
 				return paths[i].Path > paths[j].Path
 			})
 		}
+		var defaultBack string
+		if back := f.DefaultBackend; back != nil {
+			defaultBack = back.ID
+		}
 		hosts = append(hosts, hostMock{
 			Hostname:     f.Hostname,
+			DefaultBack:  defaultBack,
 			Paths:        paths,
 			RootRedirect: f.RootRedirect,
 			TLS:          tlsMock{TLSFilename: f.TLS.TLSFilename},

--- a/pkg/haproxy/types/maps.go
+++ b/pkg/haproxy/types/maps.go
@@ -98,6 +98,18 @@ func (hm *HostsMap) AddAliasPathMapping(alias HostAliasConfig, path *Path, targe
 	}
 }
 
+// AddTargetIfMissing ...
+func (hm *HostsMap) AddTargetIfMissing(hostname, path string, target string, match MatchType) {
+	if h := hm.rawhosts[hostname]; h != nil {
+		for _, entry := range h {
+			if entry.path == path && entry.match == match && entry.Value == target {
+				return
+			}
+		}
+	}
+	hm.addTarget(hostname, path, nil, 0, target, match)
+}
+
 func convertWildcardToRegex(hostname string, extendedMatch bool) (h string, hasWildcard bool) {
 	if !strings.HasPrefix(hostname, "*.") {
 		return hostname, false

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -534,6 +534,7 @@ type Host struct {
 	//
 	Alias               HostAliasConfig
 	CustomHTTPResponses HTTPResponses
+	DefaultBackend      *Backend
 	ExtendedWildcard    bool
 	Redirect            HostRedirectConfig
 	RootRedirect        string


### PR DESCRIPTION
Add a proper configuration for the host's default backend. Before this update, defaults should be added via the `/` root path, which eventually conflicts with a user defined root path. This implementation also adds a proper placeholder to configure a distinct default certificate when the hostname does not have any configured path and backend yet.