### PR TITLE
adding boundary in the idle_pct metric

### DIFF
--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -274,6 +274,13 @@ func (i *instance) CalcIdleMetric() {
 	idle, err := strconv.Atoi(idleStr[1])
 	if err != nil {
 		i.logger.Error("Idle_pct has an invalid integer: %s", idleStr[1])
+		return
+	}
+	if idle < 0 || idle > 100 {
+		// https://github.com/jcmoraisjr/haproxy-ingress/issues/1452
+		// https://github.com/haproxy/haproxy/issues/3339
+		i.logger.Warn("haproxy idle metric '%d' is out of bounds (0-100), skipping the scraped data to avoid an inaccurate metric", idle)
+		return
 	}
 	i.metrics.AddIdleFactor(idle)
 }


### PR DESCRIPTION
HAProxy's Idle_pct metric should go between 0 and 100, which generates a valid counter for controller's idle metric. However the counter calculation has already reported a negative value which led to Prometheus panicking. The only way to the value being negative is a Idle_pct as 101 or greater. This update adds boundary check as a safeguard, in order to protect the controller process against inaccurate data coming from HAProxy.

Also, we're skipping metric reading in case of an unexpected failure reading the Idle_pct metric.

Should be merged to all the supported branches.