### PR TITLE
add full controller name command-line option

### DIFF
--- a/docs/content/en/docs/configuration/command-line.md
+++ b/docs/content/en/docs/configuration/command-line.md
@@ -36,6 +36,7 @@ The following command-line options are supported:
 | [`--election-id`](#election-id)                         | identifier                 | `ingress-controller-leader` |   |
 | [`--enable-endpointslices-api`](#enable-endpointslices-api) | [true\|false]          | `true`                  | v0.14 |
 | [`--force-namespace-isolation`](#force-namespace-isolation) | [true\|false]          | `false`                 |       |
+| [`--full-controller-name`](#ingress-class)              | fully qualified name       |                         | v0.17 |
 | [`--haproxy-grace-period`](#haproxy-grace-period)       | time                       | `20s`                   | v0.16 |
 | [`--health-check-path`](#stats)                         | path                       | `/healthz`              |       |
 | [`--healthz-addr`](#stats)                              | tcp address                | `:10254`                | v0.15 |
@@ -343,6 +344,9 @@ link to these IngressClasses will be added to the configuration. The `--controll
 command-line option customizes the controller name, allowing to run more than one HAProxy Ingress
 in the same cluster. Configuring `--controller-class=staging` would listen to IngressClasses whose
 controller name is `haproxy-ingress.github.io/controller/staging`.
+* `--full-controller-name`: Same as `--controller-class`, but defines the fully qualified controller
+name instead of just its suffix. `--controller-class` is ignored if this option is configured, and
+`haproxy-ingress.github.io/controller` is used by default if both options are missing.
 * `--ingress-class-precedence`: defines if IngressClass resource should take precedence over
 kubernetes.io/ingress.class annotation if both are defined and conflicting.
 * `--watch-ingress-without-class`: defines if this controller should also listen to ingress resources

--- a/pkg/controller/config/config.go
+++ b/pkg/controller/config/config.go
@@ -195,7 +195,9 @@ func CreateWithConfig(ctx context.Context, restConfig *rest.Config, opt *Options
 	rootcontext := logr.NewContext(createRootContext(ctx, rootLogger, waitShutdown), rootLogger)
 
 	controllerName := "haproxy-ingress.github.io/controller"
-	if opt.ControllerClass != "" {
+	if opt.FullControllerName != "" {
+		controllerName = opt.FullControllerName
+	} else if opt.ControllerClass != "" {
 		controllerName += "/" + strings.TrimLeft(opt.ControllerClass, "/")
 	}
 

--- a/pkg/controller/config/options.go
+++ b/pkg/controller/config/options.go
@@ -59,6 +59,7 @@ type Options struct {
 	MaxOldConfigFiles        int
 	ValidateConfig           bool
 	ControllerClass          string
+	FullControllerName       string
 	WatchIngressWithoutClass bool
 	WatchIngress             bool
 	WatchGateway             bool
@@ -196,6 +197,13 @@ func (o *Options) AddFlags(fs *flag.FlagSet) {
 		"IngressClass is 'haproxy-ingress.github.io/controller'. Non-empty values add a "+
 		"new /path, e.g., controller-class=staging will make this controller look for "+
 		"'haproxy-ingress.github.io/controller/staging'",
+	)
+
+	fs.StringVar(&o.FullControllerName, "full-controller-name", o.FullControllerName, ""+
+		"Defines a fully qualified controller name this controller should listen to. If "+
+		"configured, this controller will listen to Ingress and Gateway resources whose "+
+		"controller's class matches this configuration, ignoring --controller-class "+
+		"option.",
 	)
 
 	fs.BoolVar(&o.DisableIngressClassAPI, "disable-ingress-class-api", o.DisableIngressClassAPI, ""+


### PR DESCRIPTION
Adds the ability to configure the fully qualified controller name of Ingress and Gateway classes this controller should follow. This option is more flexible than the current `--controller-name` one, which only allows to configure the suffix of the controller name.