### PR TITLE
fix response error if proto is not http or https

### DIFF
--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -900,7 +900,10 @@ func (c *converter) createBackend(routeSource *source, refEvent *routeParentRefE
 		epReady []*convutils.Endpoint
 		cl      convutils.WeightCluster
 	}
-	http500 := func() *hatypes.Backend {
+	errorResponse := func() *hatypes.Backend {
+		if modeTCP {
+			return c.haproxy.Backends().AcquireTCPRejectBackend()
+		}
 		return c.haproxy.Backends().AcquireStatusCodeBackend(http.StatusInternalServerError)
 	}
 	var backends []backend
@@ -908,7 +911,7 @@ func (c *converter) createBackend(routeSource *source, refEvent *routeParentRefE
 	for _, back := range backendRefs {
 		if back.Port == nil {
 			refEvent.backendRef = "BackendRef is missing port number"
-			return http500(), nil
+			return errorResponse(), nil
 		}
 		namespace := routeSource.Namespace
 		if back.Namespace != nil {
@@ -920,7 +923,7 @@ func (c *converter) createBackend(routeSource *source, refEvent *routeParentRefE
 				backName = fmt.Sprintf("%s/%s", *back.Namespace, back.Name)
 			}
 			refEvent.backendRefNoGrant = append(refEvent.backendRefNoGrant, backName)
-			return http500(), nil
+			return errorResponse(), nil
 		}
 		var invalidKind []string
 		if back.Group != nil && *back.Group != "" && *back.Group != "core" {
@@ -931,7 +934,7 @@ func (c *converter) createBackend(routeSource *source, refEvent *routeParentRefE
 		}
 		if len(invalidKind) > 0 {
 			refEvent.invalidKind = strings.Join(invalidKind, "; ")
-			return http500(), nil
+			return errorResponse(), nil
 		}
 		svcName := namespace + "/" + string(back.Name)
 		c.tracker.TrackRefName([]convtypes.TrackingRef{
@@ -942,7 +945,7 @@ func (c *converter) createBackend(routeSource *source, refEvent *routeParentRefE
 		if err != nil {
 			c.logger.Warn("skipping service '%s' on %s: %v", back.Name, routeSource, err)
 			refEvent.backendRef = err.Error()
-			return http500(), nil
+			return errorResponse(), nil
 		}
 		svclist = append(svclist, svc)
 		portStr := strconv.Itoa(int(*back.Port))
@@ -950,13 +953,13 @@ func (c *converter) createBackend(routeSource *source, refEvent *routeParentRefE
 		if svcport == nil {
 			c.logger.Warn("skipping service '%s' on %s: port '%s' not found", back.Name, routeSource, portStr)
 			refEvent.backendRef = fmt.Sprintf("Port %s not found", portStr)
-			return http500(), nil
+			return errorResponse(), nil
 		}
 		epReady, _, err := convutils.CreateEndpoints(c.cache, svc, svcport)
 		if err != nil {
 			c.logger.Warn("skipping service '%s' on %s: %v", back.Name, routeSource, err)
 			refEvent.backendRef = err.Error()
-			return http500(), nil
+			return errorResponse(), nil
 		}
 		backends = append(backends, backend{
 			service: back.Name,
@@ -974,7 +977,7 @@ func (c *converter) createBackend(routeSource *source, refEvent *routeParentRefE
 	habackend := c.haproxy.Backends().AcquireBackend(routeSource.Namespace, routeSource.Name, index)
 	habackend.ModeTCP = modeTCP
 	if len(backends) == 0 {
-		return http500(), nil
+		return errorResponse(), nil
 	}
 	cl := make([]*convutils.WeightCluster, len(backends))
 	for i := range backends {

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1336,6 +1336,33 @@ d1.local#/ d1_app_8080`)
 	c.logger.CompareLogging(defaultLogging)
 }
 
+func TestInstanceSupportBackend(t *testing.T) {
+	c := setup(t)
+	defer c.teardown()
+
+	_ = c.config.Backends().AcquireStatusCodeBackend(429)
+	_ = c.config.Backends().AcquireStatusCodeBackend(500)
+	_ = c.config.Backends().AcquireTCPRejectBackend()
+
+	c.Update()
+	c.checkConfig(`
+<<global>>
+<<defaults>>
+<<backends-default>>
+backend _status429
+    mode http
+    http-request return status 429 default-errorfiles
+backend _status500
+    mode http
+    http-request return status 500 default-errorfiles
+backend _tcp_reject
+    mode tcp
+    tcp-request content reject
+<<support>>
+`)
+	c.logger.CompareLogging(defaultLogging)
+}
+
 func TestInstanceFrontendList(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()

--- a/pkg/haproxy/types/backends.go
+++ b/pkg/haproxy/types/backends.go
@@ -213,12 +213,15 @@ func (b *Backends) BuildSortedShard(shardRef int) []*Backend {
 	return b.buildSortedItems(b.shards[shardRef])
 }
 
-func (b *Backends) BuildStatusCodeItems() []*Backend {
+func (b *Backends) BuildSupportBackendItems() []*Backend {
 	items := make([]*Backend, len(b.statusCode))
 	var i int
 	for _, item := range b.statusCode {
 		items[i] = item
 		i++
+	}
+	if b.tcpReject != nil {
+		items = append(items, b.tcpReject)
 	}
 	sort.Slice(items, func(i, j int) bool {
 		return items[i].ID < items[j].ID
@@ -313,6 +316,15 @@ func (b *Backends) AcquireNotFoundBackend() *Backend {
 		b.error404 = createBackend(0, "_error404", "", "") // this is also hardcoded in the template
 	}
 	return b.error404
+}
+
+func (b *Backends) AcquireTCPRejectBackend() *Backend {
+	if b.tcpReject == nil {
+		backend := createBackend(0, "_tcp_reject", "", "")
+		backend.ModeTCP = true
+		b.tcpReject = backend
+	}
+	return b.tcpReject
 }
 
 // AcquireStatusCodeBackend ...

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -637,6 +637,7 @@ type Backends struct {
 	changedShards  map[int]bool
 	httpsRedir     *Backend
 	error404       *Backend
+	tcpReject      *Backend
 	statusCode     map[int]*Backend
 	DefaultBackend *Backend
 }

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -998,8 +998,8 @@ backend _acme_challenge
 {{- end }}
 
 {{- $has404 := $backends.HasBackend "_error404" }}
-{{- $statusBackends := $backends.BuildStatusCodeItems }}
-{{- if or $has404 $statusBackends }}
+{{- $supportBackends := $backends.BuildSupportBackendItems }}
+{{- if or $has404 $supportBackends }}
 
   # # # # # # # # # # # # # # # # # # #
 # #
@@ -1020,13 +1020,18 @@ backend _error404
 {{- end }}
 {{- end }}
 
-{{- range $statusBackend := $statusBackends }}
-backend {{ $statusBackend.ID }}
-    mode http
-{{- range $snippet := index $global.CustomProxy $statusBackend.ID }}
+{{- range $supportBackend := $supportBackends }}
+backend {{ $supportBackend.ID }}
+    mode {{ if $supportBackend.ModeTCP }}tcp{{ else }}http{{ end }}
+{{- range $snippet := index $global.CustomProxy $supportBackend.ID }}
     {{ $snippet }}
 {{- end }}
-    http-request return status {{ $statusBackend.Code }} default-errorfiles
+{{- if eq $supportBackend.ID "_tcp_reject" }}
+    tcp-request content reject
+{{- end }}
+{{- if $supportBackend.Code }}
+    http-request return status {{ $supportBackend.Code }} default-errorfiles
+{{- end }}
 {{- end }}
 
 {{- end }}{{/* define "backend-support" */}}


### PR DESCRIPTION
Creates a TCP based response in case a route configuration error leads to an error. TLS and TCP protos were incorrectly using the 500 HTTP status page from HTTP and HTTPS, leading to clients rejecting the content instead of simply receiving a FIN.