### PR TITLE
enable leaf reference on go1.19 compatibility mode

### DIFF
--- a/pkg/main.go
+++ b/pkg/main.go
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 //go:debug default=go1.19
+//go:debug x509keypairleaf=1
 package main
 
 // TODO remove go1.19 compatibility after dropping legacy mode

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -1,3 +1,5 @@
+//go:debug default=go1.19
+//go:debug x509keypairleaf=1
 package integration_test
 
 import (


### PR DESCRIPTION
A fix on x509 certificate validation for v0.15.1 changed the func used to parse the crt and key pair. The method creates a `tls.Certificate`, whose `Leaf` attribute is used internally.

The `Leaf` attribute is populated since go1.23, which is older than the version used to compile the controller. The legacy controller engine code used up to v0.14 have compatibility issues with go version newer than 1.19. v0.15 added controller-runtime, but still has the older engine available that can be enabled in legacy mode. Because of the legacy engine, v0.15 code runs in go1.19 compatibility mode which leads the Leaf attribute of the certificate to become unassigned.

The integration tests cover this functionality and would caught this error, but the compatibility mode was being applied only in the main package. This update not only enables the Leaf attribute, but also adds the same compatibility mode in the integration tests package as well.

This is a v0.15 failure only, v0.16 had the compatibility mode removed along with the legacy controller engine, and v0.14 uses only the legacy code to validate certificates.