### PR TITLE
fix HTTPS frontend name mismatch breaking backend pathID matching

### DIFF
--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -99,10 +99,12 @@ func (c *config) SyncConfig() {
 }
 
 func (c *config) syncFrontend(f *hatypes.Frontend) {
+	f.RenderedName = f.Name
 	if f.IsHTTPS {
 		if f.HasSSLPassthrough() {
 			// using ssl-passthrough config, so need a `mode tcp`
 			// frontend with `inspect-delay` and `req.ssl_sni`
+			f.RenderedName = f.Name + "__local"
 			if f.Name == "_front_https" {
 				f.TLSProxyName = "_front__tls" // backward compatible name
 			} else {

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -4826,6 +4826,81 @@ d3.local#/ d3_app1-http_8080
 	c.logger.CompareLogging(defaultLogging)
 }
 
+func TestInstanceSSLPassthroughFrontendACL(t *testing.T) {
+	c := setup(t)
+	defer c.teardown()
+
+	var h *hatypes.Host
+	var b *hatypes.Backend
+
+	fhttp := c.httpFrontend(80)
+	fhttps := c.httpsFrontend(443)
+
+	// A backend accessible from both HTTP and HTTPS frontends with
+	// different path config (SSLRedirect on HTTP) to trigger NeedFrontendACL.
+	b = c.config.Backends().AcquireBackend("d1", "app", "8080")
+	b.Endpoints = []*hatypes.Endpoint{endpointS1}
+
+	h = fhttp.AcquireHost("d1.local")
+	h.AddPath(b, "/", hatypes.MatchBegin).SSLRedirect = true
+
+	h = fhttps.AcquireHost("d1.local")
+	h.AddPath(b, "/", hatypes.MatchBegin)
+	h.TLS.TLSFilename = "/var/haproxy/ssl/certs/default.pem"
+	h.TLS.TLSHash = "0"
+
+	// SSL passthrough host on a different hostname, same HTTPS frontend.
+	// This causes the HTTPS frontend to be rendered as _front_https__local.
+	b2 := c.config.Backends().AcquireBackend("d2", "ssl-app", "8443")
+	b2.Endpoints = []*hatypes.Endpoint{endpointS21}
+	b2.ModeTCP = true
+
+	h = fhttps.AcquireHost("d2.local")
+	h.AddPath(b2, "/", hatypes.MatchBegin)
+	h.SSLPassthrough = true
+
+	c.Update()
+	c.checkConfig(`
+<<global>>
+<<defaults>>
+backend d1_app_8080
+    mode http
+    acl https-request ssl_fc
+    # path01 = fe:_front_http -- host/path:d1.local/
+    # path02 = fe:_front_https__local -- host/path:d1.local/
+    http-request set-var-fmt(req.fe) "%f"
+    http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_front_http_req__begin.map) if { var(req.fe) -m str _front_http }
+    http-request set-var(txn.pathID) var(req.base),lower,map_beg(/etc/haproxy/maps/_back_d1_app_8080_front_https__local_req__begin.map) if { var(req.fe) -m str _front_https__local }
+    http-request redirect scheme https if !https-request { var(txn.pathID) -m str path01 }
+    server s1 172.17.0.11:8080 weight 100
+backend d2_ssl-app_8443
+    mode tcp
+    server s21 172.17.0.121:8080 weight 100
+<<backends-default>>
+<<frontend-http>>
+    default_backend _error404
+listen _front__tls
+    mode tcp
+    bind :443
+    tcp-request inspect-delay 5s
+    tcp-request content set-var(req.sslpassback) req.ssl_sni,lower,map_str(/etc/haproxy/maps/_front_https_sslpassthrough__exact.map)
+    tcp-request content accept if { req.ssl_hello_type 1 }
+    use_backend %[var(req.sslpassback)]
+    server _default_server_front_https_socket unix@/var/run/haproxy/_front_https_socket.sock send-proxy-v2
+frontend _front_https__local
+    mode http
+    bind unix@/var/run/haproxy/_front_https_socket.sock accept-proxy ssl alpn h2,http/1.1 crt-list /etc/haproxy/maps/_front_https_bind_crt.list ca-ignore-err all crt-ignore-err all
+    <<set-req-base>>
+    http-request set-var(req.hostbackend) var(req.base),lower,map_beg(/etc/haproxy/maps/_front_https_host__begin.map)
+    <<https-headers>>
+    use_backend %[var(req.hostbackend)] if { var(req.hostbackend) -m found }
+    default_backend _error404
+<<support>>
+`)
+
+	c.logger.CompareLogging(defaultLogging)
+}
+
 func TestInstanceRootRedirect(t *testing.T) {
 	c := setup(t)
 	defer c.teardown()

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -337,7 +337,7 @@ func (b *Backend) PathsMaps() []*BackendPathsMaps {
 func (b *Backend) createPathsMaps() []*BackendPathsMaps {
 	var pathsMaps []*BackendPathsMaps
 	for _, path := range b.Paths {
-		frontendName := path.Host.Frontend.RenderedName()
+		frontendName := path.Host.Frontend.RenderedName
 		i := slices.IndexFunc(pathsMaps, func(b *BackendPathsMaps) bool { return slices.Contains(b.Frontends, frontendName) })
 		if i < 0 {
 			i = len(pathsMaps)

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -337,7 +337,7 @@ func (b *Backend) PathsMaps() []*BackendPathsMaps {
 func (b *Backend) createPathsMaps() []*BackendPathsMaps {
 	var pathsMaps []*BackendPathsMaps
 	for _, path := range b.Paths {
-		frontendName := path.Host.Frontend.Name
+		frontendName := path.Host.Frontend.RenderedName()
 		i := slices.IndexFunc(pathsMaps, func(b *BackendPathsMaps) bool { return slices.Contains(b.Frontends, frontendName) })
 		if i < 0 {
 			i = len(pathsMaps)

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -43,13 +43,14 @@ func (f *Frontends) AcquireFrontend(port int32, isHTTPS bool) *Frontend {
 		name = fmt.Sprintf("%s_%d", name, port)
 	}
 	frontend := &Frontend{
-		Name:     name,
-		Bind:     fmt.Sprintf(":%d", port),
-		IsHTTPS:  isHTTPS,
-		port:     port,
-		hosts:    map[string]*Host{},
-		hostsAdd: map[string]*Host{},
-		hostsDel: map[string]*Host{},
+		Name:         name,
+		RenderedName: name,
+		Bind:         fmt.Sprintf(":%d", port),
+		IsHTTPS:      isHTTPS,
+		port:         port,
+		hosts:        map[string]*Host{},
+		hostsAdd:     map[string]*Host{},
+		hostsDel:     map[string]*Host{},
 	}
 	f.items = append(f.items, frontend)
 	return frontend
@@ -309,15 +310,6 @@ func (f *Frontend) HasTLSAuth() bool {
 		}
 	}
 	return false
-}
-
-// RenderedName returns the actual HAProxy frontend name, including the
-// "__local" suffix when the frontend is HTTPS with SSL passthrough.
-func (f *Frontend) RenderedName() string {
-	if f.IsHTTPS && f.HasSSLPassthrough() {
-		return f.Name + "__local"
-	}
-	return f.Name
 }
 
 // HasSSLPassthrough ...

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -311,6 +311,15 @@ func (f *Frontend) HasTLSAuth() bool {
 	return false
 }
 
+// RenderedName returns the actual HAProxy frontend name, including the
+// "__local" suffix when the frontend is HTTPS with SSL passthrough.
+func (f *Frontend) RenderedName() string {
+	if f.IsHTTPS && f.HasSSLPassthrough() {
+		return f.Name + "__local"
+	}
+	return f.Name
+}
+
 // HasSSLPassthrough ...
 func (f *Frontend) HasSSLPassthrough() bool {
 	for _, host := range f.hosts {

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -487,10 +487,11 @@ type Frontends struct {
 
 // Frontend ...
 type Frontend struct {
-	HTTPMaps  *FrontendHTTPMaps
-	HTTPSMaps *FrontendHTTPSMaps
-	Name      string
-	IsHTTPS   bool
+	HTTPMaps     *FrontendHTTPMaps
+	HTTPSMaps    *FrontendHTTPSMaps
+	Name         string
+	RenderedName string
+	IsHTTPS      bool
 	//
 	// Bind related
 	Bind        string

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1371,7 +1371,7 @@ frontend {{ $frontend.Name }}
 # #
 #     HTTPS frontend
 #
-{{- $httpsFrontendName := printf "%s%s" $frontend.Name (iif $hasSSLPassthrough "__local" "") }}
+{{- $httpsFrontendName := $frontend.RenderedName }}
 frontend {{ $httpsFrontendName }}
     mode http
 


### PR DESCRIPTION
When ssl-passthrough is enabled, the HTTPS frontend is rendered as _front_https__local in haproxy.tmpl, but createPathsMaps() used Frontend.Name (_front_https without the suffix). This caused the var(req.fe) string match to fail, silently skipping all path-conditional rules (rewrite-target, HSTS, ssl-redirect, cors, etc.).

Add Frontend.RenderedName() that includes the __local suffix when appropriate, and use it in both createPathsMaps() and the template.

Fixes #1432.