### PR TITLE
Use numeric USER in Dockerfile

### DIFF
--- a/builder/Dockerfile
+++ b/builder/Dockerfile
@@ -43,7 +43,8 @@ RUN mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
  && setcap 'cap_net_bind_service=+ep' /usr/local/sbin/haproxy
 
 STOPSIGNAL SIGTERM
-USER haproxy
+# uid 99 = haproxy
+USER 99
 
 # dumb-init reaps the old haproxy process in the embedded, non master-worker mode,
 # after receiving SIGUSR1, avoiding it to become a zombie.

--- a/rootfs/Dockerfile
+++ b/rootfs/Dockerfile
@@ -26,7 +26,8 @@ RUN mkdir -p /var/empty /etc/haproxy /var/lib/haproxy /var/run/haproxy\
  && setcap 'cap_net_bind_service=+ep' /usr/local/sbin/haproxy
 
 STOPSIGNAL SIGTERM
-USER haproxy
+# uid 99 = haproxy
+USER 99
 
 # dumb-init reaps the old haproxy process in the embedded, non master-worker mode,
 # after receiving SIGUSR1, avoiding it to become a zombie.


### PR DESCRIPTION
When switching back to the unprivileged user in the image build, we should specify this via the numeric UID (99) rather than the symbolic username (haproxy).  This is good practice generally, but it is essential for compatibility with the `runAsNonRoot` container security context setting in Kubernetes.

When a container is configured to `runAsNonRoot` but does _not_ have an explicit `runAsUser` setting, Kubernetes will refuse to run it if the image specifies a symbolic `USER` name in its config, since it is impossible for the container runtime to know for certain that this name will not map to UID 0 once the container is up and running.  Specifying the `USER` numerically provides this guarantee.

Fixes jcmoraisjr/haproxy-ingress#1430