### PR TITLE
drop htx configuration

### DIFF
--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -517,7 +517,6 @@ The table below describes all supported configuration keys.
 | [`use-cpu-map`](#cpu-map)                            | [true\|false]                           | Global   | `true`                           |
 | [`use-forwarded-proto`](#http-passthrough)           | [true\|false]                           | Frontend | `true`                           |
 | [`use-haproxy-user`](#security)                      | [true\|false]                           | Global   | `false`                          |
-| [`use-htx`](#use-htx)                                | [true\|false]                           | Global   | `false`                          |
 | [`use-proxy-protocol`](#proxy-protocol)              | [true\|false]                           | Frontend | `false`                          |
 | [`use-resolver`](#dns-resolvers)                     | resolver name                           | Backend  |                                  |
 | [`username`](#security)                              | haproxy user name                       | Global   | `haproxy`                        |
@@ -925,10 +924,7 @@ See also:
 |--------------------|-----------|---------|-------|
 | `backend-protocol` | `Backend` | `h1`    | v0.9  |
 
-Defines the HTTP protocol version of the backend. Note that HTTP/2 is only supported if HTX is enabled.
-A case-insensitive match is used, so either `h1` or `H1` configures HTTP/1 protocol. A non SSL/TLS
-configuration does not overrides [secure-backends](#secure-backend), so `h1` and secure-backends `true`
-will still configure SSL/TLS.
+Defines the HTTP protocol version of the backend. A case-insensitive match is used, so either `h1` or `H1` configures HTTP/1 protocol. A non SSL/TLS configuration does not overrides [secure-backends](#secure-backend), so `h1` and secure-backends `true` will still configure SSL/TLS.
 
 Options:
 
@@ -943,7 +939,6 @@ FastCGI protocol needs a reference to valid haproxy's fcgi-app section via [`fcg
 
 See also:
 
-* [use-htx](#use-htx) configuration key to enable HTTP/2 backends.
 * [secure-backend](#secure-backend) configuration keys to configure optional client certificate and certificate authority bundle of SSL/TLS connections.
 * [FastCGI](#fastcgi) configuration keys.
 * https://docs.haproxy.org/3.0/configuration.html#5.2-proto
@@ -3141,22 +3136,6 @@ HTTP/2 on the client side.
 See also:
 
 * https://docs.haproxy.org/3.0/configuration.html#5.1-alpn
-
----
-
-### Use HTX
-
-| Configuration key | Scope    | Default | Since |
-|-------------------|----------|---------|-------|
-| `use-htx`         | `Global` | `true`  | v0.9  |
-
-Defines if the new HTX internal representation for HTTP elements should be used. The default value
-is `true` since v0.10, it was `false` on v0.9. HTX should be used to enable HTTP/2 protocol to backends.
-
-See also:
-
-* [backend-protocol](#backend-protocol) configuration keys
-* https://docs.haproxy.org/3.0/configuration.html#4-option%20http-use-htx
 
 ---
 

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -902,10 +902,6 @@ func (c *updater) buildBackendProtocol(d *backData) {
 			return
 		}
 	}
-	if protocol == "h2" && !c.haproxy.Global().UseHTX {
-		c.logger.Warn("ignoring h2 protocol on %v due to HTX disabled, changing to h1", proto.Source)
-		protocol = "h1"
-	}
 	if !secure {
 		secure = d.mapper.Get(ingtypes.BackSecureBackends).Bool()
 	}

--- a/pkg/converters/ingress/annotations/backend_test.go
+++ b/pkg/converters/ingress/annotations/backend_test.go
@@ -2292,7 +2292,6 @@ func TestBackendServerNaming(t *testing.T) {
 func TestBackendProtocol(t *testing.T) {
 	testCase := []struct {
 		source     *Source
-		useHTX     bool
 		fcgiapps   []string
 		annDefault map[string]string
 		ann        map[string]map[string]string
@@ -2427,7 +2426,6 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 		},
 		// 8
 		{
-			useHTX: true,
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackBackendProtocol: "GRPC",
@@ -2513,7 +2511,6 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 		},
 		// 15
 		{
-			useHTX: true,
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackBackendProtocol: "h2-ssl",
@@ -2537,19 +2534,6 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 		},
 		// 17
 		{
-			source: &Source{Namespace: "default", Name: "app1", Type: "service"},
-			ann: map[string]map[string]string{
-				"/": {
-					ingtypes.BackBackendProtocol: "h2",
-				},
-			},
-			expected: hatypes.ServerConfig{
-				Protocol: "h1",
-			},
-			logging: `WARN ignoring h2 protocol on service 'default/app1' due to HTX disabled, changing to h1`,
-		},
-		// 18
-		{
 			ann: map[string]map[string]string{
 				"/": {
 					ingtypes.BackBackendProtocol: "h1-ssl",
@@ -2562,7 +2546,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 				SNI:      "ssl_fc_sni",
 			},
 		},
-		// 19
+		// 18
 		{
 			ann: map[string]map[string]string{
 				"/": {
@@ -2576,7 +2560,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 				SNI:      "var(req.host)",
 			},
 		},
-		// 20
+		// 19
 		{
 			ann: map[string]map[string]string{
 				"/": {
@@ -2590,7 +2574,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 				SNI:      "str(domain.tld)",
 			},
 		},
-		// 21
+		// 20
 		{
 			source: &Source{Namespace: "default", Name: "app", Type: "ingress"},
 			ann: map[string]map[string]string{
@@ -2605,7 +2589,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 			},
 			logging: `WARN skipping invalid domain (SNI) on ingress 'default/app': invalid/domain`,
 		},
-		// 22
+		// 21
 		{
 			ann: map[string]map[string]string{
 				"/": {
@@ -2619,7 +2603,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 				VerifyHost: "domain.tld",
 			},
 		},
-		// 23
+		// 22
 		{
 			source: &Source{Namespace: "default", Name: "app", Type: "ingress"},
 			ann: map[string]map[string]string{
@@ -2634,7 +2618,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 			},
 			logging: `WARN skipping invalid domain (verify-hostname) on ingress 'default/app': invalid/domain`,
 		},
-		// 24
+		// 23
 		{
 			ann: map[string]map[string]string{
 				"/": {
@@ -2648,7 +2632,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 				VerifyHost: "valid-domain.tld",
 			},
 		},
-		// 25
+		// 24
 		{
 			ann: map[string]map[string]string{
 				"/": {
@@ -2662,7 +2646,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 				VerifyHost: "sub.valid-domain.tld",
 			},
 		},
-		// 26
+		// 25
 		{
 			source: &Source{Namespace: "default", Name: "app", Type: "ingress"},
 			ann: map[string]map[string]string{
@@ -2677,7 +2661,7 @@ WARN skipping CA on service 'default/app1': secret not found: 'default/ca'`,
 			},
 			logging: `WARN skipping invalid domain (verify-hostname) on ingress 'default/app': invalid-domain`,
 		},
-		// 27
+		// 26
 		{
 			ann: map[string]map[string]string{
 				"/": {
@@ -2701,7 +2685,7 @@ WARN skipping client certificate on <global>: a globally configured resource nam
 WARN skipping CA on <global>: a globally configured resource name is missing the namespace: ca
 `,
 		},
-		// 28
+		// 27
 		{
 			ann: map[string]map[string]string{
 				"/": {
@@ -2729,7 +2713,6 @@ WARN skipping CA on <global>: a globally configured resource name is missing the
 	for i, test := range testCase {
 		c := setup(t)
 		d := c.createBackendMappingData("default/app", test.source, test.annDefault, test.ann, test.paths)
-		c.haproxy.Global().UseHTX = test.useHTX
 		c.haproxy.Global().FastCGIApps = test.fcgiapps
 		c.cache.SecretTLSPath = test.tlsSecrets
 		c.cache.SecretCAPath = test.caSecrets

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -184,7 +184,6 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	d.global.Master.IsMasterWorker = c.options.MasterSocket != ""
 	d.global.Master.WorkerMaxReloads = mapper.Get(ingtypes.GlobalWorkerMaxReloads).Int()
 	d.global.StrictHost = mapper.Get(ingtypes.GlobalStrictHost).Bool()
-	d.global.UseHTX = mapper.Get(ingtypes.GlobalUseHTX).Bool()
 	c.buildGlobalAcme(d)
 	c.buildGlobalAuthProxy(d)
 	c.buildGlobalAuthTLS(d)

--- a/pkg/converters/ingress/defaults.go
+++ b/pkg/converters/ingress/defaults.go
@@ -120,7 +120,6 @@ func createDefaults() map[string]string {
 		types.GlobalTimeoutClientFin:             "50s",
 		types.GlobalTimeoutStop:                  "10m",
 		types.GlobalUseCPUMap:                    "true",
-		types.GlobalUseHTX:                       "true",
 		types.GlobalDefaultBackendRedirectCode:   "302",
 	}
 }

--- a/pkg/converters/ingress/types/global.go
+++ b/pkg/converters/ingress/types/global.go
@@ -119,7 +119,6 @@ const (
 	GlobalUseChroot                    = "use-chroot"
 	GlobalUseCPUMap                    = "use-cpu-map"
 	GlobalUseHAProxyUser               = "use-haproxy-user"
-	GlobalUseHTX                       = "use-htx"
 	GlobalUsername                     = "username"
 	GlobalWorkerMaxReloads             = "worker-max-reloads"
 )

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -6377,7 +6377,6 @@ func (c *testConfig) configGlobal(global *hatypes.Global) {
 	global.Timeout.ServerFin = "50s"
 	global.Timeout.Stop = "15m"
 	global.Timeout.Tunnel = "1h"
-	global.UseHTX = true
 }
 
 func (c *testConfig) httpFrontend(port int32) *hatypes.Frontend {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -81,7 +81,6 @@ type Global struct {
 	TimeoutStopDuration     time.Duration
 	StrictHost              bool
 	FastCGIApps             []string
-	UseHTX                  bool
 	DefaultBackendRedir     string
 	DefaultBackendRedirCode int
 	NoRedirects             []string

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -163,9 +163,6 @@ defaults
 {{- end }}
     option dontlognull
     option http-keep-alive
-{{- if not $global.UseHTX }}
-    no option http-use-htx
-{{- end }}
 {{- range $response := $global.CustomHTTPResponses.HAProxy }}
     errorfile {{ $response.Name }} {{ $global.LocalFSPrefix }}/etc/haproxy/errorfiles/{{ $response.Name }}-{{ $global.CustomHTTPResponses.ID }}.http
 {{- end }}


### PR DESCRIPTION
HTX is a HAProxy 1.9 / 2.0 feature used during h2 development, as a transitory mux implementation helper. This option is always enabled now, there is no reason to maintain a flag to remove it. Removal does not break actual deployments, since any eventually configured HTX option should always be true and now it is being ignored.