### PR TITLE
match sni using single dns label

### DIFF
--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -1105,7 +1105,7 @@ func (c *converter) createTLSHosts(gatewaySource, routeSource *source, listener 
 		}
 		if h == nil {
 			h = f.AcquireHost(string(hostname))
-			h.ExtendedWildcard = true
+			h.ExtendedWildcard = false
 			h.SSLPassthrough = true
 		}
 		link := hatypes.CreatePathLink("/", hatypes.MatchPrefix).WithHTTPHost(h)


### PR DESCRIPTION
Gateway API uses distinct wildcard hostname match on HTTP and TLS:

* Host header and HTTPRoute hostnames matching understand a wildcard as one or more DNS labels, so the wildcard hostname is used as a suffix;
* TLS SNI extension and TLSRoute hostnames matching understand a wildcard as a single DNS label, following RFC-2818.

Context:

https://github.com/kubernetes-sigs/gateway-api/blob/8f9b904306371cbfed9f9d542e9af667de804286/site-src/concepts/hostnames.md?plain=1#L142-L145

https://github.com/kubernetes-sigs/gateway-api/pull/4437#discussion_r2741544624

TLSRoute was not following this configuration, but instead the suffix approach of the HTTPRoute, making one of the conformance tests to fail. This update configures ExtendedWildcard to false, so HAProxy configures the TLS/SNI match using single DNS label instead.