### PR TITLE
fix: move logic to capture request origin header earlier

### DIFF
--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -649,6 +649,23 @@ backend {{ $backend.ID }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
+{{- $corsCfg := $backend.PathConfig "Cors" }}
+{{- range $i, $cors := $corsCfg.Items }}
+{{- if and $cors.Enabled $cors.AllowOrigin }}
+{{- $corsNeedACL := or $cors.AllowOriginRegex (gt (len $cors.AllowOrigin) 1) (ne (index $cors.AllowOrigin 0) "*") }}
+{{- if $corsNeedACL }}
+    http-request set-var(txn.hdr_origin{{ $i }}) req.hdr(Origin)
+{{- end }}
+{{- range $pathIDs := $corsCfg.PathIDs $i }}
+    http-request set-var(txn.cors_max_age) str({{ $cors.MaxAge }}) if METH_OPTIONS
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS
+        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{- /*------------------------------------*/}}
 {{- $maxbodyCfg := $backend.PathConfig "MaxBodySize" }}
 {{- if and $backend.CustomHTTPResponses.Lua $maxbodyCfg.Items }}
     http-request set-var(txn.lua_scope) str({{ $backend.ID }})
@@ -713,23 +730,6 @@ backend {{ $backend.ID }}
 {{- end }}
 {{- if $backend.TLS.AddCertHeader }}
     http-request set-header {{ $global.SSL.HeadersPrefix }}-Client-Cert %{+Q}[ssl_c_der,base64]{{ if $needOffloadACL }} if local-offload{{ end }}
-{{- end }}
-{{- end }}
-
-{{- /*------------------------------------*/}}
-{{- $corsCfg := $backend.PathConfig "Cors" }}
-{{- range $i, $cors := $corsCfg.Items }}
-{{- if and $cors.Enabled $cors.AllowOrigin }}
-{{- $corsNeedACL := or $cors.AllowOriginRegex (gt (len $cors.AllowOrigin) 1) (ne (index $cors.AllowOrigin 0) "*") }}
-{{- if $corsNeedACL }}
-    http-request set-var(txn.hdr_origin{{ $i }}) req.hdr(Origin)
-{{- end }}
-{{- range $pathIDs := $corsCfg.PathIDs $i }}
-    http-request set-var(txn.cors_max_age) str({{ $cors.MaxAge }}) if METH_OPTIONS
-        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
-    http-request use-service lua.send-cors-preflight if METH_OPTIONS
-        {{- if $pathIDs }} { var(txn.pathID) -m str {{ $pathIDs }} }{{ end }}
-{{- end }}
 {{- end }}
 {{- end }}
 


### PR DESCRIPTION
Move the logic that captures the incoming request Origin header into the `txn.hdr_origin0` variable so that it comes before the directives that handle MaxBodySize.  The `http-request use-service` directive that applies if the body size exceeds the configured maximum has the effect of disregarding any other `http-request` directives that come after it in the configuration, which in turn meant that the generated 413 response would say `Access-Control-Allow-Origin: *` even in cases where a successful request would reflect back the client's `Origin` header.  Moving the variable capture before the `lua.send-413` means the CORS headers are consistent between successful and 413-error responses.

Fixes #1384