### PR TITLE
fix: repopulate ingress status after leader re-acquisition

### DIFF
--- a/pkg/controller/services/svcaddress.go
+++ b/pkg/controller/services/svcaddress.go
@@ -216,6 +216,8 @@ func (s *svcAddress) shutdown() {
 	if err := s.updateAllResources(nil); err != nil {
 		s.log.Error(err, "error updating resources")
 	}
+	// Mirror the wipe so a later leadership re-acquisition repopulates status via checkChanged.
+	s.curr = nil
 }
 
 func (s *svcAddress) readCurrentLB(ctx context.Context) (lb []networking.IngressLoadBalancerIngress, err error) {


### PR DESCRIPTION
On lose-leadership, shutdown() writes nil to every managed Ingress/Gateway status but does not reset `s.curr`. If leadership is re-acquired later, `s.curr` is equal to the freshly-read LB list and status stays empty until a pod restart.

My idea is to reset `s.curr`  so Ingress/Gateway statuses recover automatically on the next reconcile.

Fixes #1485