### PR TITLE
add ip mode command-line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -42,6 +42,7 @@ The following command-line options are supported:
 | [`--healthz-port`](#stats)                              | port number                | `10254`                 |       |
 | [`--ingress-class`](#ingress-class)                     | name                       | `haproxy`               |       |
 | [`--ingress-class-precedence`](#ingress-class)          | [true\|false]              | `false`                 | v0.13.5 |
+| [`--ip-mode`](#ip-mode)                                 | [v4\|v6\|v4v6\|lo\|node\|auto] | `auto`              | v0.17 |
 | [`--kubeconfig`](#kubeconfig)                           | /path/to/kubeconfig        | in cluster config       |       |
 | [`--local-filesystem-prefix`](#local-filesystem-prefix) | temporary base directory   |                         | v0.14 |
 | [`--log-zap`](#logging)                                 | [true\|false]              | `false`                 | v0.14 |
@@ -356,6 +357,29 @@ See also:
 
 * [Class matter]({{% relref "keys/#class-matter" %}}) in the Configuration Keys doc
 * https://kubernetes.io/docs/concepts/services-networking/ingress/#ingress-class
+
+---
+
+## ip-mode
+
+* `--ip-mode`
+
+Since v0.17
+
+Defines the IP mode used on frontends (listening bind) if not configured in the frontend binding, and loopback addresses created by HAProxy Ingress (auth-proxy and empty slots). Defaults to `auto` if not configured.
+
+The following options are available:
+
+* `v4`: uses only IPv4 on default listening bind configurations, and IPv4 on loopback addresses.
+* `v6`: uses only IPv6 on default listening bind configurations, and IPv6 on loopback addresses.
+* `v4v6`: uses both IPv4 and IPv6 on default listening bind configurations, and IPv4 on loopback addresses.
+* `lo`: uses IP addresses of the loopback interface to determine the IP mode. The initialization fails in case of a failure finding and reading the loopback interface.
+* `node`: uses both Internal and External IP addresses of the Node where controller is running to determine the IP mode. The initialization fails in case the node status cannot be read.
+* `auto`: same as node, but defaults to IPv4 instead of failing the initialization in case the node status cannot be read.
+
+See also:
+
+* [Bind]({{% relref "keys#bind" %}}) configuration keys
 
 ---
 

--- a/docs/content/en/docs/configuration/keys.md
+++ b/docs/content/en/docs/configuration/keys.md
@@ -1006,10 +1006,12 @@ See also:
 | `bind-https`              | `Frontend` |         | v0.8  |
 | ~~`bind-fronting-proxy`~~ | `Frontend` |         | v0.8  |
 
-Configures listening IP and port for HTTP(S) incoming requests. These
-configuration keys have backward compatibility with [Bind IP addr](#bind-ip-addr),
-[Bind port](#bind-port) and [HTTP Passthrough](#http-passthrough) keys.
-The bind configuration keys in this section have precedence if declared.
+Configures listening IP and port for HTTP(S) incoming requests. If empty, the
+configuration provided in [Bind IP addr](#bind-ip-addr),
+[Bind port](#bind-port) and [HTTP Passthrough](#http-passthrough) keys are used.
+If none of the options are declared, HAProxy Ingress configure the listening bind
+based on the IP stack defined in [`--ip-mode`]({{% relref "command-line#ip-mode" %}})
+command-line option.
 
 Any HAProxy supported option can be used, this will be copied verbatim to the
 bind keyword. See HAProxy
@@ -1038,6 +1040,7 @@ Special care should be taken on port number overlap on global, and annotation ba
 See also:
 
 * https://docs.haproxy.org/3.0/configuration.html#4-bind
+* [--ip-mode]({{% relref "command-line#ip-mode" %}}) command-line option
 * [Bind IP addr](#bind-ip-addr)
 * [Bind port](#bind-port)
 * [HTTP Frontends](#http-frontends) configuration keys
@@ -1056,7 +1059,8 @@ See also:
 
 Define listening IPv4/IPv6 address on public HAProxy frontends. Since v0.10 the default
 value changed from `*` to an empty string, which haproxy interprets in the same way and
-binds on all IPv4 address.
+binds on all IPv4 and/or IPv6 addresses, depending on the [`--ip-mode`]({{% relref "command-line#ip-mode" %}})
+command-line option.
 
 * `bind-ip-addr-tcp`: IP address of all ConfigMap based TCP services declared on [`tcp-services-configmap`]({{% relref "command-line#tcp-services-configmap" %}}) command-line option.
 * `bind-ip-addr-healthz`: IP address of the health check URL.

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/netip"
 	"os"
 	"os/signal"
 	"regexp"
@@ -314,6 +315,38 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		return nil, fmt.Errorf("error getting controller pod selector: %w", err)
 	}
 
+	var hasIPv4, hasIPv6 bool
+	switch opt.IPMode {
+	case "v4":
+		hasIPv4, hasIPv6 = true, false
+	case "v6":
+		hasIPv4, hasIPv6 = false, true
+	case "v4v6":
+		hasIPv4, hasIPv6 = true, true
+	case "lo":
+		var err error
+		hasIPv4, hasIPv6, err = readIPModeFromLoopback()
+		if err != nil {
+			return nil, fmt.Errorf("error reading IP mode from loopback interface: %w", err)
+		}
+	case "node", "auto":
+		var err error
+		hasIPv4, hasIPv6, err = readIPModeFromNode(ctx, client, controllerPod)
+		if err != nil {
+			if opt.IPMode == "node" {
+				return nil, fmt.Errorf("error reading IP mode from controller node: %w", err)
+			}
+			configLog.Info("error reading IP mode from controller node, using IPv4", "err", err.Error())
+			hasIPv4, hasIPv6 = true, false
+		}
+	default:
+		return nil, fmt.Errorf("unsupported IP mode: %s", opt.IPMode)
+	}
+	if !hasIPv4 && !hasIPv6 {
+		return nil, fmt.Errorf("neither v4 nor v6 stack were identified using IP mode '%s'", opt.IPMode)
+	}
+	configLog.Info("IP mode configured", "mode", opt.IPMode, "hasIPv4", hasIPv4, "hasIPv6", hasIPv6)
+
 	// we could `|| hasGateway[version...]` instead of `|| opt.WatchGateway` here,
 	// but we're choosing a consistent startup behavior despite of the cluster configuration.
 	election := opt.UpdateStatus || opt.AcmeServer || opt.WatchGateway
@@ -543,6 +576,8 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		HasGatewayV1:             hasGatewayV1,
 		HasGrantB1:               hasGrantB1,
 		HasGrantV1:               hasGrantV1,
+		HasIPv4:                  hasIPv4,
+		HasIPv6:                  hasIPv6,
 		HasTCPRouteA2:            hasTCPRouteA2,
 		HasTLSRouteA2:            hasTLSRouteA2,
 		HasTLSRouteV1:            hasTLSRouteV1,
@@ -764,6 +799,65 @@ func getControllerPodSelector(ctx context.Context, configLog logr.Logger, client
 	return podSelector, nil
 }
 
+func readIPModeFromNode(ctx context.Context, client *kubernetes.Clientset, controllerPod types.NamespacedName) (hasIPv4, hasIPv6 bool, err error) {
+	if controllerPod.Name == "" || controllerPod.Namespace == "" {
+		return false, false, fmt.Errorf("missing POD_NAMESPACE or POD_NAME envvars")
+	}
+	pod, err := client.CoreV1().Pods(controllerPod.Namespace).Get(ctx, controllerPod.Name, metav1.GetOptions{})
+	if err != nil {
+		return false, false, err
+	}
+	node, err := client.CoreV1().Nodes().Get(ctx, pod.Spec.NodeName, metav1.GetOptions{})
+	if err != nil {
+		return false, false, err
+	}
+	for _, addr := range node.Status.Addresses {
+		v4, v6 := parseIP(addr.Address)
+		hasIPv4 = hasIPv4 || v4
+		hasIPv6 = hasIPv6 || v6
+	}
+	return hasIPv4, hasIPv6, nil
+}
+
+func readIPModeFromLoopback() (hasIPv4, hasIPv6 bool, err error) {
+	intfs, err := net.Interfaces()
+	if err != nil {
+		return false, false, err
+	}
+	idx := slices.IndexFunc(intfs, func(intf net.Interface) bool {
+		// "lo" from Linux, "lo0" from macOS
+		return intf.Name == "lo" || intf.Name == "lo0"
+	})
+	if idx < 0 {
+		return false, false, fmt.Errorf("loopback interface not found")
+	}
+	addrs, err := intfs[idx].Addrs()
+	if err != nil {
+		return false, false, err
+	}
+	for _, addr := range addrs {
+		v4, v6 := parseIP(addr.String())
+		hasIPv4 = hasIPv4 || v4
+		hasIPv6 = hasIPv6 || v6
+	}
+	return hasIPv4, hasIPv6, nil
+}
+
+func parseIP(ipAddr string) (v4, v6 bool) {
+	prefix, err := netip.ParsePrefix(ipAddr)
+	if err != nil {
+		return false, false
+	}
+	addr := prefix.Addr()
+	if addr.Is4() || addr.Is4In6() {
+		return true, false
+	}
+	if addr.Is6() {
+		return false, true
+	}
+	return false, false
+}
+
 // Config ...
 type Config struct {
 	AcmeCheckPeriod          time.Duration
@@ -802,6 +896,8 @@ type Config struct {
 	HasGatewayV1             bool
 	HasGrantB1               bool
 	HasGrantV1               bool
+	HasIPv4                  bool
+	HasIPv6                  bool
 	HasTCPRouteA2            bool
 	HasTLSRouteA2            bool
 	HasTLSRouteV1            bool

--- a/pkg/controller/config/options.go
+++ b/pkg/controller/config/options.go
@@ -23,6 +23,7 @@ func NewOptions() *Options {
 		AcmeSecretKeyName:       "acme-private-key",
 		AcmeTokenConfigMapName:  "acme-validation-tokens",
 		BucketsResponseTime:     []float64{.0005, .001, .002, .005, .01},
+		IPMode:                  "auto",
 		AnnPrefix:               "haproxy-ingress.github.io,ingress.kubernetes.io",
 		RateLimitUpdate:         0.5,
 		WaitBeforeUpdate:        200 * time.Millisecond,
@@ -75,6 +76,7 @@ type Options struct {
 	BucketsResponseTime      []float64
 	PublishService           string
 	PublishAddress           string
+	IPMode                   string
 	TCPConfigMapName         string
 	AnnPrefix                string
 	RateLimitUpdate          float64
@@ -287,6 +289,11 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 		"Comma separated list of hostname/IP addresses that should be used to configure "+
 		"Ingress and Gateway API status. This option cannot be used if --publish-service is "+
 		"configured.",
+	)
+
+	fs.StringVar(&o.IPMode, "ip-mode", o.IPMode, ""+
+		"Defines the IP mode used on default frontend binding, loopback address, and empty "+
+		"slots configuration. Options are: 'v4', 'v6', 'v4v6', 'lo', 'node', 'auto'.",
 	)
 
 	fs.StringVar(&o.TCPConfigMapName, "tcp-services-configmap", o.TCPConfigMapName, ""+

--- a/pkg/controller/services/services.go
+++ b/pkg/controller/services/services.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/tracker"
 	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy"
+	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/utils/workqueue"
 )
@@ -120,6 +121,15 @@ func (s *Services) setup(ctx context.Context) error {
 		acmeSigner = acmeClient.signer
 		acmeQueue = acmeClient
 	}
+	var ipMode hatypes.IPMode
+	switch {
+	case cfg.HasIPv4 && cfg.HasIPv6:
+		ipMode = hatypes.IPModeV4V6
+	case cfg.HasIPv6:
+		ipMode = hatypes.IPModeV6
+	default:
+		ipMode = hatypes.IPModeV4
+	}
 	instanceOptions := haproxy.InstanceOptions{
 		RootFSPrefix:      rootFSPrefix,
 		LocalFSPrefix:     cfg.LocalFSPrefix,
@@ -133,6 +143,7 @@ func (s *Services) setup(ctx context.Context) error {
 		AdminSocket:       adminSocket,
 		AcmeSocket:        acmeSocket,
 		BackendShards:     cfg.BackendShards,
+		IPMode:            ipMode,
 		Metrics:           metrics,
 		ReloadQueue:       reloadQueue,
 		ReloadStrategy:    cfg.ReloadStrategy,
@@ -150,6 +161,7 @@ func (s *Services) setup(ctx context.Context) error {
 		Tracker:          tracker,
 		DynamicConfig:    dynConfig,
 		LocalFSPrefix:    cfg.LocalFSPrefix,
+		IPMode:           ipMode,
 		IsExternal:       instanceOptions.IsExternal,
 		MasterSocket:     instanceOptions.MasterSocket,
 		AdminSocket:      instanceOptions.AdminSocket,

--- a/pkg/converters/ingress/annotations/backend.go
+++ b/pkg/converters/ingress/annotations/backend.go
@@ -209,7 +209,7 @@ func (c *updater) setAuthExternal(config ConfigValueGetter, auth *hatypes.AuthEx
 		return
 	}
 	proxy := &c.haproxy.Frontends().AuthProxy
-	authBackendName, err := proxy.AcquireAuthBackendName(backend.BackendID())
+	authBackendName, err := proxy.AcquireAuthBackendName(backend.BackendID(), c.options.IPMode)
 	if err != nil {
 		c.logger.Warn("ignoring auth URL on %s: %v", url.Source.String(), err)
 		return

--- a/pkg/converters/ingress/annotations/frontend.go
+++ b/pkg/converters/ingress/annotations/frontend.go
@@ -205,8 +205,7 @@ func (c *updater) buildFrontBindHTTP(d *frontData) {
 	d.front.AcceptProxy = d.get(ingtypes.FrontUseProxyProtocol).Bool()
 	if bindHTTP := d.get(ingtypes.FrontBindHTTP).Value; bindHTTP != "" {
 		d.front.Bind = bindHTTP
-	} else {
-		ip := d.get(ingtypes.FrontBindIPAddrHTTP).Value
+	} else if ip := d.get(ingtypes.FrontBindIPAddrHTTP).Value; ip != "" {
 		d.front.Bind = fmt.Sprintf("%s:%d", ip, d.front.Port())
 	}
 }
@@ -215,8 +214,7 @@ func (c *updater) buildFrontBindHTTPS(d *frontData) {
 	d.front.AcceptProxy = d.get(ingtypes.FrontUseProxyProtocol).Bool()
 	if bindHTTPS := d.get(ingtypes.FrontBindHTTPS).Value; bindHTTPS != "" {
 		d.front.Bind = bindHTTPS
-	} else {
-		ip := d.get(ingtypes.FrontBindIPAddrHTTP).Value
+	} else if ip := d.get(ingtypes.FrontBindIPAddrHTTP).Value; ip != "" {
 		d.front.Bind = fmt.Sprintf("%s:%d", ip, d.front.Port())
 	}
 }
@@ -232,9 +230,15 @@ func (c *updater) buildFrontHTTPPassthrough(d *frontData) {
 		bind = d.get(ingtypes.FrontBindFrontingProxy).Value
 	}
 	if bind == "" {
-		bind = fmt.Sprintf("%s:%d", d.get(ingtypes.FrontBindIPAddrHTTP).Value, httpPort)
+		ipaddr := d.get(ingtypes.FrontBindIPAddrHTTP).Value
+		if ipaddr != "" {
+			bind = fmt.Sprintf("%s:%d", ipaddr, httpPort)
+		}
 	}
 	d.front.HTTPPassthrough = true
 	d.front.HTTPPassUseProto = d.get(ingtypes.FrontUseForwardedProto).Bool()
-	d.front.Bind = bind
+	// Bind only overwritten if configured; otherwise using default from ip-mode
+	if bind != "" {
+		d.front.Bind = bind
+	}
 }

--- a/pkg/converters/ingress/annotations/frontend_test.go
+++ b/pkg/converters/ingress/annotations/frontend_test.go
@@ -26,6 +26,8 @@ import (
 
 	ingtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/ingress/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
+	"github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy"
+	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 )
 
 func TestFrontendLocalConfig(t *testing.T) {
@@ -224,6 +226,7 @@ func TestHTTPPassthrough(t *testing.T) {
 func TestFrontendBind(t *testing.T) {
 	testCases := map[string]struct {
 		global, ann  map[string]string
+		ipMode       hatypes.IPMode
 		expHTTPBind  string
 		expHTTPSBind string
 		expHTTPErr   string
@@ -233,31 +236,31 @@ func TestFrontendBind(t *testing.T) {
 	}{
 		"test01": {
 			ann:          map[string]string{},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 		},
 		"test02": {
 			ann: map[string]string{
 				ingtypes.FrontBindHTTP: ":80,:8080",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPLog:   `WARN skipping 'bind-http' configuration on ingress 'default/ing1': missing 'http-frontend' key`,
 		},
 		"test03": {
 			ann: map[string]string{
 				ingtypes.FrontBindHTTPS: ":443,:8443",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPSLog:  `WARN skipping 'bind-https' configuration on ingress 'default/ing1': missing 'http-frontend' key`,
 		},
 		"test04": {
 			ann: map[string]string{
 				ingtypes.FrontBindIPAddrHTTP: "127.0.0.1",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPLog:   `WARN skipping 'bind-ip-addr-http' configuration on ingress 'default/ing1': missing 'http-frontend' key`,
 			expHTTPSLog:  `WARN skipping 'bind-ip-addr-http' configuration on ingress 'default/ing1': missing 'http-frontend' key`,
 		},
@@ -269,8 +272,8 @@ func TestFrontendBind(t *testing.T) {
 				ingtypes.FrontHTTPFrontend: "Front9000",
 				ingtypes.FrontBindHTTP:     ":80,:8080",
 			},
-			expHTTPBind:  "*:9090",
-			expHTTPSBind: "*:9443",
+			expHTTPBind:  ":9090",
+			expHTTPSBind: ":9443",
 			expHTTPLog:   `WARN skipping 'bind-http' configuration on ingress 'default/ing1': custom bind configuration not allowed`,
 		},
 		"test06": {
@@ -283,7 +286,7 @@ func TestFrontendBind(t *testing.T) {
 				ingtypes.FrontBindHTTP:     ":80,:8080",
 			},
 			expHTTPBind:  ":80,:8080",
-			expHTTPSBind: "*:9443",
+			expHTTPSBind: ":9443",
 		},
 		"test07": {
 			global: map[string]string{
@@ -294,7 +297,7 @@ func TestFrontendBind(t *testing.T) {
 				ingtypes.FrontHTTPFrontend: "Front9000",
 				ingtypes.FrontBindHTTPS:    ":443,:8443",
 			},
-			expHTTPBind:  "*:9090",
+			expHTTPBind:  ":9090",
 			expHTTPSBind: ":443,:8443",
 		},
 		"test08": {
@@ -313,8 +316,8 @@ func TestFrontendBind(t *testing.T) {
 			ann: map[string]string{
 				ingtypes.FrontHTTPFrontend: "Front9000",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPErr:   `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPSErr:  `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 		},
@@ -325,8 +328,8 @@ Front8000=8080/8443
 Front9000=9090/8443
 `,
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPLog:   `WARN ignoring local frontend configuration: local frontend ports 9090/8443 cannot collide with other already declared ports: [80 443 8080 8443]`,
 			expHTTPSLog:  `WARN ignoring local frontend configuration: local frontend ports 9090/8443 cannot collide with other already declared ports: [80 443 8080 8443]`,
 		},
@@ -337,8 +340,8 @@ Front8000=8080/8443
 Front8000=9090/9443
 `,
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPLog:   `WARN ignoring local frontend configuration: frontend ID already in use: 'Front8000'`,
 			expHTTPSLog:  `WARN ignoring local frontend configuration: frontend ID already in use: 'Front8000'`,
 		},
@@ -349,8 +352,8 @@ Front8000=9090/9443
 			ann: map[string]string{
 				ingtypes.FrontHTTPFrontend: "Front9000",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPErr:   `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPSErr:  `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPLog:   `WARN ignoring local frontend configuration: local frontend ports 9090/443 cannot collide with other already declared ports: [80 443]`,
@@ -363,8 +366,8 @@ Front8000=9090/9443
 			ann: map[string]string{
 				ingtypes.FrontHTTPFrontend: "Front9000",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPErr:   `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPSErr:  `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPLog:   `WARN ignoring local frontend configuration: local frontend ports 80/9443 cannot collide with other already declared ports: [80 443]`,
@@ -377,8 +380,8 @@ Front8000=9090/9443
 			ann: map[string]string{
 				ingtypes.FrontHTTPFrontend: "Front9000",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPErr:   `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPSErr:  `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPLog:   `WARN ignoring local frontend configuration: invalid port numbers: '9090/-9443'`,
@@ -391,8 +394,8 @@ Front8000=9090/9443
 			ann: map[string]string{
 				ingtypes.FrontHTTPFrontend: "Front9000",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPErr:   `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPSErr:  `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPLog:   `WARN ignoring local frontend configuration: invalid port numbers: '9090/invalid'`,
@@ -405,8 +408,8 @@ Front8000=9090/9443
 			ann: map[string]string{
 				ingtypes.FrontHTTPFrontend: "Front900",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPErr:   `frontend ID not found on ingress 'default/ing1': 'Front900'`,
 			expHTTPSErr:  `frontend ID not found on ingress 'default/ing1': 'Front900'`,
 		},
@@ -417,8 +420,8 @@ Front8000=9090/9443
 			ann: map[string]string{
 				ingtypes.FrontHTTPFrontend: "Front9000",
 			},
-			expHTTPBind:  "*:9090",
-			expHTTPSBind: "*:9443",
+			expHTTPBind:  ":9090",
+			expHTTPSBind: ":9443",
 		},
 		"test19": {
 			global: map[string]string{
@@ -429,8 +432,8 @@ Front8000=9090/9443
 				ingtypes.FrontHTTPFrontend: "Front9000",
 				ingtypes.FrontBindHTTP:     "127.0.0.1:9090",
 			},
-			expHTTPBind:  "*:80",
-			expHTTPSBind: "*:443",
+			expHTTPBind:  ":80",
+			expHTTPSBind: ":443",
 			expHTTPErr:   `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPSErr:  `frontend ID not found on ingress 'default/ing1': 'Front9000'`,
 			expHTTPLog:   `WARN ignoring local frontend configuration: invalid frontend declaration syntax: 'Front9000=9090'`,
@@ -446,13 +449,51 @@ Front8000=9090/9443
 				ingtypes.FrontBindHTTP:     "127.0.0.1:9090",
 			},
 			expHTTPBind:  "127.0.0.1:9090",
-			expHTTPSBind: "*:9443",
+			expHTTPSBind: ":9443",
+		},
+		"test21": {
+			ipMode:       hatypes.IPModeV6,
+			expHTTPBind:  ":::80",
+			expHTTPSBind: ":::443",
+		},
+		"test22": {
+			ipMode:       hatypes.IPModeV4V6,
+			expHTTPBind:  ":80,:::80",
+			expHTTPSBind: ":443,:::443",
+		},
+		"test23": {
+			global: map[string]string{
+				ingtypes.FrontBindHTTP: "127.0.0.1:80",
+			},
+			ipMode:       hatypes.IPModeV6,
+			expHTTPBind:  "127.0.0.1:80",
+			expHTTPSBind: ":::443",
+		},
+		"test24": {
+			global: map[string]string{
+				ingtypes.FrontBindHTTPS: "127.0.0.1:443",
+			},
+			ipMode:       hatypes.IPModeV6,
+			expHTTPBind:  ":::80",
+			expHTTPSBind: "127.0.0.1:443",
+		},
+		"test25": {
+			global: map[string]string{
+				ingtypes.FrontBindIPAddrHTTP: "127.0.0.1",
+			},
+			ipMode:       hatypes.IPModeV6,
+			expHTTPBind:  "127.0.0.1:80",
+			expHTTPSBind: "127.0.0.1:443",
 		},
 	}
 	source := &Source{Namespace: "default", Name: "ing1", Type: "ingress"}
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
 			c := setup(t)
+			if test.ipMode != "" {
+				// pass as a parameter somehow?
+				c.haproxy = haproxy.CreateInstance(c.logger, haproxy.InstanceOptions{IPMode: test.ipMode}).Config()
+			}
 			defer c.teardown()
 			if test.global == nil {
 				test.global = make(map[string]string)
@@ -462,9 +503,6 @@ Front8000=9090/9443
 			}
 			if test.global[ingtypes.GlobalHTTPSPort] == "" {
 				test.global[ingtypes.GlobalHTTPSPort] = "443"
-			}
-			if test.global[ingtypes.FrontBindIPAddrHTTP] == "" {
-				test.global[ingtypes.FrontBindIPAddrHTTP] = "*"
 			}
 			if dHTTP, err := c.createFrontData(source, false, test.ann, test.global); err == nil {
 				c.createUpdater().buildFrontBindHTTP(dHTTP)

--- a/pkg/converters/ingress/annotations/updater_test.go
+++ b/pkg/converters/ingress/annotations/updater_test.go
@@ -121,7 +121,10 @@ type testConfig struct {
 func setup(t *testing.T) *testConfig {
 	logger := &types_helper.LoggerMock{T: t}
 	tracker := tracker.NewTracker()
-	instance := haproxy.CreateInstance(logger, haproxy.InstanceOptions{}).Config()
+	opt := haproxy.InstanceOptions{
+		IPMode: hatypes.IPModeV4,
+	}
+	instance := haproxy.CreateInstance(logger, opt).Config()
 	instance.Global().Peers.LocalPeer.BESuffix = "proxy01" // we need this to properly initialize updater's vars map
 	return &testConfig{
 		t:       t,

--- a/pkg/converters/types/options.go
+++ b/pkg/converters/types/options.go
@@ -19,6 +19,7 @@ package types
 import (
 	"time"
 
+	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 	"github.com/jcmoraisjr/haproxy-ingress/pkg/types"
 )
 
@@ -39,6 +40,7 @@ type ConverterOptions struct {
 	DefaultCrtSecret string
 	FakeCrtFile      CrtFile
 	FakeCAFile       CrtFile
+	IPMode           hatypes.IPMode
 	AnnotationPrefix []string
 	DisableKeywords  []string
 	AcmeTrackTLSAnn  bool

--- a/pkg/converters/utils/services.go
+++ b/pkg/converters/utils/services.go
@@ -24,7 +24,8 @@ import (
 	api "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 
-	"github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
+	convtypes "github.com/jcmoraisjr/haproxy-ingress/pkg/converters/types"
+	hatypes "github.com/jcmoraisjr/haproxy-ingress/pkg/haproxy/types"
 )
 
 // FindServicePort ...
@@ -79,7 +80,7 @@ func createEndpointSlices(endpointSlices []*discoveryv1.EndpointSlice, svcPort *
 	for _, endpointSlice := range endpointSlices {
 		var loopbackEndpoint, portsAsReplicas bool
 		if ann := endpointSlice.GetAnnotations(); ann != nil {
-			loopbackEndpoint = ann["internal.haproxy-ingress.github.io/loopback-endpoint"] == "1"
+			loopbackEndpoint = ann["internal.haproxy-ingress.github.io/loopbackv4-endpoint"] == "1"
 			portsAsReplicas = ann["internal.haproxy-ingress.github.io/ports-as-replicas"] == "1"
 		}
 		for _, epPort := range endpointSlice.Ports {
@@ -88,7 +89,7 @@ func createEndpointSlices(endpointSlices []*discoveryv1.EndpointSlice, svcPort *
 				// from distinct port numbers instead of distinct endpoints+addresses. Endpoint
 				// is hardcoded to loopback and no other Service and EndpointSlice configuration
 				// is checked.
-				ready = append(ready, newEndpoint("127.0.0.1", int(*epPort.Port), nil))
+				ready = append(ready, newEndpoint(hatypes.LoopbackV4, int(*epPort.Port), nil))
 				continue
 			}
 
@@ -120,7 +121,7 @@ func createEndpointSlices(endpointSlices []*discoveryv1.EndpointSlice, svcPort *
 				// address here.
 				addr := endpoint.Addresses[0]
 				if loopbackEndpoint {
-					addr = "127.0.0.1"
+					addr = hatypes.LoopbackV4
 				}
 				domainEndpoint := newEndpoint(addr, int(*epPort.Port), endpoint.TargetRef)
 
@@ -146,7 +147,7 @@ func createEndpointSlices(endpointSlices []*discoveryv1.EndpointSlice, svcPort *
 }
 
 // CreateEndpoints ...
-func CreateEndpoints(cache types.Cache, svc *api.Service, svcPort *api.ServicePort) (ready, notReady []*Endpoint, err error) {
+func CreateEndpoints(cache convtypes.Cache, svc *api.Service, svcPort *api.ServicePort) (ready, notReady []*Endpoint, err error) {
 	switch svc.Spec.Type {
 	case api.ServiceTypeExternalName:
 		ready, err = createEndpointsExternalName(cache, svc, svcPort)
@@ -176,7 +177,7 @@ func CreateSvcEndpoint(svc *api.Service, svcPort *api.ServicePort) (endpoint *En
 	return newEndpoint(svc.Spec.ClusterIP, int(port), nil), nil
 }
 
-func createEndpointsExternalName(cache types.Cache, svc *api.Service, svcPort *api.ServicePort) (endpoints []*Endpoint, err error) {
+func createEndpointsExternalName(cache convtypes.Cache, svc *api.Service, svcPort *api.ServicePort) (endpoints []*Endpoint, err error) {
 	port := int(svcPort.Port)
 	if port <= 0 {
 		return nil, fmt.Errorf("invalid port number: %d", port)

--- a/pkg/haproxy/config.go
+++ b/pkg/haproxy/config.go
@@ -62,6 +62,7 @@ type config struct {
 }
 
 type options struct {
+	ipMode       hatypes.IPMode
 	mapsTemplate *template.Config
 	mapsDir      string
 	shardCount   int
@@ -75,7 +76,7 @@ func createConfig(options options) *config {
 		options:     options,
 		acmeData:    &hatypes.AcmeData{},
 		global:      &hatypes.Global{},
-		frontends:   &hatypes.Frontends{},
+		frontends:   hatypes.CreateFrontends(options.ipMode),
 		backends:    hatypes.CreateBackends(options.shardCount),
 		tcpbackends: hatypes.CreateTCPBackends(),
 		tcpservices: hatypes.CreateTCPServices(),

--- a/pkg/haproxy/dynupdate.go
+++ b/pkg/haproxy/dynupdate.go
@@ -229,7 +229,7 @@ func (d *dynUpdater) checkBackendPair(pair *backendPair) bool {
 			// DNS based updates finishes prematurely. Ensure the ep
 			// list size of the new one is at least as big as the old one.
 			for i := len(curBack.Endpoints); i < len(oldBack.Endpoints); i++ {
-				curBack.AddEmptyEndpoint()
+				curBack.AddEmptyEndpoint(d.config.options.ipMode)
 			}
 		}
 		return updated
@@ -314,7 +314,7 @@ func (d *dynUpdater) dynamicallySyncSlots(pair *backendPair) bool {
 
 	// copy remaining empty slots from oldBack to curBack, so it can be used in a future update
 	for i := len(added); i < len(empty); i++ {
-		curBack.AddEmptyEndpoint().Name = empty[i].Name
+		curBack.AddEmptyEndpoint(d.config.options.ipMode).Name = empty[i].Name
 	}
 
 	return updated
@@ -424,7 +424,7 @@ func (d *dynUpdater) alignSlots() {
 				}
 			}
 			for i := totalFreeSlots; i < minFreeSlots; i++ {
-				back.AddEmptyEndpoint()
+				back.AddEmptyEndpoint(d.config.options.ipMode)
 				changed = true
 			}
 			// * []endpoints == group of blocks
@@ -434,7 +434,7 @@ func (d *dynUpdater) alignSlots() {
 			newFreeSlots = blockSize - (((len(back.Endpoints) + blockSize - 1) % blockSize) + 1)
 		}
 		for i := 0; i < newFreeSlots; i++ {
-			back.AddEmptyEndpoint()
+			back.AddEmptyEndpoint(d.config.options.ipMode)
 			changed = true
 		}
 		if changed {

--- a/pkg/haproxy/dynupdate_test.go
+++ b/pkg/haproxy/dynupdate_test.go
@@ -87,7 +87,7 @@ INFO-V(2) updated endpoint '172.17.0.4:8080' weight '1' on backend/server 'defau
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
-				b.AddEmptyEndpoint()
+				b.AddEmptyEndpoint(types.IPModeV4)
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
@@ -242,7 +242,7 @@ INFO-V(2) updated endpoint '172.17.0.2:8080' weight '2' on backend/server 'defau
 		"test09": {
 			doconfig1: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
-				b.AddEmptyEndpoint()
+				b.AddEmptyEndpoint(types.IPModeV4)
 				b.AcquireEndpoint("172.17.0.3", 8080, "")
 			},
 			doconfig2: func(c *testConfig) {
@@ -277,7 +277,7 @@ INFO-V(2) enabled endpoint '172.17.0.2:8080' weight '1' on backend/server 'defau
 		"test10": {
 			doconfig1: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
-				b.AddEmptyEndpoint()
+				b.AddEmptyEndpoint(types.IPModeV4)
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
 			},
 			doconfig2: func(c *testConfig) {
@@ -404,7 +404,7 @@ INFO-V(2) disabled endpoint '172.17.0.4:8080' weight '1' on backend/server 'defa
 			doconfig1: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
-				b.AddEmptyEndpoint()
+				b.AddEmptyEndpoint(types.IPModeV4)
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
@@ -432,8 +432,8 @@ INFO-V(2) need to reload due to config changes: [backends]`,
 			doconfig1: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
-				b.AddEmptyEndpoint()
-				b.AddEmptyEndpoint()
+				b.AddEmptyEndpoint(types.IPModeV4)
+				b.AddEmptyEndpoint(types.IPModeV4)
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
@@ -528,7 +528,7 @@ INFO-V(2) need to reload due to config changes: [backends]`,
 			doconfig1: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b.AcquireEndpoint("172.17.0.2", 8080, "").Label = "green"
-				b.AddEmptyEndpoint()
+				b.AddEmptyEndpoint(types.IPModeV4)
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
@@ -563,7 +563,7 @@ INFO-V(2) enabled endpoint '172.17.0.3:8080' weight '1' on backend/server 'defau
 			doconfig1: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b.AcquireEndpoint("172.17.0.2", 8080, "").Label = "green"
-				b.AddEmptyEndpoint()
+				b.AddEmptyEndpoint(types.IPModeV4)
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
@@ -899,7 +899,7 @@ INFO-V(2) updated endpoint '172.17.0.3:8080' weight '1' on backend/server 'defau
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")
 				b.Resolver = "k8s"
 				b.AcquireEndpoint("172.17.0.2", 8080, "")
-				b.AddEmptyEndpoint()
+				b.AddEmptyEndpoint(types.IPModeV4)
 			},
 			doconfig2: func(c *testConfig) {
 				b := c.config.Backends().AcquireBackend("default", "app", "8080")

--- a/pkg/haproxy/instance.go
+++ b/pkg/haproxy/instance.go
@@ -50,6 +50,7 @@ type InstanceOptions struct {
 	BackendShards     int
 	HAProxyCfgDir     string
 	HAProxyMapsDir    string
+	IPMode            hatypes.IPMode
 	IsMasterWorker    bool
 	IsExternal        bool
 	ConnectionTimeout time.Duration
@@ -246,6 +247,7 @@ func (i *instance) ParseTemplates() error {
 func (i *instance) Config() Config {
 	if i.config == nil {
 		config := createConfig(options{
+			ipMode:       i.options.IPMode,
 			mapsTemplate: i.mapsTmpl,
 			mapsDir:      i.options.HAProxyMapsDir,
 			shardCount:   i.options.BackendShards,

--- a/pkg/haproxy/instance_test.go
+++ b/pkg/haproxy/instance_test.go
@@ -3830,7 +3830,7 @@ frontend _front__auth
 
 		for _, back := range test.backs {
 			backend := c.config.Backends().AcquireAuthBackend(back.iplist, back.port, back.hostname)
-			_, _ = auth.AcquireAuthBackendName(backend.BackendID())
+			_, _ = auth.AcquireAuthBackendName(backend.BackendID(), hatypes.IPModeV4)
 		}
 
 		c.Update()
@@ -4179,7 +4179,7 @@ func TestInstanceCustomProxy(t *testing.T) {
 	auth.RangeStart = 4001
 	auth.RangeEnd = 4010
 	authBackend := c.config.Backends().AcquireAuthBackend([]string{"172.17.100.11"}, 5000, "")
-	_, _ = auth.AcquireAuthBackendName(authBackend.BackendID())
+	_, _ = auth.AcquireAuthBackendName(authBackend.BackendID(), hatypes.IPModeV4)
 
 	tcp := c.config.tcpbackends.Acquire("default_pgsql", 5432)
 	tcp.AddEndpoint("172.17.0.21", 5432)
@@ -6337,6 +6337,7 @@ func setupOptions(options testOptions) *testConfig {
 		HAProxyMapsDir: tempdir,
 		Metrics:        helper_test.NewMetricsMock(),
 		BackendShards:  options.shardCount,
+		IPMode:         hatypes.IPModeV4,
 		//
 		fake: true,
 	}).(*instance)

--- a/pkg/haproxy/types/backend.go
+++ b/pkg/haproxy/types/backend.go
@@ -58,8 +58,8 @@ func (b *Backend) AcquireEndpoint(ip string, port int, targetRef string) *Endpoi
 }
 
 // AddEmptyEndpoint ...
-func (b *Backend) AddEmptyEndpoint() *Endpoint {
-	endpoint := b.AddEndpoint("127.0.0.1", 1023, "")
+func (b *Backend) AddEmptyEndpoint(ipMode IPMode) *Endpoint {
+	endpoint := b.AddEndpoint(loopbackAddress(ipMode), 1023, "")
 	endpoint.Enabled = false
 	// we need to set the cookie value to something here so that when dynamic
 	// update enables these endpoints without a reload, they will use cookie
@@ -76,7 +76,7 @@ func (b *Backend) AddEndpoint(ip string, port int, targetRef string) *Endpoint {
 		names := strings.Split(targetRef, "/")
 		name = names[len(names)-1]
 	case EpIPPort:
-		if ip != "127.0.0.1" {
+		if ip != LoopbackV4 && ip != LoopbackV6 {
 			name = fmt.Sprintf("%s:%d", ip, port)
 		}
 	}
@@ -461,7 +461,7 @@ func (b *BackendPathConfig) PathIDs(index int) []string {
 
 // IsEmpty ...
 func (ep *Endpoint) IsEmpty() bool {
-	return ep.IP == "127.0.0.1" && ep.Port == 1023
+	return (ep.IP == LoopbackV4 || ep.IP == LoopbackV6) && ep.Port == 1023
 }
 
 func pathsEqual(paths1, paths2 []*Path) bool {

--- a/pkg/haproxy/types/backend_test.go
+++ b/pkg/haproxy/types/backend_test.go
@@ -124,7 +124,7 @@ func TestFillSourceIPs(t *testing.T) {
 			if e != "" {
 				b.AcquireEndpoint(e, 8080, "")
 			} else {
-				b.AddEmptyEndpoint()
+				b.AddEmptyEndpoint(IPModeV4)
 			}
 		}
 		for _, s := range test.src {

--- a/pkg/haproxy/types/frontend.go
+++ b/pkg/haproxy/types/frontend.go
@@ -23,6 +23,12 @@ import (
 	"sort"
 )
 
+func CreateFrontends(ipMode IPMode) *Frontends {
+	return &Frontends{
+		ipMode: ipMode,
+	}
+}
+
 func (f *Frontends) AcquireFrontend(port int32, isHTTPS bool) *Frontend {
 	var has bool
 	for _, frontend := range f.items {
@@ -42,10 +48,19 @@ func (f *Frontends) AcquireFrontend(port int32, isHTTPS bool) *Frontend {
 	if has {
 		name = fmt.Sprintf("%s_%d", name, port)
 	}
+	var bind string
+	switch f.ipMode {
+	case IPModeV4V6:
+		bind = fmt.Sprintf(":%d,:::%[1]d", port)
+	case IPModeV6:
+		bind = fmt.Sprintf(":::%d", port)
+	default:
+		bind = fmt.Sprintf(":%d", port)
+	}
 	frontend := &Frontend{
 		Name:         name,
 		RenderedName: name,
-		Bind:         fmt.Sprintf(":%d", port),
+		Bind:         bind,
 		IsHTTPS:      isHTTPS,
 		port:         port,
 		hosts:        map[string]*Host{},
@@ -333,7 +348,7 @@ func (f *Frontend) HasVarNamespace() bool {
 }
 
 // AcquireAuthBackendName ...
-func (proxy *AuthProxy) AcquireAuthBackendName(backend BackendID) (authBackendName string, err error) {
+func (proxy *AuthProxy) AcquireAuthBackendName(backend BackendID, ipMode IPMode) (authBackendName string, err error) {
 	freePort := proxy.RangeStart
 	for _, bind := range proxy.BindList {
 		if bind.Backend == backend {
@@ -350,6 +365,7 @@ func (proxy *AuthProxy) AcquireAuthBackendName(backend BackendID) (authBackendNa
 	bind := &AuthProxyBind{
 		AuthBackendName: fmt.Sprintf("_auth_%d", freePort),
 		Backend:         backend,
+		Loopback:        loopbackAddress(ipMode),
 		LocalPort:       freePort,
 		SocketID:        socketID,
 	}
@@ -372,6 +388,13 @@ func (proxy *AuthProxy) RemoveAuthBackendExcept(used map[string]bool) {
 		}
 	}
 	proxy.BindList = bindList[:i]
+}
+
+func loopbackAddress(ipMode IPMode) string {
+	if ipMode == IPModeV6 {
+		return LoopbackV6
+	}
+	return LoopbackV4
 }
 
 // String ...

--- a/pkg/haproxy/types/frontend_test.go
+++ b/pkg/haproxy/types/frontend_test.go
@@ -18,7 +18,41 @@ package types
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
+
+func TestAcquireFrontend(t *testing.T) {
+	testCases := map[string]struct {
+		ipMode  IPMode
+		port    int32
+		expBind string
+	}{
+		"v4 mode": {
+			ipMode:  IPModeV4,
+			port:    8080,
+			expBind: ":8080",
+		},
+		"v6 mode": {
+			ipMode:  IPModeV6,
+			port:    8080,
+			expBind: ":::8080",
+		},
+		"v4v6 mode": {
+			ipMode:  IPModeV4V6,
+			port:    8080,
+			expBind: ":8080,:::8080",
+		},
+	}
+
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			frontends := CreateFrontends(test.ipMode)
+			f := frontends.AcquireFrontend(test.port, false)
+			require.Equal(t, test.expBind, f.Bind)
+		})
+	}
+}
 
 func TestAcquireAuthFrontendLocalPort(t *testing.T) {
 	testCases := []struct {
@@ -62,7 +96,7 @@ func TestAcquireAuthFrontendLocalPort(t *testing.T) {
 		authBackendNames := make([]string, len(test.backends))
 		errs := make([]string, len(test.backends))
 		for j, back := range test.backends {
-			authBackendName, err := authProxy.AcquireAuthBackendName(BackendID{Name: back})
+			authBackendName, err := authProxy.AcquireAuthBackendName(BackendID{Name: back}, IPModeV4)
 			authBackendNames[j] = authBackendName
 			if err != nil {
 				errs[j] = err.Error()

--- a/pkg/haproxy/types/types.go
+++ b/pkg/haproxy/types/types.go
@@ -480,15 +480,30 @@ type AuthProxy struct {
 type AuthProxyBind struct {
 	AuthBackendName string
 	Backend         BackendID
+	Loopback        string
 	LocalPort       int
 	SocketID        int
 }
+
+type IPMode string
+
+const (
+	IPModeV4   IPMode = "IPV4"
+	IPModeV6   IPMode = "IPV6"
+	IPModeV4V6 IPMode = "IPV4V6"
+)
+
+const (
+	LoopbackV4 = "127.0.0.1"
+	LoopbackV6 = "[::1]"
+)
 
 // Frontends ...
 type Frontends struct {
 	AuthProxy AuthProxy
 	//
 	items   []*Frontend
+	ipMode  IPMode
 	changed bool
 }
 

--- a/rootfs/etc/templates/haproxy/haproxy.tmpl
+++ b/rootfs/etc/templates/haproxy/haproxy.tmpl
@@ -1055,14 +1055,14 @@ backend {{ $bind.AuthBackendName }}
 {{- range $snippet := index $global.CustomProxy $bind.AuthBackendName }}
     {{ $snippet }}
 {{- end }}
-    server {{ $bind.AuthBackendName }} 127.0.0.1:{{ $bind.LocalPort }}
+    server {{ $bind.AuthBackendName }} {{ $bind.Loopback }}:{{ $bind.LocalPort }}
 {{- end }}
 
 {{- /*------------------------------------*/}}
 frontend {{ $proxy.Name }}
     mode http
 {{- range $bind := $proxy.BindList }}
-    bind 127.0.0.1:{{ $bind.LocalPort }}
+    bind {{ $bind.Loopback }}:{{ $bind.LocalPort }}
         {{- if $use_socket }} id {{ $bind.SocketID }}{{ end }}
 {{- end }}
 

--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -234,6 +234,8 @@ func (f *framework) StartController(ctx context.Context, t *testing.T) {
 	opt.LocalFSPrefix = "/tmp/haproxy-ingress"
 	opt.PublishService = PublishSvcName
 	opt.ConfigMap = GlobalConfigMap.String()
+	// Our Request() method and EndpointSlice configuration currently uses IPv4 address only
+	opt.IPMode = "v4"
 	if f.optOverride != nil {
 		f.optOverride(opt)
 	}
@@ -670,7 +672,7 @@ apiVersion: discovery.k8s.io/v1
 addressType: IPv4
 endpoints:
 - addresses:
-  - 0.0.0.255 ## ignored due to loopback-endpoint/ports-as-replicas annotations
+  - 0.0.0.255 ## ignored due to loopbackv4-endpoint/ports-as-replicas annotations
   conditions:
     ready: true
 metadata:
@@ -686,7 +688,7 @@ ports: []
 	if portsAsReplicas {
 		eps.Annotations["internal.haproxy-ingress.github.io/ports-as-replicas"] = "1"
 	} else {
-		eps.Annotations["internal.haproxy-ingress.github.io/loopback-endpoint"] = "1"
+		eps.Annotations["internal.haproxy-ingress.github.io/loopbackv4-endpoint"] = "1"
 	}
 	eps.Labels["kubernetes.io/service-name"] = svc.Name
 	for _, svcport := range svc.Spec.Ports {


### PR DESCRIPTION
Add option to customize the IP stack HAProxy should use when configuring loopback addresses (used in auth external and empty slots for dynamic update), as well as the frontend listeners.

By default the IP stack is read from the node HAProxy Ingress is deployed - the IP formats used on node's addresses makes HAProxy Ingress bind ports on those same stacks. For the loopback addresses, IPv4 is always used except if the v4 stack is not found.

This adds a backward compatibility change: if controller can reach the node status, IPv6 should be enabled if the node has an IPv6 address. Use --ip-mode=v4 to preserve the legacy behavior. IPv4 only is used by default if there is an error reading node status.