### PR TITLE
drop nbproc configuration

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -421,7 +421,6 @@ The table below describes all supported configuration keys.
 | [`modsecurity-timeout-idle`](#modsecurity)           | time with suffix                        | Global   | `30s`                            |
 | [`modsecurity-timeout-processing`](#modsecurity)     | time with suffix                        | Global   | `1s`                             |
 | [`modsecurity-use-coraza`](#modsecurity)             | [true\|false]                           | Global   | `false`                          |
-| [`nbproc-ssl`](#nbproc)                              | number of process                       | Global   | `0`                              |
 | [`nbthread`](#nbthread)                              | number of threads                       | Global   |                                  |
 | [`no-redirect-locations`](#redirect)                 | comma-separated list of URIs            | Global   | `/.well-known/acme-challenge`    |
 | [`no-tls-redirect-locations`](#ssl-redirect)         | comma-separated list of URIs            | Global   | `/.well-known/acme-challenge`    |
@@ -1437,8 +1436,7 @@ See also:
 | `cpu-map`         | `Global` |         |       |
 | `use-cpu-map`     | `Global` | `true`  |       |
 
-Define how processes/threads map to CPUs. The default value is generated based
-on [nbthread](#nbthread) and [nbproc](#nbproc).
+Define how threads map to CPUs. The default value is generated based on [nbthread](#nbthread).
 
 * `cpu-map`: Custom override specifying the [cpu mapping behaviour](https://docs.haproxy.org/3.0/configuration.html#3.1-cpu-map).
 * `use-cpu-map`: Set to `false` to prevent any cpu mapping
@@ -1446,7 +1444,6 @@ on [nbthread](#nbthread) and [nbproc](#nbproc).
 See also:
 
 * [nbthread](#nbthread) configuration key
-* [nbproc](#nbproc) configuration key
 * https://docs.haproxy.org/3.0/configuration.html#3.1-cpu-map
 
 ---
@@ -2221,40 +2218,6 @@ See also:
 * https://www.haproxy.org/download/2.0/doc/SPOE.txt
 * https://docs.haproxy.org/3.0/configuration.html#9.3
 * https://github.com/jcmoraisjr/modsecurity-spoa
-
----
-
-### Nbproc
-
-| Configuration key | Scope    | Default | Since |
-|-------------------|----------|---------|-------|
-| `nbproc-ssl`      | `Global` | `0`     |       |
-
-{{< alert title="Warning" color="warning" >}}
-This option works only on v0.7 or below. Since v0.8 the only supported value is `0` zero.
-{{< /alert >}}
-
-Define the number of dedicated HAProxy process to the SSL/TLS handshake and
-offloading. The default value is 0 (zero) which means HAProxy should process all
-the SSL/TLS offloading, as well as the header inspection and load balancing
-within the same HAProxy process.
-
-The recommended value depends on how much CPU a single HAProxy process is
-spending. Use 0 (zero) if the amount of processing has low CPU usage. This will
-avoid a more complex topology and an inter-process communication. Use the number
-of cores of a dedicated host minus 1 (one) to distribute the SSL/TLS offloading
-process. Leave one core dedicated to header inspection and load balancing.
-
-If splitting HAProxy into two or more process and the number of threads is one,
-`cpu-map` is used to bind each process on its own CPU core.
-
-See also:
-
-* [nbthread](#nbthread) configuration key
-* [cpu-map](#cpu-map) configuration key
-* https://docs.haproxy.org/3.0/configuration.html#3.1-nbproc
-* https://docs.haproxy.org/3.0/configuration.html#4-bind-process
-* https://docs.haproxy.org/3.0/configuration.html#3.1-cpu-map
 
 ---
 

--- a/pkg/converters/ingress/annotations/global.go
+++ b/pkg/converters/ingress/annotations/global.go
@@ -250,64 +250,20 @@ func (c *updater) buildGlobalPeers(d *globalData) {
 }
 
 func (c *updater) buildGlobalProc(d *globalData) {
-	balance := d.mapper.Get(ingtypes.GlobalNbprocBalance).Int()
-	if balance < 1 {
-		c.logger.Warn("invalid value of nbproc-balance configmap option (%v), using 1", balance)
-		balance = 1
-	}
-	if balance > 1 {
-		// need to visit (at least) statistics and healthz bindings as well
-		// as admin socket before using more than one balance backend
-		c.logger.Warn("nbproc-balance configmap option (%v) greater than 1 is not yet supported, using 1", balance)
-		balance = 1
-	}
-	ssl := d.mapper.Get(ingtypes.GlobalNbprocSSL).Int()
-	if ssl < 0 {
-		c.logger.Warn("invalid value of nbproc-ssl configmap option (%v), using 0", ssl)
-		ssl = 0
-	}
-	if ssl > 0 {
-		c.logger.Warn("v08 controller does not support nbproc-ssl, using 0")
-		ssl = 0
-	}
-	procs := balance + ssl
 	threads := d.mapper.Get(ingtypes.GlobalNbthread).Int()
 	if threads < 0 {
 		c.logger.Warn("ignoring invalid value of nbthread: %d", threads)
 		threads = 0
 	}
-	bindprocBalance := "1"
-	if balance > 1 {
-		bindprocBalance = fmt.Sprintf("1-%v", balance)
-	}
-	bindprocSSL := ""
-	if ssl == 0 {
-		bindprocSSL = bindprocBalance
-	} else if ssl == 1 {
-		bindprocSSL = fmt.Sprintf("%v", balance+1)
-	} else if ssl > 1 {
-		bindprocSSL = fmt.Sprintf("%v-%v", balance+1, procs)
-	}
 	useCPUMap := d.mapper.Get(ingtypes.GlobalUseCPUMap).Bool()
 	cpumap := ""
 	if useCPUMap {
 		cpumap = d.mapper.Get(ingtypes.GlobalCPUMap).Value
-		if cpumap == "" {
-			if threads > 1 {
-				if procs == 1 {
-					cpumap = fmt.Sprintf("auto:1/1-%v 0-%v", threads, threads-1)
-				}
-			} else if procs > 1 {
-				cpumap = fmt.Sprintf("auto:1-%v 0-%v", procs, procs-1)
-			}
+		if cpumap == "" && threads > 1 {
+			cpumap = fmt.Sprintf("auto:1/1-%v 0-%v", threads, threads-1)
 		}
 	}
-	d.global.Procs.Nbproc = procs
 	d.global.Procs.Nbthread = threads
-	d.global.Procs.NbprocBalance = balance
-	d.global.Procs.NbprocSSL = ssl
-	d.global.Procs.BindprocBalance = bindprocBalance
-	d.global.Procs.BindprocSSL = bindprocSSL
 	d.global.Procs.CPUMap = cpumap
 }
 

--- a/pkg/converters/ingress/annotations/global_test.go
+++ b/pkg/converters/ingress/annotations/global_test.go
@@ -640,38 +640,34 @@ func TestDisableCpuMap(t *testing.T) {
 		// 0
 		{
 			ann: map[string]string{
-				ingtypes.GlobalUseCPUMap:     "false",
-				ingtypes.GlobalNbthread:      "1",
-				ingtypes.GlobalNbprocBalance: "1",
+				ingtypes.GlobalUseCPUMap: "false",
+				ingtypes.GlobalNbthread:  "1",
 			},
 			expected: "",
 		},
 		// 1
 		{
 			ann: map[string]string{
-				ingtypes.GlobalUseCPUMap:     "false",
-				ingtypes.GlobalCPUMap:        "auto 1/1 1-",
-				ingtypes.GlobalNbthread:      "1",
-				ingtypes.GlobalNbprocBalance: "1",
+				ingtypes.GlobalUseCPUMap: "false",
+				ingtypes.GlobalCPUMap:    "auto 1/1 1-",
+				ingtypes.GlobalNbthread:  "1",
 			},
 			expected: "",
 		},
 		// 2
 		{
 			ann: map[string]string{
-				ingtypes.GlobalUseCPUMap:     "true",
-				ingtypes.GlobalCPUMap:        "auto:1/1 1-",
-				ingtypes.GlobalNbthread:      "4",
-				ingtypes.GlobalNbprocBalance: "1",
+				ingtypes.GlobalUseCPUMap: "true",
+				ingtypes.GlobalCPUMap:    "auto:1/1 1-",
+				ingtypes.GlobalNbthread:  "4",
 			},
 			expected: "auto:1/1 1-",
 		},
 		// 3
 		{
 			ann: map[string]string{
-				ingtypes.GlobalUseCPUMap:     "true",
-				ingtypes.GlobalNbthread:      "2",
-				ingtypes.GlobalNbprocBalance: "1",
+				ingtypes.GlobalUseCPUMap: "true",
+				ingtypes.GlobalNbthread:  "2",
 			},
 			expected: "auto:1/1-2 0-1",
 		},

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -102,7 +102,6 @@ func createDefaults() map[string]string {
 		types.GlobalModsecurityTimeoutIdle:       "30s",
 		types.GlobalModsecurityTimeoutProcessing: "1s",
 		types.GlobalModsecurityTimeoutServer:     "5s",
-		types.GlobalNbprocBalance:                "1",
 		types.GlobalNoRedirectLocations:          "/.well-known/acme-challenge",
 		types.GlobalNoTLSRedirectLocations:       "/.well-known/acme-challenge",
 		types.GlobalOriginalForwardedForHdr:      "X-Original-Forwarded-For",

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -84,8 +84,6 @@ const (
 	GlobalModsecurityTimeoutProcessing = "modsecurity-timeout-processing"
 	GlobalModsecurityTimeoutServer     = "modsecurity-timeout-server"
 	GlobalModsecurityUseCoraza         = "modsecurity-use-coraza"
-	GlobalNbprocBalance                = "nbproc-balance"
-	GlobalNbprocSSL                    = "nbproc-ssl"
 	GlobalNbthread                     = "nbthread"
 	GlobalNoRedirectLocations          = "no-redirect-locations"
 	GlobalNoTLSRedirectLocations       = "no-tls-redirect-locations"

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -98,13 +98,8 @@ type Global struct {
 
 // ProcsConfig ...
 type ProcsConfig struct {
-	Nbproc          int
-	Nbthread        int
-	NbprocBalance   int
-	NbprocSSL       int
-	BindprocBalance string
-	BindprocSSL     string
-	CPUMap          string
+	Nbthread int
+	CPUMap   string
 }
 
 // SyslogConfig ...

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -79,9 +79,6 @@ global
 {{- if $global.Security.UseChroot }}
     chroot /var/empty
 {{- end }}
-{{- if gt $global.Procs.Nbproc 1 }}
-    nbproc {{ $global.Procs.Nbproc }}
-{{- end }}
 {{- if $global.Procs.Nbthread }}
     nbthread {{ $global.Procs.Nbthread }}
 {{- end }}
@@ -89,7 +86,6 @@ global
     cpu-map {{ $global.Procs.CPUMap }}
 {{- end }}
     stats socket {{ default "--" $global.AdminSocket }} level admin expose-fd listeners mode 600
-        {{- if gt $global.Procs.Nbproc 1 }} process 1{{ end }}
 {{- if $global.Timeout.Stats }}
     stats timeout {{ $global.Timeout.Stats }}
 {{- end }}
@@ -1723,7 +1719,6 @@ listen stats
     bind {{ $global.Stats.BindIP }}:{{ $global.Stats.Port }}
         {{- if $global.Stats.TLSFilename }} ssl crt {{ $global.Stats.TLSFilename }}{{ end }}
         {{- if $global.Stats.AcceptProxy }} accept-proxy{{ end }}
-        {{- if gt $global.Procs.Nbproc 1 }} process 1{{ end }}
 {{- if $global.Stats.Auth }}
     stats realm HAProxy\ Statistics
     stats auth {{ $global.Stats.Auth }}


### PR DESCRIPTION
nbproc was never fully migrated after v0.8 refactor, and also HAProxy does not support it anymore. So, removing from the configuration. This update does not break actual deployments, since it was always enforcing value 1 and now it just ignores declared configuration.