### PR TITLE
add watch-ingress command line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -79,6 +79,7 @@ The following command-line options are supported:
 | [`--wait-before-shutdown`](#wait-before-shutdown)       | seconds as integer         | `0`                     | v0.8  |
 | [`--wait-before-update`](#wait-before-update)           | duration                   | `200ms`                 | v0.11 |
 | [`--watch-gateway`](#watch-gateway)                     | [true\|false]              | `true`                  | v0.13 |
+| [`--watch-ingress`](#watch-ingress)                     | [true\|false]              | `true`                  | v0.17 |
 | [`--watch-ingress-without-class`](#ingress-class)       | [true\|false]              | `false`                 | v0.12 |
 | [`--watch-namespace`](#watch-namespace)                 | namespace                  | all namespaces          |       |
 
@@ -850,6 +851,16 @@ restarted if the CRDs are installed after starting the controller. See also the 
 configuration [doc]({{% relref "gateway-api" %}}).
 
 When enabled, `--watch-gateway` enforces a leader election. A leader must be elected to update Gateway API status. See also [`--election-id`](#election-id).
+
+---
+
+# watch-ingress
+
+* `--watch-ingress`
+
+Since v0.17
+
+Enables Ingress API watch and parse. This option is enabled by default. Add `--watch-ingress=false` option to instruct the controller to not watch, parse and synchronize any ingress resource. Disabling this configuration is similar to not have neither an ingress class nor the ingress class annotation configured, with the advantage of saving memory by not caching or watching ingress resources.
 
 ---
 

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -177,10 +177,6 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		configLog.Info(fmt.Sprintf("WARNING: --shutdown-timeout=%s is less than --haproxy-grace-period=%s", opt.ShutdownTimeout.String(), opt.HAProxyGracePeriod.String()))
 	}
 
-	if opt.IngressClass != "" {
-		configLog.Info("watching for ingress resources with 'kubernetes.io/ingress.class'", "annotation", opt.IngressClass)
-	}
-
 	var waitShutdown time.Duration
 	if opt.WaitBeforeShutdown != "" {
 		var err error
@@ -201,16 +197,19 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 	if opt.ControllerClass != "" {
 		controllerName += "/" + strings.TrimLeft(opt.ControllerClass, "/")
 	}
-	configLog.Info("watching for ingress resources with IngressClass", "controller-name", controllerName)
 
-	if opt.WatchIngressWithoutClass {
-		configLog.Info("watching for ingress resources without any class reference - --watch-ingress-without-class is true")
+	if opt.WatchIngress {
+		configLog.Info("watching for Ingress API resources - --watch-ingress is true", "controller-name", controllerName)
+		if opt.IngressClass != "" {
+			configLog.Info("watching for ingress resources with 'kubernetes.io/ingress.class'", "annotation", opt.IngressClass)
+		}
+		if opt.WatchIngressWithoutClass {
+			configLog.Info("watching for ingress resources without any class reference - --watch-ingress-without-class is true")
+		} else {
+			configLog.Info("ignoring ingress resources without any class reference - --watch-ingress-without-class is false")
+		}
 	} else {
-		configLog.Info("ignoring ingress resources without any class reference - --watch-ingress-without-class is false")
-	}
-
-	if opt.WatchGateway {
-		configLog.Info("watching for Gateway API resources - --watch-gateway is true")
+		configLog.Info("ignoring Ingress API resources - --watch-ingress is false")
 	}
 
 	var hasGateway, hasGatewayV1, hasGatewayB1, hasTCPRouteA2, hasTLSRouteV1, hasTLSRouteA2, hasGrantV1, hasGrantB1 bool
@@ -274,6 +273,13 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		hasTLSRouteA2 = tlsA2 && gw && !hasTLSRouteV1
 		hasGrantV1 = grantV1 && gw
 		hasGrantB1 = grantB1 && gw && !hasGrantV1
+
+		configLog.Info("watching for Gateway API resources - --watch-gateway is true", "controller-name", controllerName)
+		if !hasGateway {
+			configLog.Info("Gateway API CRDs not found, ignoring")
+		}
+	} else {
+		configLog.Info("ignoring Gateway API resources - --watch-gateway is false")
 	}
 
 	if opt.EnableEndpointSlicesAPI {
@@ -575,6 +581,7 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		VerifyHostname:           opt.VerifyHostname,
 		VersionInfo:              versionInfo,
 		WaitBeforeUpdate:         opt.WaitBeforeUpdate,
+		WatchIngress:             opt.WatchIngress,
 		WatchIngressWithoutClass: opt.WatchIngressWithoutClass,
 		WatchNamespace:           opt.WatchNamespace,
 	}, nil
@@ -833,6 +840,7 @@ type Config struct {
 	VerifyHostname           bool
 	VersionInfo              version.Info
 	WaitBeforeUpdate         time.Duration
+	WatchIngress             bool
 	WatchIngressWithoutClass bool
 	WatchNamespace           string
 }

--- a/pkg/controller/config/options.go
+++ b/pkg/controller/config/options.go
@@ -13,6 +13,7 @@ func NewOptions() *Options {
 		KubeConfig:              StringValue(""),
 		IngressClass:            "haproxy",
 		ReloadStrategy:          "reusesocket",
+		WatchIngress:            true,
 		WatchGateway:            true,
 		MasterWorker:            true,
 		ConnectionTimeout:       30 * time.Second,
@@ -58,6 +59,7 @@ type Options struct {
 	ValidateConfig           bool
 	ControllerClass          string
 	WatchIngressWithoutClass bool
+	WatchIngress             bool
 	WatchGateway             bool
 	MasterWorker             bool
 	MasterSocket             string
@@ -209,6 +211,10 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 
 	fs.BoolVar(&o.WatchGateway, "watch-gateway", o.WatchGateway, ""+
 		"Watch and parse resources from the Gateway API.",
+	)
+
+	fs.BoolVar(&o.WatchIngress, "watch-ingress", o.WatchIngress, ""+
+		"Watch and parse resources from the Ingress API.",
 	)
 
 	fs.BoolVar(&o.MasterWorker, "master-worker", o.MasterWorker, ""+

--- a/pkg/controller/reconciler/watchers.go
+++ b/pkg/controller/reconciler/watchers.go
@@ -66,7 +66,9 @@ type watchers struct {
 
 func (w *watchers) getHandlers() []*hdlr {
 	handlers := w.handlersCore()
-	handlers = append(handlers, w.handlersIngress()...)
+	if w.cfg.WatchIngress {
+		handlers = append(handlers, w.handlersIngress()...)
+	}
 	if w.cfg.HasGatewayB1 {
 		handlers = append(handlers, w.handlersGatewayv1beta1()...)
 	}

--- a/pkg/controller/services/cache.go
+++ b/pkg/controller/services/cache.go
@@ -210,6 +210,9 @@ func (c *c) ExternalNameLookup(externalName string) ([]net.IP, error) {
 }
 
 func (c *c) GetIngress(ingressName string) (*networking.Ingress, error) {
+	if !c.config.WatchIngress {
+		return nil, fmt.Errorf("ingress API is not enabled")
+	}
 	ing := networking.Ingress{}
 	err := c.get(ingressName, &ing)
 	if err == nil && !c.IsValidIngress(&ing) {
@@ -219,6 +222,9 @@ func (c *c) GetIngress(ingressName string) (*networking.Ingress, error) {
 }
 
 func (c *c) GetIngressList() ([]*networking.Ingress, error) {
+	if !c.config.WatchIngress {
+		return nil, nil
+	}
 	list := networking.IngressList{}
 	if err := c.client.List(c.ctx, &list); err != nil {
 		return nil, err
@@ -234,6 +240,9 @@ func (c *c) GetIngressList() ([]*networking.Ingress, error) {
 }
 
 func (c *c) GetIngressClass(className string) (*networking.IngressClass, error) {
+	if !c.config.WatchIngress {
+		return nil, fmt.Errorf("ingress API is not enabled")
+	}
 	class := networking.IngressClass{}
 	err := c.get(className, &class)
 	return &class, err

--- a/pkg/controller/services/services.go
+++ b/pkg/controller/services/services.go
@@ -163,6 +163,7 @@ func (s *Services) setup(ctx context.Context) error {
 		DisableKeywords:  cfg.DisableKeywords,
 		AcmeTrackTLSAnn:  cfg.AcmeTrackTLSAnn,
 		TrackInstances:   cfg.TrackOldInstances,
+		WatchIngress:     cfg.WatchIngress,
 		HasGateway:       cfg.HasGateway,
 		HasTLSRoute:      cfg.HasTLSRouteA2 || cfg.HasTLSRouteV1,
 		HasTCPRoute:      cfg.HasTCPRouteA2,

--- a/pkg/converters/converters.go
+++ b/pkg/converters/converters.go
@@ -96,9 +96,11 @@ func (c *converters) Sync() error {
 	//
 	// ingress converter
 	//
-	logger.Info("syncing Ingress API resources")
-	ingressConverter.Sync(needFullSync)
-	c.timer.Tick("parse_ingress")
+	if c.options.WatchIngress {
+		logger.Info("syncing Ingress API resources")
+		ingressConverter.Sync(needFullSync)
+		c.timer.Tick("parse_ingress")
+	}
 
 	//
 	// tcpservices converter

--- a/pkg/converters/ingress/global.go
+++ b/pkg/converters/ingress/global.go
@@ -35,7 +35,9 @@ type ConfigGlobal interface {
 	Sync(full bool) error
 }
 
-// TODO: decouple global and ingress converters, and move global to its own package
+// TODO: decouple global and ingress converters, and move global to its own package.
+// Currently the configuration is already decoupled, but the global scope in the
+// updater still shares some types and methods with the ingress counterpart.
 
 // NewGlobalConverter ...
 func NewGlobalConverter(options *convtypes.ConverterOptions, haproxy haproxy.Config, changed *convtypes.ChangedObjects) ConfigGlobal {

--- a/pkg/converters/types/options.go
+++ b/pkg/converters/types/options.go
@@ -43,6 +43,7 @@ type ConverterOptions struct {
 	DisableKeywords  []string
 	AcmeTrackTLSAnn  bool
 	TrackInstances   bool
+	WatchIngress     bool
 	HasGateway       bool
 	HasTLSRoute      bool
 	HasTCPRoute      bool

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -113,17 +113,19 @@ func NewFramework(ctx context.Context, t *testing.T, o ...options.Framework) *fr
 	require.NoError(t, err)
 
 	return &framework{
-		scheme: scheme,
-		config: config,
-		cli:    cli,
+		scheme:      scheme,
+		config:      config,
+		cli:         cli,
+		optOverride: opt.OptOverride,
 	}
 }
 
 type framework struct {
-	scheme  *runtime.Scheme
-	config  *rest.Config
-	cli     client.WithWatch
-	admSock socket.HAProxySocket
+	scheme      *runtime.Scheme
+	config      *rest.Config
+	cli         client.WithWatch
+	admSock     socket.HAProxySocket
+	optOverride options.OptOverrideCallback
 }
 
 // HAProxy version 3.4-dev5-028940725 2026/02/19 - https://haproxy.org/
@@ -232,6 +234,9 @@ func (f *framework) StartController(ctx context.Context, t *testing.T) {
 	opt.LocalFSPrefix = "/tmp/haproxy-ingress"
 	opt.PublishService = PublishSvcName
 	opt.ConfigMap = GlobalConfigMap.String()
+	if f.optOverride != nil {
+		f.optOverride(opt)
+	}
 	os.Setenv("POD_NAMESPACE", GlobalConfigMap.Namespace)
 	ctx, cancel := context.WithCancel(ctx)
 	cfg, err := ctrlconfig.CreateWithConfig(ctx, f.config, opt)

--- a/tests/framework/options/framework.go
+++ b/tests/framework/options/framework.go
@@ -1,5 +1,9 @@
 package options
 
+import (
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/controller/config"
+)
+
 type Framework func(o *frameworkOpt)
 
 func CRDs(crds ...string) Framework {
@@ -10,8 +14,17 @@ func CRDs(crds ...string) Framework {
 	}
 }
 
+type OptOverrideCallback = func(opt *config.Options)
+
+func OptOverride(optOverride OptOverrideCallback) Framework {
+	return func(o *frameworkOpt) {
+		o.OptOverride = optOverride
+	}
+}
+
 type frameworkOpt struct {
-	CRDPaths []string
+	CRDPaths    []string
+	OptOverride OptOverrideCallback
 }
 
 func ParseFrameworkOptions(opts ...Framework) (opt frameworkOpt) {

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/controller/config"
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
 	"github.com/jcmoraisjr/haproxy-ingress/tests/framework"
 	"github.com/jcmoraisjr/haproxy-ingress/tests/framework/options"
@@ -1445,7 +1446,12 @@ func TestIntegrationGateway(t *testing.T) {
 	t.Run("v050-v1beta1", func(t *testing.T) {
 		for _, channel := range channels {
 			t.Run(channel, func(t *testing.T) {
-				f := framework.NewFramework(ctx, t, options.CRDs("gateway-api-v050-v1beta1-"+channel))
+				f := framework.NewFramework(ctx, t,
+					options.CRDs("gateway-api-v050-v1beta1-"+channel),
+					options.OptOverride(func(opt *config.Options) {
+						opt.WatchIngress = false
+					}),
+				)
 				f.StartController(ctx, t)
 				httpServerPort := f.CreateHTTPServer(ctx, t, "gw-v1beta1")
 				gc := f.CreateGatewayClassB1(ctx, t)
@@ -1466,7 +1472,12 @@ func TestIntegrationGateway(t *testing.T) {
 	t.Run("v100-v1", func(t *testing.T) {
 		for _, channel := range channels {
 			t.Run(channel, func(t *testing.T) {
-				f := framework.NewFramework(ctx, t, options.CRDs("gateway-api-v100-v1-"+channel))
+				f := framework.NewFramework(ctx, t,
+					options.CRDs("gateway-api-v100-v1-"+channel),
+					options.OptOverride(func(opt *config.Options) {
+						opt.WatchIngress = false
+					}),
+				)
 				f.StartController(ctx, t)
 
 				httpServerPort := f.CreateHTTPServer(ctx, t, "gw-v1-http")
@@ -1524,7 +1535,12 @@ func TestIntegrationGateway(t *testing.T) {
 	t.Run("v151-v1", func(t *testing.T) {
 		for _, channel := range channels {
 			t.Run(channel, func(t *testing.T) {
-				f := framework.NewFramework(ctx, t, options.CRDs("gateway-api-v151-v1-"+channel))
+				f := framework.NewFramework(ctx, t,
+					options.CRDs("gateway-api-v151-v1-"+channel),
+					options.OptOverride(func(opt *config.Options) {
+						opt.WatchIngress = false
+					}),
+				)
 				f.StartController(ctx, t)
 
 				httpServerPort := f.CreateHTTPServer(ctx, t, "gw-v1-http")


### PR DESCRIPTION
Add the ability to disable ingress watching and parsing. Global configurations, previsouly part of the ingress parsing, was just decoupled and now it always runs, despite of disabled APIs. This is a suggested options for controller deployment following only Gateway API resources.