### PR TITLE
drop misplaced and noop http-server-close option

### DIFF
--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -1672,7 +1672,6 @@ defaults
     maxconn 2000
     option redispatch
     option dontlognull
-    option http-server-close
     option http-keep-alive
     timeout client          50s
     timeout client-fin      50s
@@ -1730,7 +1729,6 @@ defaults
     maxconn 2000
     option redispatch
     option dontlognull
-    option http-server-close
     option http-keep-alive
     timeout client          50s
     timeout client-fin      50s
@@ -4472,7 +4470,6 @@ defaults
     maxconn 2000
     option redispatch
     option dontlognull
-    option http-server-close
     option http-keep-alive
     errorfile 403 /etc/haproxy/errorfiles/403-global.http
     errorfile 503 /etc/haproxy/errorfiles/503-global.http
@@ -6324,7 +6321,6 @@ func (c *testConfig) checkConfigFile(expected, fileName string) {
     maxconn 2000
     option redispatch
     option dontlognull
-    option http-server-close
     option http-keep-alive
     timeout client          50s
     timeout client-fin      50s

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -162,7 +162,6 @@ defaults
     option redispatch
 {{- end }}
     option dontlognull
-    option http-server-close
     option http-keep-alive
 {{- if not $global.UseHTX }}
     no option http-use-htx


### PR DESCRIPTION
`option http-server-close` is incorrectly configured, just before a `option http-keep-alive` that makes it noop. Although this is there since the very beginning, 10y ago, we have no attachment to it, so lets remove.