### PR TITLE
padronize the eventually timeout and interval

### DIFF
--- a/tests/framework/framework.go
+++ b/tests/framework/framework.go
@@ -69,6 +69,9 @@ const (
 	TestPortHTTP    = 28080
 	TestPortHTTPS   = 28443
 	TestPortStat    = 21936
+
+	CommonTimeout  = 15 * time.Second
+	CommonInterval = 2 * time.Second
 )
 
 var (
@@ -260,9 +263,9 @@ func (f *framework) StartController(ctx context.Context, t *testing.T) {
 		req.URL.Path = "/"
 		_, err = http.DefaultClient.Do(req)
 		assert.NoError(collect, err)
-	}, 10*time.Second, time.Second)
+	}, CommonTimeout, CommonInterval)
 
-	f.admSock = socket.NewSocket(ctx, "/tmp/haproxy-ingress/var/run/haproxy/admin.sock", 5*time.Second, false)
+	f.admSock = socket.NewSocket(ctx, "/tmp/haproxy-ingress/var/run/haproxy/admin.sock", CommonTimeout, false)
 }
 
 type Response struct {
@@ -345,14 +348,14 @@ func (*framework) Request(ctx context.Context, t *testing.T, method, host, path 
 				return
 			}
 			assert.Contains(collect, opt.ExpectResponseCode, res.StatusCode)
-		}, 5*time.Second, time.Second)
+		}, CommonTimeout, CommonInterval)
 		// ... but requires that no request error happened.
 		require.NoError(t, err)
 	case opt.ExpectError != "":
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_, err := cli.Do(req)
 			assert.ErrorContains(collect, err, opt.ExpectError)
-		}, 5*time.Second, time.Second)
+		}, CommonTimeout, CommonInterval)
 		return Response{EchoResponse: buildEchoResponse(t, "")}
 	default:
 		res, err = cli.Do(req)
@@ -389,7 +392,7 @@ func (*framework) TCPRequest(ctx context.Context, t *testing.T, tcpPort int32, d
 			conn, err = net.Dial("tcp", fmt.Sprintf(":%d", tcpPort))
 		}
 		assert.NoError(collect, err)
-	}, 5*time.Second, time.Second)
+	}, CommonTimeout, CommonInterval)
 	defer conn.Close()
 	_, err := conn.Write([]byte(data))
 	require.NoError(t, err)
@@ -448,7 +451,7 @@ func (*framework) Websocket(ctx context.Context, t *testing.T, host, path string
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_, _, err := websocket.DefaultDialer.DialContext(ctx, url.String(), header)
 			assert.ErrorContains(collect, err, opt.ExpectError)
-		}, 5*time.Second, time.Second)
+		}, CommonTimeout, CommonInterval)
 		return nil
 	}
 
@@ -457,7 +460,7 @@ func (*framework) Websocket(ctx context.Context, t *testing.T, host, path string
 		var err error
 		ws, _, err = websocket.DefaultDialer.DialContext(ctx, url.String(), header)
 		assert.NoError(collect, err)
-	}, 5*time.Second, time.Second)
+	}, CommonTimeout, CommonInterval)
 	t.Cleanup(func() { ws.Close() })
 
 	return &WSConn{ws}
@@ -482,7 +485,7 @@ func (f *framework) RequireIngressStatus(ctx context.Context, t *testing.T, ing 
 			return
 		}
 		assert.Equal(collect, expectedIngressStatus, ing.Status)
-	}, 5*time.Second, time.Second)
+	}, CommonTimeout, CommonInterval)
 }
 
 var pidRegex = regexp.MustCompile(`Pid: ([0-9]+)`)

--- a/tests/integration/integration_test.go
+++ b/tests/integration/integration_test.go
@@ -649,7 +649,7 @@ func TestIntegrationIngress(t *testing.T) {
 			for _, msg := range expected {
 				assert.True(collect, slices.Contains(messages, msg), "message not found: "+msg)
 			}
-		}, 5*time.Second, time.Second)
+		}, framework.CommonTimeout, framework.CommonInterval)
 
 		// each client should receive their responses as well
 		assert.Equal(t, []string{"msg 1", "msg 4"}, ws1.ReadClientMessages(t))
@@ -904,7 +904,7 @@ Request forbidden by administrative rules.
 				}
 			}
 			assert.Fail(collect, "lease event not found")
-		}, 10*time.Second, time.Second)
+		}, framework.CommonTimeout, framework.CommonInterval)
 	})
 
 	t.Run("should update ingress status", func(t *testing.T) {
@@ -953,7 +953,7 @@ Request forbidden by administrative rules.
 					},
 				},
 			}, ing.Status)
-		}, 5*time.Second, time.Second)
+		}, framework.CommonTimeout, framework.CommonInterval)
 
 		// recover initial svc status
 		svcpub.Status.LoadBalancer.Ingress = svcpublb
@@ -1050,7 +1050,7 @@ Request forbidden by administrative rules.
 
 		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_ = framework.TLSConnection(collect, "localhost", tcpIngressPort)
-		}, 5*time.Second, time.Second)
+		}, framework.CommonTimeout, framework.CommonInterval)
 
 		conn := framework.TLSConnection(t, "localhost", tcpIngressPort)
 		require.NotNil(t, conn)
@@ -1310,7 +1310,7 @@ Request forbidden by administrative rules.
 		eventuallyServerCount := func(t *testing.T, svc *corev1.Service, expectedServerCount int) {
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
 				assert.Equal(collect, expectedServerCount, f.ReadNumBackendServers(t, svc))
-			}, 5*time.Second, time.Second)
+			}, framework.CommonTimeout, framework.CommonInterval)
 		}
 		eventuallyBalanceCount := func(t *testing.T, hostname string, expectedServerCount int) {
 			require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -1319,7 +1319,7 @@ Request forbidden by administrative rules.
 					return
 				}
 				assert.Equal(collect, expectedServerCount, count)
-			}, 15*time.Second, 3*time.Second)
+			}, framework.CommonTimeout, framework.CommonInterval)
 		}
 		changeReplicas := func(ep *discoveryv1.EndpointSlice, addRemove int) {
 			switch {


### PR DESCRIPTION
Configure a common, and a bit higher timeout and interval for the eventually assertion. Some tests are flaking, timing out to achieve the expected state, probably due to slow/busy machines causing slower reconciliations.

This update not only change timeout to 15s (usually 5s or 10s) and interval to 2s (usually 1s), but also defines them via const.