### PR TITLE
fix cors default origin on ingress api

### DIFF
--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -557,6 +557,10 @@ func (c *updater) buildBackendCors(d *backData) {
 		enabled := config.Get(ingtypes.BackCorsEnable).Bool()
 
 		if enabled {
+			var allowOrigin []string
+			if origin := config.Get(ingtypes.BackCorsAllowOrigin).Value; origin != "" {
+				allowOrigin = strings.Split(origin, ",")
+			}
 			var allowOriginRegex []string
 			if regex := config.Get(ingtypes.BackCorsAllowOriginRegex).Value; regex != "" {
 				allowOriginRegex = strings.Split(regex, " ")
@@ -566,7 +570,7 @@ func (c *updater) buildBackendCors(d *backData) {
 				AllowCredentials: config.Get(ingtypes.BackCorsAllowCredentials).Bool(),
 				AllowHeaders:     config.Get(ingtypes.BackCorsAllowHeaders).Value,
 				AllowMethods:     config.Get(ingtypes.BackCorsAllowMethods).Value,
-				AllowOrigin:      strings.Split(config.Get(ingtypes.BackCorsAllowOrigin).Value, ","),
+				AllowOrigin:      allowOrigin,
 				AllowOriginRegex: allowOriginRegex,
 				ExposeHeaders:    config.Get(ingtypes.BackCorsExposeHeaders).Value,
 				MaxAge:           config.Get(ingtypes.BackCorsMaxAge).Int(),

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -1258,8 +1258,6 @@ const (
 	corsDefaultMaxAge  = 86400
 )
 
-var corsDefaultOrigin = []string{"*"}
-
 func TestCors(t *testing.T) {
 	testCases := []struct {
 		paths    []string
@@ -1287,7 +1285,6 @@ func TestCors(t *testing.T) {
 					AllowCredentials: false,
 					AllowHeaders:     corsDefaultHeaders,
 					AllowMethods:     corsDefaultMethods,
-					AllowOrigin:      corsDefaultOrigin,
 					ExposeHeaders:    "",
 					MaxAge:           corsDefaultMaxAge,
 				},
@@ -1310,7 +1307,6 @@ func TestCors(t *testing.T) {
 					AllowCredentials: false,
 					AllowHeaders:     corsDefaultHeaders,
 					AllowMethods:     corsDefaultMethods,
-					AllowOrigin:      corsDefaultOrigin,
 					ExposeHeaders:    "",
 					MaxAge:           corsDefaultMaxAge,
 				},
@@ -1350,7 +1346,6 @@ func TestCors(t *testing.T) {
 					AllowCredentials: false,
 					AllowHeaders:     corsDefaultHeaders,
 					AllowMethods:     corsDefaultMethods,
-					AllowOrigin:      corsDefaultOrigin,
 					ExposeHeaders:    "",
 					MaxAge:           corsDefaultMaxAge,
 				},
@@ -1371,7 +1366,6 @@ func TestCors(t *testing.T) {
 					AllowCredentials: false,
 					AllowHeaders:     corsDefaultHeaders,
 					AllowMethods:     corsDefaultMethods,
-					AllowOrigin:      corsDefaultOrigin,
 					AllowOriginRegex: []string{`^http://d1\.local$`, `^https?://d[23]\.local`, `https://([a-z]*\.){0,3}d3\.local$`},
 					ExposeHeaders:    "",
 					MaxAge:           corsDefaultMaxAge,
@@ -1392,7 +1386,6 @@ func TestCors(t *testing.T) {
 					AllowCredentials: false,
 					AllowHeaders:     corsDefaultHeaders,
 					AllowMethods:     corsDefaultMethods,
-					AllowOrigin:      corsDefaultOrigin,
 					ExposeHeaders:    "",
 					MaxAge:           corsDefaultMaxAge,
 				},
@@ -1435,7 +1428,6 @@ func TestCors(t *testing.T) {
 					AllowCredentials: false,
 					AllowHeaders:     "*",
 					AllowMethods:     corsDefaultMethods,
-					AllowOrigin:      corsDefaultOrigin,
 					ExposeHeaders:    "",
 					MaxAge:           corsDefaultMaxAge,
 				},
@@ -1445,7 +1437,6 @@ func TestCors(t *testing.T) {
 	annDefault := map[string]string{
 		ingtypes.BackCorsAllowHeaders: corsDefaultHeaders,
 		ingtypes.BackCorsAllowMethods: corsDefaultMethods,
-		ingtypes.BackCorsAllowOrigin:  strings.Join(corsDefaultOrigin, ","),
 		ingtypes.BackCorsMaxAge:       strconv.Itoa(corsDefaultMaxAge),
 	}
 	source := &Source{

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -297,6 +297,30 @@ func TestBackends(t *testing.T) {
     http-response set-header Vary %[res.fhdr(Vary)],Origin if cors_allow_origin0 { res.hdr(Vary) -m found } !{ res.hdr(Vary) -m str "Origin" }
     http-response set-header Vary Origin if cors_allow_origin0 !{ res.hdr(Vary) -m found }`,
 		},
+		"test12": {
+			doconfig: func(c *testConfig, h *hatypes.Host, b *hatypes.Backend) {
+				config := hatypes.Cors{
+					Enabled:          true,
+					AllowOrigin:      []string{},
+					AllowOriginRegex: []string{},
+					AllowHeaders:     "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization",
+					AllowMethods:     "GET, PUT, POST, DELETE, PATCH, OPTIONS",
+					MaxAge:           86400,
+				}
+				h.FindPath("/")[0].Cors = config
+			},
+			path: []string{"/"},
+			expected: `
+    http-request set-var(txn.hdr_origin) req.hdr(Origin) if { req.hdr(Origin) -m found }
+    http-request set-var(txn.hdr_cors_method) req.fhdr(Access-Control-Request-Method) if { req.fhdr(Access-Control-Request-Method) -m found }
+    http-request set-var(txn.hdr_cors_headers) req.fhdr(Access-Control-Request-Headers) if { req.fhdr(Access-Control-Request-Headers) -m found }
+    http-request set-var(txn.cors_max_age) str(86400) if METH_OPTIONS
+    http-request use-service lua.send-cors-preflight if METH_OPTIONS
+    acl cors_allow_origin0 var(txn.hdr_origin) -m found
+    http-response set-header Access-Control-Allow-Origin %[var(txn.hdr_origin)] if cors_allow_origin0
+    http-response set-header Access-Control-Allow-Methods "GET, PUT, POST, DELETE, PATCH, OPTIONS" if cors_allow_origin0
+    http-response set-header Access-Control-Allow-Headers "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization" if cors_allow_origin0`,
+		},
 		"test14": {
 			doconfig: func(c *testConfig, h *hatypes.Host, b *hatypes.Backend) {
 				config := hatypes.Cors{


### PR DESCRIPTION
CORS template changed how it handles default allow origin - now both string and regex matches should be empty, or string match should have just a wildcard.

Since the last refactor, default string based match is empty, so it does not conflict with regex match, but we missed to fix the converter parsing: we were creating a slice with an empty string, instead of an empty slice, leading the template to render this empty string as the allowed origin. This update fixes the converter, which makes both string and regex match to be optional.