### PR TITLE
fix ip address parsing for ip mode

### DIFF
--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -329,14 +329,21 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 		if err != nil {
 			return nil, fmt.Errorf("error reading IP mode from loopback interface: %w", err)
 		}
-	case "node", "auto":
+	case "node":
 		var err error
 		hasIPv4, hasIPv6, err = readIPModeFromNode(ctx, client, controllerPod)
 		if err != nil {
-			if opt.IPMode == "node" {
-				return nil, fmt.Errorf("error reading IP mode from controller node: %w", err)
-			}
+			return nil, fmt.Errorf("error reading IP mode from controller node: %w", err)
+		}
+	case "auto":
+		var err error
+		hasIPv4, hasIPv6, err = readIPModeFromNode(ctx, client, controllerPod)
+		if err != nil {
 			configLog.Info("error reading IP mode from controller node, using IPv4", "err", err.Error())
+			hasIPv4, hasIPv6 = true, false
+		}
+		if !hasIPv4 && !hasIPv6 {
+			configLog.Info("cannot find any valid IPv4 or IPv6 from node status, using IPv4")
 			hasIPv4, hasIPv6 = true, false
 		}
 	default:
@@ -844,12 +851,15 @@ func readIPModeFromLoopback() (hasIPv4, hasIPv6 bool, err error) {
 }
 
 func parseIP(ipAddr string) (v4, v6 bool) {
-	prefix, err := netip.ParsePrefix(ipAddr)
+	addr, err := netip.ParseAddr(ipAddr)
 	if err != nil {
-		return false, false
+		prefix, err := netip.ParsePrefix(ipAddr)
+		if err != nil {
+			return false, false
+		}
+		addr = prefix.Addr()
 	}
-	addr := prefix.Addr()
-	if addr.Is4() || addr.Is4In6() {
+	if addr.Is4() {
 		return true, false
 	}
 	if addr.Is6() {

--- a/pkg/controller/config/config_test.go
+++ b/pkg/controller/config/config_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The HAProxy Ingress Controller Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseIP(t *testing.T) {
+	type ipClass int
+	const (
+		ipv4 ipClass = iota
+		ipv6
+		ipNone
+	)
+	testCases := map[string]struct {
+		addr     string
+		expClass ipClass
+	}{
+		"ipv4-loopback": {
+			addr:     "127.0.0.1",
+			expClass: ipv4,
+		},
+		"ipv4-loopback-prefix": {
+			addr:     "127.0.0.1/8",
+			expClass: ipv4,
+		},
+		"ipv4-public": {
+			addr:     "200.0.0.10",
+			expClass: ipv4,
+		},
+		"ipv4-public-prefix": {
+			addr:     "200.0.0.10/24",
+			expClass: ipv4,
+		},
+		"ipv4-private": {
+			addr:     "10.0.0.10",
+			expClass: ipv4,
+		},
+		"ipv4-private-prefix": {
+			addr:     "10.0.0.10/24",
+			expClass: ipv4,
+		},
+		"ipv4-in-ipv6": {
+			addr:     "::ffff:fa00:fa01",
+			expClass: ipv6,
+		},
+		"ipv4-in-ipv6-prefix": {
+			addr:     "::ffff:fa00:fa01/24",
+			expClass: ipv6,
+		},
+		"ipv6-loopback": {
+			addr:     "::1",
+			expClass: ipv6,
+		},
+		"ipv6-loopback-prefix": {
+			addr:     "::1/128",
+			expClass: ipv6,
+		},
+		"ipv6-public": {
+			addr:     "fa00::fa01",
+			expClass: ipv6,
+		},
+		"ipv6-public-prefix": {
+			addr:     "fa00::fa01/128",
+			expClass: ipv6,
+		},
+		"hostname-example": {
+			addr:     "host.example.com",
+			expClass: ipNone,
+		},
+		"hostname-valid": {
+			addr:     "haproxy-ingress.github.io",
+			expClass: ipNone,
+		},
+	}
+	for name, test := range testCases {
+		t.Run(name, func(t *testing.T) {
+			v4, v6 := parseIP(test.addr)
+			assert.Equal(t, test.expClass == ipv4, v4, "is-ipv4")
+			assert.Equal(t, test.expClass == ipv6, v6, "is-ipv6")
+		})
+	}
+}


### PR DESCRIPTION
IP mode configuration is not recognizing IP addresses without CIDR suffix, failing to identify both IPv4 and IPv6 stack in case only those IP addresses are presented.

Also, IPv4 in IPv6 was incorrectly being parsed as IPv4, however the IP addresses is represented as IPv6 and this is the configuration that matter when configuring IP mode.

Besides that, changing auto mode to fallback to IPv4 in case node IP addresses are misconfigured, making auto to never fail the controller configuration.