### PR TITLE
Fix not rendered markdown

### DIFF
--- a/docs/content/en/_index.html
+++ b/docs/content/en/_index.html
@@ -51,7 +51,7 @@ Follow announcements and mailing discussion.
 {{< /blocks/feature >}}
 
 {{< blocks/feature icon="fab fa-github" title="Contributions welcome!" url="https://github.com/jcmoraisjr/haproxy-ingress" >}}
-We do a [Pull Request](https://github.com/jcmoraisjr/haproxy-ingress/pulls) contributions workflow on **GitHub**. New users are always welcome!
+We do a <a href="https://github.com/jcmoraisjr/haproxy-ingress/pulls" target="_blank" rel="noopener">Pull Request</a> contributions workflow on <em>GitHub</em>. New users are always welcome!
 {{< /blocks/feature >}}
 
 {{< /blocks/section >}}


### PR DESCRIPTION
https://haproxy-ingress.github.io/ doesn't render the markdown proper, so switching to plain HTML it is.