### PR TITLE
add build image step in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,3 +53,21 @@ jobs:
         go-version: "1.26.1"
     - name: Run integration tests on Kubernetes ${{ matrix.envtest-version }}
       run: HAPROXY_INGRESS_ENVTEST=${{ matrix.envtest-version }} make test-integration
+  image:
+    if: github.ref_name != 'master'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - uses: docker/login-action@v4
+      with:
+        username: jcmoraisjr
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - uses: docker/setup-qemu-action@v4
+    - uses: docker/setup-buildx-action@v4
+    - uses: docker/build-push-action@v7
+      with:
+        context: .
+        file: builder/Dockerfile
+        platforms: linux/amd64,linux/arm64/v8,linux/arm/v7,linux/arm/v6,linux/s390x
+        push: false
+        tags: haproxy-ingress.localhost:latest


### PR DESCRIPTION
Since the refactor of the Dockerfile builder, which cross-compile in the build platform instead of compile in the target, emulated one, the build step should be (almost) fast enough to be part of the regular build.

Adding the build image step can anticipate issues during cross-compile and local image generation for the target platform.