### PR TITLE
configure CA for requests missing SNI

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -238,7 +238,6 @@ intm
 invalidcrt
 IPHTTP
 iplist
-ipnode
 IPTCP
 IPVS
 ironashram

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -311,6 +311,7 @@ The table below describes all supported configuration keys.
 | [`auth-signin`](#auth-external)                      | Sign in URL                             | Path     |                                  |
 | [`auth-tls-cert-header`](#auth-tls)                  | [true\|false]                           | Backend  |                                  |
 | [`auth-tls-error-page`](#auth-tls)                   | url                                     | Host     |                                  |
+| [`auth-tls-default-secret`](#auth-tls)               | namespace/secret name                   | Global   |                                  |
 | [`auth-tls-secret`](#auth-tls)                       | namespace/secret name                   | Host     |                                  |
 | [`auth-tls-strict`](#auth-tls)                       | [true\|false]                           | Host     |                                  |
 | [`auth-tls-verify-client`](#auth-tls)                | [off\|optional\|on\|optional_no_ca]     | Host     |                                  |
@@ -876,6 +877,7 @@ See also:
 |-----------------------------|-----------|---------|--------|
 | `auth-tls-cert-header`      | `Backend` | `false` |        |
 | `auth-tls-error-page`       | `Host`    |         |        |
+| `auth-tls-default-secret`   | `Global`  |         | v0.16  |
 | `auth-tls-secret`           | `Host`    |         |        |
 | `auth-tls-strict`           | `Host`    | `true`  | v0.8.1 |
 | `auth-tls-verify-client`    | `Host`    |         |        |
@@ -903,6 +905,7 @@ The following keys are supported:
 
 * `auth-tls-cert-header`: If `true` HAProxy will add `X-SSL-Client-Cert` http header with a base64 encoding of the X509 certificate provided by the client. Default is to not provide the client certificate.
 * `auth-tls-error-page`: Optional URL of the page to redirect the user if he doesn't provide a certificate or the certificate is invalid.
+* `auth-tls-default-secret`: Optional, defines the namespace/name of the secret with `ca.crt` key to be used if the client does not provide the SNI extension in the TLS handshake. An optional `ca.crl` key can also provide a CRL in PEM format for the server to verify against. Note that this option will also apply on requests having SNI, but unknown in the configuration, asking them to optionally provide a client certificate. Currently there is no way to make a client certificate mandatory during the TLS handshake, so if the client does not provide one, the handshake will succeed and the SSL related headers will be empty. Ingress handling this request should configure `auth-tls-verify-client` as `optional`, HAProxy will refuse the request otherwise because SNI and Host header would not match.
 * `auth-tls-secret`: Mandatory secret name with `ca.crt` key providing all certificate authority bundles used to validate client certificates. Since v0.9, an optional `ca.crl` key can also provide a CRL in PEM format for the server to verify against. A filename prefixed with `file://` can be used containing the CA bundle in PEM format, and optionally followed by a comma and the filename with the crl, eg `file:///dir/ca.pem` or `file:///dir/ca.pem,/dir/crl.pem`.
 * `auth-tls-strict`: Defines if a wrong or incomplete configuration, eg missing secret with `ca.crt`, should forbid connection attempts. If `false`, a wrong or incomplete configuration will ignore the authentication config, allowing anonymous connection. If `true`, a strict configuration is used: all requests will be rejected with HTTP 495 or 496, or redirected to the error page if configured, until a proper `ca.crt` is provided. Strict configuration will only be used if `auth-tls-secret` has a secret name and `auth-tls-verify-client` is missing or is not configured as `off`. This options used to have `false` as the default value up to v0.13, changing its default to `true` since v0.14 to improve security.
 * `auth-tls-verify-client`: Optional configuration of Client Verification behavior. Supported values are `off`, `on`, `optional` and `optional_no_ca`. The default value is `on` if a valid secret is provided, `off` otherwise. `optional` makes the certificate optional but validates it when provided by the client. From v0.8 to v0.13 controller versions, `optional_no_ca` used to validate the certificate as well, since v0.14 it makes the proxy bypass any validation.

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -80,6 +80,22 @@ func (c *updater) buildGlobalAuthProxy(d *globalData) {
 	authproxy.RangeEnd, _ = strconv.Atoi(proxy[3])
 }
 
+func (c *updater) buildGlobalAuthTLS(d *globalData) {
+	tlsSecret := d.mapper.Get(ingtypes.GlobalAuthTLSDefaultSecret)
+	if tlsSecret.Value == "" {
+		return
+	}
+	cafile, crlfile, err := c.cache.GetCASecretPath("", tlsSecret.Value, nil)
+	if err == nil {
+		d.global.SSL.DefaultCAFilename = cafile.Filename
+		d.global.SSL.DefaultCAHash = cafile.SHA1Hash
+		d.global.SSL.DefaultCRLFilename = crlfile.Filename
+		d.global.SSL.DefaultCRLHash = crlfile.SHA1Hash
+	} else {
+		c.logger.Error("error building default CA secret %s: %v", tlsSecret.Source, err)
+	}
+}
+
 func (c *updater) buildGlobalCloseSessions(d *globalData) {
 	durationCfg := d.mapper.Get(ingtypes.GlobalCloseSessionsDuration).Value
 	if durationCfg == "" {

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -187,6 +187,7 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()
 	c.buildGlobalAcme(d)
 	c.buildGlobalAuthProxy(d)
+	c.buildGlobalAuthTLS(d)
 	c.buildGlobalCustomConfig(d)
 	c.buildGlobalCustomResponses(d)
 	c.buildGlobalDNS(d)

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -25,6 +25,7 @@ const (
 	GlobalAcmeTermsAgreed              = "acme-terms-agreed"
 	GlobalAllowLocalBind               = "allow-local-bind"
 	GlobalAuthLogFormat                = "auth-log-format"
+	GlobalAuthTLSDefaultSecret         = "auth-tls-default-secret"
 	GlobalAuthProxy                    = "auth-proxy"
 	GlobalBindIPAddrHealthz            = "bind-ip-addr-healthz"
 	GlobalBindIPAddrPrometheus         = "bind-ip-addr-prometheus"

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -257,7 +257,17 @@ func (c *config) writeFrontendMaps(f *hatypes.Frontend) error {
 	if f.IsHTTPS {
 		// TODO crtList* to be removed after implement a template to the crt list
 		f.CrtListFile = mapsFilenamePrefix + "_bind_crt.list"
-		crtListItems = append(crtListItems, &hatypes.HostsMapEntry{Key: defaultCrtFile + " !*"})
+		crtListEntry := []string{defaultCrtFile}
+		if c.global.SSL.DefaultCAFilename != "" {
+			var bindConf []string
+			bindConf = append(bindConf, "ca-file", c.global.SSL.DefaultCAFilename, "verify", "optional")
+			if c.global.SSL.DefaultCRLFilename != "" {
+				bindConf = append(bindConf, "crl-file", c.global.SSL.DefaultCRLFilename)
+			}
+			crtListEntry = append(crtListEntry, fmt.Sprintf("[%s]", strings.Join(bindConf, " ")))
+		}
+		crtListEntry = append(crtListEntry, "!*")
+		crtListItems = append(crtListItems, &hatypes.HostsMapEntry{Key: strings.Join(crtListEntry, " ")})
 	}
 	for _, host := range f.BuildSortedHosts() {
 		for _, path := range host.Paths {

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -3630,6 +3630,73 @@ d2.local http://d2.local/error.html
 	c.logger.CompareLogging(defaultLogging)
 }
 
+func TestInstanceFrontendDefaultCA(t *testing.T) {
+	testCases := map[string]struct {
+		cafile  string
+		crlfile string
+		expBind string
+	}{
+		"test01": {
+			cafile:  "",
+			crlfile: "",
+			expBind: `
+/var/haproxy/ssl/certs/default.pem !*
+`,
+		},
+		"test02": {
+			cafile:  "/ssl/ca.crt",
+			crlfile: "",
+			expBind: `
+/var/haproxy/ssl/certs/default.pem [ca-file /ssl/ca.crt verify optional] !*
+`,
+		},
+		"test03": {
+			cafile:  "/ssl/ca.crt",
+			crlfile: "/ssl/crl.crt",
+			expBind: `
+/var/haproxy/ssl/certs/default.pem [ca-file /ssl/ca.crt verify optional crl-file /ssl/crl.crt] !*
+`,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+
+			c := setup(t)
+			defer c.teardown()
+
+			b := c.config.Backends().AcquireBackend("d1", "app", "8080")
+			b.Endpoints = []*hatypes.Endpoint{endpointS1}
+			f1 := c.httpFrontend(80)
+			f2 := c.httpsFrontend(443)
+			h1 := f1.AcquireHost("d1.local")
+			h1.AddPath(b, "/", hatypes.MatchBegin)
+			h2 := f2.AcquireHost("d1.local")
+			h2.AddPath(b, "/", hatypes.MatchBegin)
+
+			c.config.global.SSL.DefaultCAFilename = test.cafile
+			c.config.global.SSL.DefaultCRLFilename = test.crlfile
+
+			c.Update()
+
+			c.checkConfig(`
+<<global>>
+<<defaults>>
+backend d1_app_8080
+    mode http
+    server s1 172.17.0.11:8080 weight 100
+<<backends-default>>
+<<frontends-default>>
+<<support>>
+`)
+
+			c.checkMap("_front_https_bind_crt.list", test.expBind)
+
+			c.logger.CompareLogging(defaultLogging)
+		})
+
+	}
+}
+
 func TestInstanceFrontendAuth(t *testing.T) {
 	type back struct {
 		iplist   []string

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -136,6 +136,10 @@ type SSLConfig struct {
 	BackendCipherSuites string
 	Ciphers             string // TLS up to 1.2
 	CipherSuites        string // TLS 1.3
+	DefaultCAFilename   string
+	DefaultCAHash       string
+	DefaultCRLFilename  string
+	DefaultCRLHash      string
 	DHParam             DHParamConfig
 	Engine              string
 	HeadersPrefix       string

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -320,6 +320,7 @@ func TestIntegrationIngress(t *testing.T) {
 			options.ExpectResponseCode(200),
 		)
 		assert.True(t, res.EchoResponse.Parsed)
+
 		crtder, _ := pem.Decode(crtValid)
 		sha1sum := sha1.Sum(crtder.Bytes)
 		reqHeaders := framework.AppendStringMap(commonReqHeaders, map[string]string{
@@ -328,6 +329,47 @@ func TestIntegrationIngress(t *testing.T) {
 			"x-ssl-client-sha1": strings.ToUpper(hex.EncodeToString(sha1sum[:])),
 		})
 		assert.Equal(t, reqHeaders, res.EchoResponse.ReqHeaders)
+	})
+
+	t.Run("should allow mTLS without SNI", func(t *testing.T) {
+		// t.Parallel() // changing global configmap, cannot run in parallel
+
+		cm := corev1.ConfigMap{}
+		err := f.Client().Get(ctx, framework.GlobalConfigMap, &cm)
+		require.NoError(t, err)
+		cm.Data[ingtypes.GlobalAuthTLSDefaultSecret] = secretCA.Namespace + "/" + secretCA.Name
+		err = f.Client().Update(ctx, &cm)
+		require.NoError(t, err)
+
+		svc := f.CreateService(ctx, t, httpServerPort)
+		_, hostname := f.CreateIngress(ctx, t, svc,
+			options.DefaultTLS(),
+			options.AddConfigKeyAnnotation(ingtypes.HostAuthTLSSecret, secretCA.Name),
+			options.AddConfigKeyAnnotation(ingtypes.HostAuthTLSVerifyClient, "optional"),
+		)
+
+		// http request without SNI
+		res := f.Request(ctx, t, http.MethodGet, hostname, "/",
+			options.TLSRequest(),
+			options.TLSSkipVerify(),
+			options.ClientCertificateKeyPEM(crtValid, keyValid),
+			options.ExpectResponseCode(200),
+		)
+		assert.True(t, res.EchoResponse.Parsed)
+
+		crtder, _ := pem.Decode(crtValid)
+		sha1sum := sha1.Sum(crtder.Bytes)
+		reqHeaders := framework.AppendStringMap(commonReqHeaders, map[string]string{
+			"x-ssl-client-cn":   framework.CertificateClientCN,
+			"x-ssl-client-dn":   "/CN=" + framework.CertificateClientCN,
+			"x-ssl-client-sha1": strings.ToUpper(hex.EncodeToString(sha1sum[:])),
+		})
+		assert.Equal(t, reqHeaders, res.EchoResponse.ReqHeaders)
+
+		// restore global configmap
+		delete(cm.Data, ingtypes.GlobalAuthTLSDefaultSecret)
+		err = f.Client().Update(ctx, &cm)
+		require.NoError(t, err)
 	})
 
 	t.Run("should authorize request", func(t *testing.T) {


### PR DESCRIPTION
TLS handshake happens around the SNI extension provided by the client. It is used to choose an appropriate server certificate, defines if the server will accept a client certificate or even enforce that one is provided. None of this can happen if client does not provide SNI.

Older clients however don't support SNI at all, so their requests cannot have the benefit of a dedicated certificate and dedicated mTLS behavior. We already have default certificate for missing or unknown SNI, and this update includes the support for mTLS as well. In case a CA and optional CRL is provided, HAProxy asks an optional client certificate during the TLS handshake. If provided, all the SSL headers are populated just like in the SNI matching counterpart.