### PR TITLE
delay test of image build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,7 @@ jobs:
     - name: Run integration tests on Kubernetes ${{ matrix.envtest-version }}
       run: HAPROXY_INGRESS_ENVTEST=${{ matrix.envtest-version }} make test-integration
   image:
-    if: github.ref_name != 'master'
+    if: github.ref_name == 'master' || startsWith(github.ref_name, 'release-') ## delayed check, PRs do not have access to secrets
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Image building now is fast enough to be part of the regular pipelines. Even though we don't push images, we still need to authenticate against Docker Hub to prevent rate limit issues. This authentication requires a token, but the token is not available on PR events. Because of that we are moving the image test after the PR being merged, which still helps to anticipate any problem on any of the supported targets.