### PR TITLE
start decoupling global and ingress converters

### DIFF
--- a/pkg/controller/services/ssl.go
+++ b/pkg/controller/services/ssl.go
@@ -198,7 +198,8 @@ func (s *SSL) buildCertFromCrtAndKey(fileName string, crt, key, ca []byte) (*ssl
 }
 
 func (s *SSL) buildCertFromCAAndCRL(caFileName, crlFileName string, ca, crl []byte) (*sslCert, error) {
-	if _, err := s.checkValidCertPEM(ca); err != nil {
+	crt, err := s.checkValidCertPEM(ca)
+	if err != nil {
 		return nil, err
 	}
 	var pemSHA1 [sha1.Size]byte
@@ -222,6 +223,7 @@ func (s *SSL) buildCertFromCAAndCRL(caFileName, crlFileName string, ca, crl []by
 		CRLFileName: crlFileName,
 		PemFileName: caFileName,
 		PemSHA:      hex.EncodeToString(pemSHA1[:]),
+		Certificate: crt,
 	}, nil
 }
 
@@ -254,8 +256,9 @@ func (s *SSL) createFakeCertAndCA() (crtFile, caFile convtypes.CrtFile, err erro
 		Certificate: sslCrt.Certificate,
 	}
 	caFile = convtypes.CrtFile{
-		Filename: sslCA.PemFileName,
-		SHA1Hash: sslCA.PemSHA,
+		Filename:    sslCA.PemFileName,
+		SHA1Hash:    sslCA.PemSHA,
+		Certificate: sslCA.Certificate,
 	}
 	return crtFile, caFile, nil
 }

--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -17,9 +17,9 @@ limitations under the License.
 package converters
 
 import (
-	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/configmap"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/gateway"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/tcpservices"
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
@@ -50,10 +50,12 @@ type converters struct {
 func (c *converters) Sync() error {
 	logger := c.options.Logger
 	changed := c.changed
+	globalConverter := ingress.NewGlobalConverter(c.options, c.haproxy, changed)
 	ingressConverter := ingress.NewIngressConverter(c.options, c.haproxy, changed)
 	gatewayConverter := gateway.NewGatewayConverter(c.options, c.haproxy, changed, ingressConverter)
 
 	needFullSync := changed.NeedFullSync ||
+		globalConverter.NeedFullSync() ||
 		gatewayConverter.NeedFullSync() ||
 		ingressConverter.NeedFullSync()
 	if needFullSync {
@@ -70,11 +72,21 @@ func (c *converters) Sync() error {
 	}
 
 	//
+	// Global converter
+	//
+	logger.Info("syncing Global configurations")
+	err := globalConverter.Sync(needFullSync)
+	c.timer.Tick("parse_global")
+	if err != nil {
+		return err
+	}
+
+	//
 	// gateway converter
 	//
-	if c.options.HasGateway && needFullSync {
+	if c.options.HasGateway {
 		logger.Info("syncing Gateway API resources")
-		err := gatewayConverter.SyncFull()
+		err := gatewayConverter.Sync(needFullSync)
 		c.timer.Tick("parse_gateway")
 		if err != nil {
 			return err
@@ -89,7 +101,7 @@ func (c *converters) Sync() error {
 	c.timer.Tick("parse_ingress")
 
 	//
-	// configmap converters
+	// tcpservices converter
 	//
 	if changed.TCPConfigMapDataCur != nil || changed.TCPConfigMapDataNew != nil {
 		// We always need to run configmap based tcp sync, when configured, because
@@ -97,7 +109,7 @@ func (c *converters) Sync() error {
 		// or secret updates. Although cur is always assigned if configmap based tcp
 		// is configured, only new is assigned in the very first run. OTOH, new is
 		// only assigned when the configmap is changed. So we need to check both.
-		tcpSvcConverter := configmap.NewTCPServicesConverter(c.options, c.haproxy, changed)
+		tcpSvcConverter := tcpservices.NewTCPServicesConverter(c.options, c.haproxy, changed)
 		tcpSvcConverter.Sync()
 		c.timer.Tick("parse_tcp_svc")
 	}

--- a/pkg/converters/gateway/gateway.go
+++ b/pkg/converters/gateway/gateway.go
@@ -49,7 +49,7 @@ import (
 // Config ...
 type Config interface {
 	NeedFullSync() bool
-	SyncFull() error
+	Sync(full bool) error
 }
 
 // NewGatewayConverter ...
@@ -235,7 +235,10 @@ func (c *converter) NeedFullSync() bool {
 	return changed
 }
 
-func (c *converter) SyncFull() error {
+func (c *converter) Sync(full bool) error {
+	if !full {
+		return nil
+	}
 	if err := c.syncReferenceGrant(); err != nil {
 		return err
 	}

--- a/pkg/converters/gateway/gateway_test.go
+++ b/pkg/converters/gateway/gateway_test.go
@@ -830,7 +830,7 @@ tls:
 func TestGatewayClassStatus(t *testing.T) {
 	c := setup(t)
 	gwcls := c.createGatewayClass("haproxy")
-	_ = c.createConverter().SyncFull()
+	_ = c.createConverter().Sync(true)
 	c.compareStatus("gatewayclass", gwcls, `
 conditions:
 - lastTransitionTime: "-"
@@ -999,7 +999,7 @@ listeners:
 			c := setup(t)
 			_ = c.createGatewayClass("haproxy")
 			gw := test.create(c)
-			_ = c.createConverter().SyncFull()
+			_ = c.createConverter().Sync(true)
 			c.compareStatus("gateway", gw, test.expStatus)
 			c.logger.CompareLogging(test.expLogging)
 		})
@@ -1209,7 +1209,7 @@ func runTestSync(t *testing.T, testCases []testCaseSync) {
 			// ch.Links reflects changes made by the watcher
 			hasChanges := len(c.cache.Changed.Links) > 0
 			conv := c.createConverter()
-			_ = conv.SyncFull()
+			_ = conv.Sync(true)
 
 			if hasChanges {
 				c.hconfig.Commit()

--- a/pkg/converters/ingress/annotations/frontend.go
+++ b/pkg/converters/ingress/annotations/frontend.go
@@ -34,7 +34,8 @@ type FrontendPorts struct {
 	httpPort,
 	httpsPort,
 	httpPassPort int32
-	frontends map[string]httpPorts
+	frontends       map[string]httpPorts
+	createFrontends bool
 }
 
 type FrontendLocalPorts struct {
@@ -113,13 +114,15 @@ func NewFrontendPorts(logger types.Logger, haproxy haproxy.Config, globalMapper 
 		frontends[frontID] = httpPorts{http: frontHTTP, https: frontHTTPS}
 		denyPorts = append(denyPorts, frontHTTP, frontHTTPS)
 	}
+	createFrontends := globalMapper.Get(ingtypes.GlobalCreateDefaultFrontends).Bool()
 
 	return &FrontendPorts{
-		logger:       logger,
-		httpPort:     httpPort,
-		httpsPort:    httpsPort,
-		httpPassPort: httpPassPort,
-		frontends:    frontends,
+		logger:          logger,
+		httpPort:        httpPort,
+		httpsPort:       httpsPort,
+		httpPassPort:    httpPassPort,
+		frontends:       frontends,
+		createFrontends: createFrontends,
 	}
 }
 
@@ -161,15 +164,19 @@ func (fp *FrontendPorts) AcquirePorts(mapper *Mapper) (FrontendLocalPorts, error
 	}, nil
 }
 
-func (fp *FrontendPorts) EnsureEmptyFrontends(frontends *hatypes.Frontends) {
-	_ = frontends.AcquireFrontend(fp.httpPort, false)
-	_ = frontends.AcquireFrontend(fp.httpsPort, true)
-	if fp.httpPassPort > 0 && fp.httpPassPort != fp.httpPort {
-		_ = frontends.AcquireFrontend(fp.httpPassPort, false)
-	}
-	for _, f := range fp.frontends {
-		_ = frontends.AcquireFrontend(f.http, false)
-		_ = frontends.AcquireFrontend(f.https, true)
+func (fp *FrontendPorts) SyncFrontends(frontends *hatypes.Frontends) {
+	if fp.createFrontends {
+		_ = frontends.AcquireFrontend(fp.httpPort, false)
+		_ = frontends.AcquireFrontend(fp.httpsPort, true)
+		if fp.httpPassPort > 0 && fp.httpPassPort != fp.httpPort {
+			_ = frontends.AcquireFrontend(fp.httpPassPort, false)
+		}
+		for _, f := range fp.frontends {
+			_ = frontends.AcquireFrontend(f.http, false)
+			_ = frontends.AcquireFrontend(f.https, true)
+		}
+	} else {
+		frontends.RemoveEmptyFrontends()
 	}
 }
 

--- a/pkg/converters/ingress/annotations/updater.go
+++ b/pkg/converters/ingress/annotations/updater.go
@@ -32,8 +32,8 @@ import (
 
 // Updater ...
 type Updater interface {
-	UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mapper)
-	UpdatePeers(haproxyConfig haproxy.Config, mapper *Mapper)
+	UpdateGlobalConfig(mapper *Mapper)
+	UpdatePeers(mapper *Mapper)
 	UpdateTCPPortConfig(tcp *hatypes.TCPServicePort, mapper *Mapper)
 	UpdateTCPHostConfig(tcpPort *hatypes.TCPServicePort, tcpHost *hatypes.TCPServiceHost, mapper *Mapper)
 	UpdateFrontConfig(front *hatypes.Frontend, mapper *Mapper, localPorts bool)
@@ -160,11 +160,11 @@ func (c *updater) splitDualCIDR(cidrlist *ConfigValue) (allow, deny []string) {
 	return allow, deny
 }
 
-func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mapper) {
-	c.UpdatePeers(haproxyConfig, mapper)
+func (c *updater) UpdateGlobalConfig(mapper *Mapper) {
+	c.UpdatePeers(mapper)
 	d := &globalData{
-		acmeData: haproxyConfig.AcmeData(),
-		global:   haproxyConfig.Global(),
+		acmeData: c.haproxy.AcmeData(),
+		global:   c.haproxy.Global(),
 		mapper:   mapper,
 	}
 	d.global.AdminSocket = c.options.AdminSocket
@@ -205,9 +205,9 @@ func (c *updater) UpdateGlobalConfig(haproxyConfig haproxy.Config, mapper *Mappe
 	c.buildGlobalCloseSessions(d) // last one, it conditionally overrides timeout config
 }
 
-func (c *updater) UpdatePeers(haproxyConfig haproxy.Config, mapper *Mapper) {
+func (c *updater) UpdatePeers(mapper *Mapper) {
 	// NOTE - Peers is updated without cleanup, so all the methods should be idempotent.
-	global := haproxyConfig.Global()
+	global := c.haproxy.Global()
 	d := &globalData{
 		global: global,
 		mapper: mapper,

--- a/pkg/converters/ingress/global.go
+++ b/pkg/converters/ingress/global.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"maps"
+	"reflect"
+	"strings"
+
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/annotations"
+	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
+	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy"
+	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/types"
+)
+
+// ConfigGlobal ...
+type ConfigGlobal interface {
+	NeedFullSync() bool
+	Sync(full bool) error
+}
+
+// TODO: decouple global and ingress converters, and move global to its own package
+
+// NewGlobalConverter ...
+func NewGlobalConverter(options *convtypes.ConverterOptions, haproxy haproxy.Config, changed *convtypes.ChangedObjects) ConfigGlobal {
+	logger := options.Logger
+	cache := options.Cache
+	defaultCrt := options.FakeCrtFile
+	updater := annotations.NewUpdater(haproxy, options)
+	mapper := newGlobalMapBuilder(options, changed).NewMapper()
+	if options.DefaultCrtSecret != "" {
+		var err error
+		defaultCrt, err = cache.GetTLSSecretPath("", options.DefaultCrtSecret, nil)
+		if err != nil {
+			defaultCrt = options.FakeCrtFile
+			logger.Warn("using auto generated fake certificate due to an error reading default TLS certificate: %v", err)
+		}
+	}
+	c := &converterGlobal{
+		logger:     logger,
+		options:    options,
+		haproxy:    haproxy,
+		changed:    changed,
+		cache:      cache,
+		updater:    updater,
+		mapper:     mapper,
+		defaultCrt: defaultCrt,
+	}
+	return c
+}
+
+func newGlobalMapBuilder(options *convtypes.ConverterOptions, changed *convtypes.ChangedObjects) *annotations.MapBuilder {
+	defaults := createDefaults()
+	if options.DefaultsOverride != nil {
+		maps.Copy(defaults, options.DefaultsOverride)
+	}
+	customConfig := changed.GlobalConfigMapDataNew
+	if customConfig == nil {
+		customConfig = changed.GlobalConfigMapDataCur
+	}
+	maps.Copy(defaults, customConfig)
+	return annotations.NewMapBuilder(options.Logger, defaults)
+}
+
+type converterGlobal struct {
+	logger     types.Logger
+	options    *convtypes.ConverterOptions
+	haproxy    haproxy.Config
+	changed    *convtypes.ChangedObjects
+	cache      convtypes.Cache
+	updater    annotations.Updater
+	mapper     *annotations.Mapper
+	defaultCrt convtypes.CrtFile
+}
+
+func (c *converterGlobal) NeedFullSync() bool {
+	crtHash := c.haproxy.Global().SSL.DefaultCrt.Hash
+	needFullSync := crtHash != c.defaultCrt.SHA1Hash
+
+	if !needFullSync {
+		// global changes need a full sync because part of these keys
+		// are default values for ingress annotations
+		cmCurr, cmNew := c.changed.GlobalConfigMapDataCur, c.changed.GlobalConfigMapDataNew
+		needFullSync = cmNew != nil && !reflect.DeepEqual(cmCurr, cmNew)
+	}
+
+	if needFullSync && crtHash == c.options.FakeCrtFile.SHA1Hash {
+		c.logger.Info("using auto generated fake certificate")
+	}
+
+	return needFullSync
+}
+
+func (c *converterGlobal) Sync(full bool) error {
+	if full {
+		return c.syncFull()
+	}
+	return c.syncPartial()
+}
+
+func (c *converterGlobal) syncFull() error {
+	c.updater.UpdateGlobalConfig(c.mapper)
+	c.haproxy.Global().SSL.DefaultCrt = hatypes.CertificateConfig{
+		Filename:   c.defaultCrt.Filename,
+		Hash:       c.defaultCrt.SHA1Hash,
+		CommonName: c.defaultCrt.Certificate.Subject.CommonName,
+		NotAfter:   c.defaultCrt.Certificate.NotAfter,
+	}
+	return nil
+}
+
+func (c *converterGlobal) syncPartial() error {
+	if c.mapper.Get(ingtypes.GlobalPeersPort).Int() != 0 {
+		// looking for controller pod changes, used by peers.
+		// missing a better tracking and global update approach.
+		ctrlNamespace := c.cache.GetControllerPod().Namespace + "/"
+		changedPods := c.changed.Links[convtypes.ResourcePod]
+		for _, pod := range changedPods {
+			if strings.HasPrefix(pod, ctrlNamespace) {
+				c.logger.Info("updating peers due to changes in controller pods")
+				c.updater.UpdatePeers(c.mapper)
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/converters/ingress/ingress.go
+++ b/pkg/converters/ingress/ingress.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"maps"
-	"reflect"
 	"regexp"
 	"slices"
 	"sort"
@@ -51,31 +50,20 @@ type Config interface {
 
 // NewIngressConverter ...
 func NewIngressConverter(options *convtypes.ConverterOptions, haproxy haproxy.Config, changed *convtypes.ChangedObjects) Config {
-	if options.DefaultConfig == nil {
-		options.DefaultConfig = createDefaults
-	}
-	// IMPLEMENT
-	// config option to allow partial parsing
-	// cache also need to know if partial parsing is enabled
-	globalConfig := changed.GlobalConfigMapDataNew
-	if globalConfig == nil {
-		globalConfig = changed.GlobalConfigMapDataCur
-	}
-	defaultConfig := options.DefaultConfig()
-	for key, value := range globalConfig {
-		defaultConfig[key] = value
-	}
-	c := &converter{
+	logger := options.Logger
+	mapBuilder := newGlobalMapBuilder(options, changed)
+	frontendPorts := annotations.NewFrontendPorts(logger, haproxy, mapBuilder.NewMapper())
+	return &converter{
 		options:            options,
 		haproxy:            haproxy,
 		changed:            changed,
-		logger:             options.Logger,
+		logger:             logger,
 		cache:              options.Cache,
 		tracker:            options.Tracker,
+		mapBuilder:         mapBuilder,
+		frontendPorts:      frontendPorts,
 		defaultBackSource:  annotations.Source{Name: "<default-backend>", Type: convtypes.ResourceIngress},
-		mapBuilder:         annotations.NewMapBuilder(options.Logger, defaultConfig),
 		updater:            annotations.NewUpdater(haproxy, options),
-		globalConfig:       annotations.NewMapBuilder(options.Logger, defaultConfig).NewMapper(),
 		tcpsvcAnnotations:  map[*hatypes.TCPServicePort]*annotations.Mapper{},
 		frontAnnotations:   map[*hatypes.Frontend]*annotations.Mapper{},
 		frontLocalPorts:    map[*hatypes.Frontend]bool{},
@@ -83,8 +71,6 @@ func NewIngressConverter(options *convtypes.ConverterOptions, haproxy haproxy.Co
 		backendAnnotations: map[*hatypes.Backend]*annotations.Mapper{},
 		ingressClasses:     map[string]*ingressClassConfig{},
 	}
-	c.readDefaultCertificate()
-	return c
 }
 
 type converter struct {
@@ -94,11 +80,10 @@ type converter struct {
 	logger             types.Logger
 	cache              convtypes.Cache
 	tracker            convtypes.Tracker
-	defaultCrt         convtypes.CrtFile
-	defaultBackSource  annotations.Source
 	mapBuilder         *annotations.MapBuilder
+	frontendPorts      *annotations.FrontendPorts
+	defaultBackSource  annotations.Source
 	updater            annotations.Updater
-	globalConfig       *annotations.Mapper
 	tcpsvcAnnotations  map[*hatypes.TCPServicePort]*annotations.Mapper
 	frontAnnotations   map[*hatypes.Frontend]*annotations.Mapper
 	frontLocalPorts    map[*hatypes.Frontend]bool
@@ -133,63 +118,15 @@ type ingressClassConfig struct {
 }
 
 func (c *converter) NeedFullSync() bool {
-	needFullSync := c.defaultCrtNeedFullSync() || c.globalConfigNeedFullSync()
-	if needFullSync && c.defaultCrt.SHA1Hash == c.options.FakeCrtFile.SHA1Hash {
-		c.logger.Info("using auto generated fake certificate")
-	}
-	return needFullSync
+	return false
 }
 
 func (c *converter) Sync(full bool) {
-	c.syncDefaultCrt()
 	if full {
 		c.syncFull()
 	} else {
 		c.syncPartial()
 	}
-}
-
-func (c *converter) defaultCrtNeedFullSync() bool {
-	f := c.haproxy.Frontends()
-	return f.DefaultCrtFile != c.defaultCrt.Filename ||
-		f.DefaultCrtHash != c.defaultCrt.SHA1Hash
-}
-
-func (c *converter) globalConfigNeedFullSync() bool {
-	// Currently if a global is changed, all the ingress objects are parsed again.
-	// This need to be done due to:
-	//
-	//   1. Default host and backend annotations. If a default value
-	//      changes, such default may impact any ingress object;
-	//   2. At the time of this writing, the following global
-	//      configuration keys are used during annotation parsing:
-	//        * GlobalDNSResolvers
-	//        * GlobalDrainSupport
-	//        * GlobalNoTLSRedirectLocations
-	//
-	// This might be improved after implement a way to guarantee that a global
-	// is just a haproxy global, default or frontend config.
-	cur, new := c.changed.GlobalConfigMapDataCur, c.changed.GlobalConfigMapDataNew
-	return new != nil && !reflect.DeepEqual(cur, new)
-}
-
-func (c *converter) readDefaultCertificate() {
-	crt := c.options.FakeCrtFile
-	if c.options.DefaultCrtSecret != "" {
-		var err error
-		crt, err = c.cache.GetTLSSecretPath("", c.options.DefaultCrtSecret, nil)
-		if err != nil {
-			crt = c.options.FakeCrtFile
-			c.logger.Warn("using auto generated fake certificate due to an error reading default TLS certificate: %v", err)
-		}
-	}
-	c.defaultCrt = crt
-}
-
-func (c *converter) syncDefaultCrt() {
-	f := c.haproxy.Frontends()
-	f.DefaultCrtFile = c.defaultCrt.Filename
-	f.DefaultCrtHash = c.defaultCrt.SHA1Hash
 }
 
 // bareLink creates a pathlink with default path and match type params,
@@ -214,13 +151,11 @@ func (c *converter) syncFull() {
 		return
 	}
 	sortIngress(ingList)
-	c.updater.UpdateGlobalConfig(c.haproxy, c.globalConfig)
 	c.syncDefaultBackend()
-	fp := annotations.NewFrontendPorts(c.logger, c.haproxy, c.globalConfig)
 	for _, ing := range ingList {
-		c.syncIngress(fp, ing)
+		c.syncIngress(ing)
 	}
-	c.syncConfig(fp)
+	c.syncConfig()
 }
 
 func (c *converter) syncPartial() {
@@ -240,18 +175,6 @@ func (c *converter) syncPartial() {
 	c.haproxy.Backends().RemoveAll(dirtyBacks)
 	c.haproxy.Userlists().RemoveAll(dirtyUsers)
 	c.haproxy.AcmeData().Storages().RemoveAll(dirtyStorages)
-
-	// looking for controller pod changes, used by peers.
-	// missing a better tracking and global update approach.
-	ctrlNamespace := c.cache.GetControllerPod().Namespace + "/"
-	changedPods := c.changed.Links[convtypes.ResourcePod]
-	for _, pod := range changedPods {
-		if strings.HasPrefix(pod, ctrlNamespace) {
-			c.logger.Info("updating peers due to changes in controller pods")
-			c.updater.UpdatePeers(c.haproxy, c.globalConfig)
-			break
-		}
-	}
 
 	c.logger.InfoV(2, "syncing %d host(s) and %d backend(s)", len(dirtyHosts), len(dirtyBacks))
 
@@ -287,11 +210,10 @@ func (c *converter) syncPartial() {
 
 	// reinclude changed/added data
 	sortIngress(ingList)
-	fp := annotations.NewFrontendPorts(c.logger, c.haproxy, c.globalConfig)
 	for _, ing := range ingList {
-		c.syncIngress(fp, ing)
+		c.syncIngress(ing)
 	}
-	c.syncConfig(fp)
+	c.syncConfig()
 }
 
 // trackAddedIngress add tracking hostnames and backends to new ingress objects
@@ -378,7 +300,7 @@ func sortIngress(ingress []*networking.Ingress) {
 	})
 }
 
-func (c *converter) syncIngress(fp *annotations.FrontendPorts, ing *networking.Ingress) {
+func (c *converter) syncIngress(ing *networking.Ingress) {
 	source := &annotations.Source{
 		Namespace: ing.Namespace,
 		Name:      ing.Name,
@@ -387,18 +309,18 @@ func (c *converter) syncIngress(fp *annotations.FrontendPorts, ing *networking.I
 	annTCP, annFront, annHost, annBack := c.readAnnotations(source, ing.Annotations)
 	tcpServicePort, _ := strconv.Atoi(annTCP[ingtypes.TCPTCPServicePort])
 	if tcpServicePort == 0 {
-		c.syncIngressHTTP(fp, source, ing, annFront, annHost, annBack)
+		c.syncIngressHTTP(source, ing, annFront, annHost, annBack)
 	} else {
 		c.syncIngressTCP(source, ing, tcpServicePort, annTCP, annBack)
 	}
 }
 
-func (c *converter) acquireFrontend(fp *annotations.FrontendPorts, source *annotations.Source, annFront, annHost map[string]string) (*frontend, error) {
+func (c *converter) acquireFrontend(source *annotations.Source, annFront, annHost map[string]string) (*frontend, error) {
 	link := bareLink()
 	localMapper := c.mapBuilder.NewMapper()
 	_ = localMapper.AddAnnotations(source, link, annFront)
 	_ = localMapper.AddAnnotations(source, link, annHost)
-	ports, err := fp.AcquirePorts(localMapper)
+	ports, err := c.frontendPorts.AcquirePorts(localMapper)
 	if err != nil {
 		return nil, err
 	}
@@ -492,8 +414,8 @@ func (h *host) AddRedirect(path string, match hatypes.MatchType, redirTo string)
 	h.redir = append(h.redir, h.inner.AddRedirect(path, match, redirTo))
 }
 
-func (c *converter) syncIngressHTTP(fp *annotations.FrontendPorts, source *annotations.Source, ing *networking.Ingress, annFront, annHost, annBack map[string]string) {
-	f, err := c.acquireFrontend(fp, source, annFront, annHost)
+func (c *converter) syncIngressHTTP(source *annotations.Source, ing *networking.Ingress, annFront, annHost, annBack map[string]string) {
+	f, err := c.acquireFrontend(source, annFront, annHost)
 	if err != nil {
 		c.logger.Warn("skipping %v configuration: %s", source, err.Error())
 		return
@@ -607,14 +529,14 @@ func (c *converter) syncIngressHTTP(fp *annotations.FrontendPorts, source *annot
 		// tls secret
 		for _, hostname := range tls.Hosts {
 			host := c.addHost(f, hostname, source, annFront, annHost, true)
-			tlsPath := c.addTLS(source, tls.SecretName)
+			crt := c.addTLS(source, tls.SecretName)
 			hhttps := host.innerHTTPS
 			if hhttps.TLS.TLSHash == "" {
-				hhttps.TLS.TLSFilename = tlsPath.Filename
-				hhttps.TLS.TLSHash = tlsPath.SHA1Hash
-				hhttps.TLS.TLSCommonName = tlsPath.Certificate.Subject.CommonName
-				hhttps.TLS.TLSNotAfter = tlsPath.Certificate.NotAfter
-			} else if hhttps.TLS.TLSHash != tlsPath.SHA1Hash {
+				hhttps.TLS.TLSFilename = crt.Filename
+				hhttps.TLS.TLSHash = crt.Hash
+				hhttps.TLS.TLSCommonName = crt.CommonName
+				hhttps.TLS.TLSNotAfter = crt.NotAfter
+			} else if hhttps.TLS.TLSHash != crt.Hash {
 				msg := fmt.Sprintf("TLS of host '%s' was already assigned", hhttps.Hostname)
 				if tls.SecretName != "" {
 					c.logger.Warn("skipping TLS secret '%s' of %v: %s", tls.SecretName, source, msg)
@@ -740,7 +662,7 @@ func (c *converter) syncIngressTCP(source *annotations.Source, ing *networking.I
 			c.logger.Warn("skipping TLS of tcp service on %v: backend was not configured", source)
 			return
 		}
-		tlsPath := c.addTLS(source, secretName)
+		crt := c.addTLS(source, secretName)
 		tlsHosts := tls.Hosts
 		if len(tlsHosts) == 0 {
 			// configures default host if none is declared
@@ -751,10 +673,10 @@ func (c *converter) syncIngressTCP(source *annotations.Source, ing *networking.I
 				tcpPort.TLS[tlsHost] = &hatypes.TCPServiceTLSConfig{
 					Hostname: tlsHost,
 					TLSConfig: hatypes.TLSConfig{
-						TLSFilename:   tlsPath.Filename,
-						TLSHash:       tlsPath.SHA1Hash,
-						TLSCommonName: tlsPath.Certificate.Subject.CommonName,
-						TLSNotAfter:   tlsPath.Certificate.NotAfter,
+						TLSFilename:   crt.Filename,
+						TLSHash:       crt.Hash,
+						TLSCommonName: crt.CommonName,
+						TLSNotAfter:   crt.NotAfter,
 						// tcp updater fills other tlsConfig fields, reading from annotation config
 					},
 				}
@@ -770,7 +692,7 @@ func (c *converter) syncIngressTCP(source *annotations.Source, ing *networking.I
 	}
 }
 
-func (c *converter) syncConfig(fp *annotations.FrontendPorts) {
+func (c *converter) syncConfig() {
 	for tcpPort, mapper := range c.tcpsvcAnnotations {
 		c.updater.UpdateTCPPortConfig(tcpPort, mapper)
 		if tcpHost := tcpPort.DefaultHost(); tcpHost != nil {
@@ -791,11 +713,7 @@ func (c *converter) syncConfig(fp *annotations.FrontendPorts) {
 		c.syncBackendEndpointCookies(backend)
 		c.syncBackendEndpointHashes(backend)
 	}
-	if c.globalConfig.Get(ingtypes.GlobalCreateDefaultFrontends).Bool() {
-		fp.EnsureEmptyFrontends(c.haproxy.Frontends())
-	} else {
-		c.haproxy.Frontends().RemoveEmptyFrontends()
-	}
+	c.frontendPorts.SyncFrontends(c.haproxy.Frontends())
 }
 
 func (c *converter) readPathType(path networking.HTTPIngressPath, ann string) hatypes.MatchType {
@@ -1148,7 +1066,7 @@ func (c *converter) syncBackendEndpointHashes(backend *hatypes.Backend) {
 	}
 }
 
-func (c *converter) addTLS(source *annotations.Source, secretName string) convtypes.CrtFile {
+func (c *converter) addTLS(source *annotations.Source, secretName string) hatypes.CertificateConfig {
 	if secretName != "" {
 		tlsFile, err := c.cache.GetTLSSecretPath(
 			source.Namespace,
@@ -1156,11 +1074,16 @@ func (c *converter) addTLS(source *annotations.Source, secretName string) convty
 			[]convtypes.TrackingRef{{Context: source.Type, UniqueName: source.FullName()}},
 		)
 		if err == nil {
-			return tlsFile
+			return hatypes.CertificateConfig{
+				Filename:   tlsFile.Filename,
+				Hash:       tlsFile.SHA1Hash,
+				CommonName: tlsFile.Certificate.Subject.CommonName,
+				NotAfter:   tlsFile.Certificate.NotAfter,
+			}
 		}
 		c.logger.Warn("using default certificate due to an error reading secret '%s' on %s: %v", secretName, source, err)
 	}
-	return c.defaultCrt
+	return c.haproxy.Global().SSL.DefaultCrt
 }
 
 func (c *converter) addEndpoints(svc *api.Service, svcPort *api.ServicePort, backend *hatypes.Backend) error {
@@ -1171,7 +1094,7 @@ func (c *converter) addEndpoints(svc *api.Service, svcPort *api.ServicePort, bac
 	for _, addr := range ready {
 		backend.AcquireEndpoint(addr.IP, addr.Port, addr.TargetRef)
 	}
-	if c.globalConfig.Get(ingtypes.GlobalDrainSupport).Bool() {
+	if c.haproxy.Global().DrainSupport.Drain {
 		for _, addr := range notReady {
 			ep := backend.AcquireEndpoint(addr.IP, addr.Port, addr.TargetRef)
 			ep.Weight = 0

--- a/pkg/converters/ingress/ingress_test.go
+++ b/pkg/converters/ingress/ingress_test.go
@@ -358,7 +358,7 @@ func TestSyncDrainSupport(t *testing.T) {
 	pod2 := c.createPod1("default/echo-yyyyy", "172.17.1.104", "none:8080")
 	c.cache.TermPodList[svcName] = []*api.Pod{pod1, pod2}
 
-	c.cache.Changed.GlobalConfigMapDataNew = map[string]string{"drain-support": "true"}
+	c.hconfig.Global().DrainSupport.Drain = true
 	c.Sync(
 		c.createIng1("default/echo", "echo.example.com", "/", "echo:8080"),
 	)
@@ -2543,7 +2543,11 @@ func (c *testConfig) SyncConverter(conv *converter, ing ...*networking.Ingress) 
 		// first run, set GlobalNew != nil and run SyncFull
 		c.cache.Changed.GlobalConfigMapDataNew = map[string]string{}
 	}
-	c.cache.SecretTLSPath["system/default"] = "/tls/tls-default.pem"
+	// default crt is populated via global converter
+	c.hconfig.Global().SSL.DefaultCrt = hatypes.CertificateConfig{
+		Filename: "/tls/tls-default.pem",
+		Hash:     "1",
+	}
 	if conv == nil {
 		conv = c.createConverter()
 	}
@@ -2553,12 +2557,11 @@ func (c *testConfig) SyncConverter(conv *converter, ing ...*networking.Ingress) 
 }
 
 func (c *testConfig) createConverter() *converter {
-	defaultConfig := func() map[string]string {
-		return map[string]string{
-			ingtypes.BackInitialWeight: "100",
-			ingtypes.GlobalHTTPPort:    strconv.Itoa(TestPortHTTP),
-			ingtypes.GlobalHTTPSPort:   strconv.Itoa(TestPortHTTPS),
-		}
+	defaultsOverride := map[string]string{
+		ingtypes.BackBalanceAlgorithm: "",
+		ingtypes.BackInitialWeight:    "100",
+		ingtypes.GlobalHTTPPort:       strconv.Itoa(TestPortHTTP),
+		ingtypes.GlobalHTTPSPort:      strconv.Itoa(TestPortHTTPS),
 	}
 	return NewIngressConverter(
 		&convtypes.ConverterOptions{
@@ -2566,7 +2569,7 @@ func (c *testConfig) createConverter() *converter {
 			Logger:           c.logger,
 			Tracker:          c.tracker,
 			DynamicConfig:    &convtypes.DynamicConfig{},
-			DefaultConfig:    defaultConfig,
+			DefaultsOverride: defaultsOverride,
 			DefaultBackend:   "system/default",
 			DefaultCrtSecret: "system/default",
 			AnnotationPrefix: []string{"ingress.kubernetes.io"},
@@ -2774,10 +2777,10 @@ func (c *testConfig) compareText(actual, expected string) {
 
 type updaterMock struct{}
 
-func (u *updaterMock) UpdateGlobalConfig(haproxyConfig haproxy.Config, config *annotations.Mapper) {
+func (u *updaterMock) UpdateGlobalConfig(config *annotations.Mapper) {
 }
 
-func (u *updaterMock) UpdatePeers(haproxyConfig haproxy.Config, config *annotations.Mapper) {
+func (u *updaterMock) UpdatePeers(config *annotations.Mapper) {
 }
 
 func (u *updaterMock) UpdateTCPPortConfig(tcp *hatypes.TCPServicePort, mapper *annotations.Mapper) {

--- a/pkg/converters/tcpservices/tcpservices.go
+++ b/pkg/converters/tcpservices/tcpservices.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package configmap
+package tcpservices
 
 import (
 	"fmt"

--- a/pkg/converters/tcpservices/tcpservices_test.go
+++ b/pkg/converters/tcpservices/tcpservices_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package configmap
+package tcpservices
 
 import (
 	"reflect"

--- a/pkg/converters/types/options.go
+++ b/pkg/converters/types/options.go
@@ -34,7 +34,7 @@ type ConverterOptions struct {
 	AdminSocket      string
 	AcmeSocket       string
 	ConnTimeout      time.Duration
-	DefaultConfig    func() map[string]string
+	DefaultsOverride map[string]string
 	DefaultBackend   string
 	DefaultCrtSecret string
 	FakeCrtFile      CrtFile

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -247,7 +247,7 @@ func (c *config) writeFrontendMaps(f *hatypes.Frontend) error {
 			commonMaps.DefaultHostMap.AddHostnamePathMapping(hatypes.DefaultHost, path, path.Backend.ID)
 		}
 	}
-	defaultCrtFile := c.frontends.DefaultCrtFile
+	defaultCrtFile := c.global.SSL.DefaultCrt.Filename
 	if defaultHost != nil {
 		if defaultHost.DefaultBackend != nil {
 			commonMaps.DefaultHostMap.AddTargetIfMissing(hatypes.DefaultHost, "/", defaultHost.DefaultBackend.ID, hatypes.MatchBegin)

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -6406,7 +6406,6 @@ func setupOptions(options testOptions) *testConfig {
 		t.Errorf("error parsing modsecurity.tmpl: %v", err)
 	}
 	config := instance.Config().(*config)
-	config.frontends.DefaultCrtFile = "/var/haproxy/ssl/certs/default.pem"
 	c := &testConfig{
 		t:        t,
 		logger:   logger,
@@ -6438,6 +6437,7 @@ func (c *testConfig) configGlobal(global *hatypes.Global) {
 	global.SSL.BackendCipherSuites = "TLS_AES_128_GCM_SHA256"
 	global.SSL.Ciphers = "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256"
 	global.SSL.CipherSuites = "TLS_AES_128_GCM_SHA256"
+	global.SSL.DefaultCrt.Filename = "/var/haproxy/ssl/certs/default.pem"
 	global.SSL.DHParam.Filename = "/var/haproxy/tls/dhparam.pem"
 	global.SSL.HeadersPrefix = "X-SSL"
 	global.SSL.Options = "no-sslv3"

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -130,6 +130,7 @@ type SSLConfig struct {
 	BackendCipherSuites string
 	Ciphers             string // TLS up to 1.2
 	CipherSuites        string // TLS 1.3
+	DefaultCrt          CertificateConfig
 	DefaultCAFilename   string
 	DefaultCAHash       string
 	DefaultCRLFilename  string
@@ -141,6 +142,14 @@ type SSLConfig struct {
 	Options             string
 	RedirectCode        int
 	SSLRedirect         bool
+}
+
+// CertificateConfig ...
+type CertificateConfig struct {
+	Filename   string
+	Hash       string
+	CommonName string
+	NotAfter   time.Time
 }
 
 // DHParamConfig ...
@@ -477,9 +486,7 @@ type AuthProxyBind struct {
 
 // Frontends ...
 type Frontends struct {
-	AuthProxy      AuthProxy
-	DefaultCrtFile string
-	DefaultCrtHash string
+	AuthProxy AuthProxy
 	//
 	items   []*Frontend
 	changed bool


### PR DESCRIPTION
A converter is responsible for receiving events from the controller and generates HAProxy configuration. Since we are parsing two APIs now, Ingress and Gateway, we should separate the common/global one so it is possible to disable Ingress altogether without impacting Gateway.

This update starts this decoupling by creating a global converter instance and removing global related configuration from within the Ingress converter. This is however just the start of the move, since the internal updater for both ingress and global are tightly coupled, and their decoupling should be done later.