### PR TITLE
fix hostname and certificate handling on gateway api

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -81,6 +81,7 @@ CVEs
 daemonset
 dario
 DCk
+defaultback
 defaultbackend
 defaulthost
 defbackend
@@ -320,6 +321,7 @@ Noacl
 nocrt
 Nofilter
 nogrants
+nohostname
 nonroot
 nopath
 nopwd
@@ -483,6 +485,7 @@ tcptls
 TLSALPN
 tlsapis
 tlsfilename
+TLSHTTP
 tlsroute
 tlsrule
 tlsserver

--- a/docs/content/en/docs/configuration/gateway-api.md
+++ b/docs/content/en/docs/configuration/gateway-api.md
@@ -6,7 +6,7 @@ description: >
   Configure HAProxy using Gateway API resources.
 ---
 
-[Gateway API](https://gateway-api.sigs.k8s.io/) is a collection of Kubernetes resources that can be installed as [Custom Resource Definitions](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/). Just like Ingress resources, Gateway API resources are used to configure incoming HTTP/s, TLS and TCP requests to the in cluster applications. HAProxy Ingress v0.17 partially supports the Gateway API spec, `v1beta1` and `v1` versions.
+[Gateway API](https://gateway-api.sigs.k8s.io/) is a collection of Kubernetes resources that can be installed as [Custom Resource Definitions](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/). Just like Ingress resources, Gateway API resources are used to configure incoming HTTP/s, TLS and TCP requests to the in cluster applications.
 
 ## Installation
 
@@ -24,14 +24,23 @@ Gateway API has also a command-line tool, see how it works and installation inst
 
 ## Conformance
 
-Most of the Gateway API `v1beta1` and `v1` specs are implemented in v0.17 release. The following list describes what is not supported:
+HAProxy Ingress is a Gateway API conformant implementation. The following APIs have all their Core features implemented:
 
-* Target Services can be annotated with [Backend or Path scoped]({{% relref "keys#scope" %}}) configuration keys, this will continue to be supported.
-* Gateway API resources don't support annotations, this should continue to be unsupported. Extensions to the Gateway API spec will be added in the extension points of the API.
-* The controller doesn't implement partial parsing yet for Gateway API resources, changes should be a bit slow on clusters with thousands of Ingress, Gateway API resources or Services.
-* Gateway's Addresses is not implemented - binding addresses use the global [bind-ip-addr]({{% relref "keys#bind-ip-addr" %}}) configuration.
-* Gateway's Hostname only supports empty/absence of Hostname or a single `*`, any other string will override the HTTPRoute Hostnames configuration without any merging.
-* HTTPRoute's Rules and BackendRefs don't support Filters.
+* Gateway
+* HTTPRoute
+* TLSRoute
+* TCPRoute
+* ReferenceGrant
+
+The following APIs are currently unsupported:
+
+* GRPCRoute
+* UDPRoute (*)
+* BackendTLSPolicy
+
+> (*) HAProxy does not support UDP routing, so the UDPRoute API will continue to be unsupported on future releases.
+
+Gateway API resources don't support annotations, this should continue to be unsupported. Extensions to the Gateway API spec will be added in the extension points of the API. However, target Services can be annotated with [Backend or Path scoped]({{% relref "keys#scope" %}}) configuration keys, this will continue to be supported.
 
 ## Ingress
 
@@ -183,3 +192,7 @@ ping
 ```
 
 Type `ping` and see a `+PONG` response. Press `^C` to close the connection.
+
+## What's next
+
+See also the [Gateway API documentation](https://gateway-api.sigs.k8s.io/)


### PR DESCRIPTION
Hostname filter was partially implemented, HTTP route configuration was being discarded if listener adds a hostname other than an wildcard.

Certificates was not being served on TLS handshake if the listener does not have any registered route.

Update the Gateway API getting started page.